### PR TITLE
fix(eval): harden OpenClaw run lifecycle waits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 RUN ln -s /app /openclaw
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN npx -y playwright@1.59.1 install --with-deps chromium && \
+RUN cd /tmp && npx -y playwright@1.59.1 install --with-deps chromium && \
     CHROME_PATH="$(find /ms-playwright -path '*/chrome' -type f | sort | head -n 1)" && \
     test -x "$CHROME_PATH" && \
     ln -sf "$CHROME_PATH" /usr/bin/chromium
@@ -28,6 +28,7 @@ COPY --chown=node:node tasks-public/ tasks-public/
 COPY --chown=node:node tasks-domain/ tasks-domain/
 COPY --chown=node:node profiles/ profiles/
 COPY --chown=node:node baselines/ baselines/
+COPY --chown=node:node scripts/ scripts/
 COPY --chown=node:node app.py .
 
 RUN python3 -m pip install --break-system-packages --no-cache-dir .

--- a/clawbench/client.py
+++ b/clawbench/client.py
@@ -226,14 +226,73 @@ class GatewayClient:
             attempt += 1
             try:
                 remaining = max(1.0, deadline - asyncio.get_running_loop().time())
+                attempt_timeout = min(30.0, remaining)
                 self._ws = await websockets.connect(
                     self.config.url,
                     max_size=10 * 1024 * 1024,
-                    open_timeout=min(self.config.connect_timeout, remaining),
+                    open_timeout=attempt_timeout,
                     additional_headers={"Origin": host},
                 )
-                break
+                self._listen_task = asyncio.create_task(self._listener())
+                challenge = await self._wait_event(
+                    "connect.challenge", timeout=attempt_timeout
+                )
+                challenge_payload = challenge.get("payload", {})
+                nonce = ""
+                if isinstance(challenge_payload, dict):
+                    raw_nonce = challenge_payload.get("nonce", "")
+                    if isinstance(raw_nonce, str):
+                        nonce = raw_nonce.strip()
+
+                role = "operator"
+                scopes = [
+                    "operator.admin",
+                    "operator.read",
+                    "operator.write",
+                    "operator.approvals",
+                    "operator.pairing",
+                ]
+                client_info = {
+                    "id": "openclaw-control-ui",
+                    "version": __version__,
+                    "platform": "linux",
+                    "mode": "ui",
+                }
+                connect_params: dict[str, Any] = {
+                    "minProtocol": PROTOCOL_VERSION,
+                    "maxProtocol": PROTOCOL_VERSION,
+                    "client": client_info,
+                    "role": role,
+                    "scopes": scopes,
+                    "caps": [],
+                    "commands": [],
+                    "permissions": {},
+                    "auth": {"token": self.config.token} if self.config.token else {},
+                }
+                device = _build_connect_device(
+                    nonce=nonce,
+                    token=self.config.token,
+                    client_id=str(client_info["id"]),
+                    client_mode=str(client_info["mode"]),
+                    role=role,
+                    scopes=scopes,
+                    platform=str(client_info["platform"]),
+                )
+                if device:
+                    connect_params["device"] = device
+
+                response = await self._rpc(
+                    "connect",
+                    connect_params,
+                    timeout=attempt_timeout,
+                )
+                payload = response.get("payload", {})
+                if payload.get("type") != "hello-ok":
+                    raise ConnectionError(f"Expected hello-ok, got: {payload}")
+                logger.info("Connected to gateway (protocol v%s)", payload.get("protocol", "?"))
+                return
             except Exception as exc:
+                await self.close()
                 if not _is_transient_gateway_connect_error(exc):
                     raise
                 if asyncio.get_running_loop().time() >= deadline:
@@ -245,60 +304,6 @@ class GatewayClient:
                     delay,
                 )
                 await asyncio.sleep(delay)
-        self._listen_task = asyncio.create_task(self._listener())
-        challenge = await self._wait_event("connect.challenge", timeout=self.config.connect_timeout)
-        challenge_payload = challenge.get("payload", {})
-        nonce = ""
-        if isinstance(challenge_payload, dict):
-            raw_nonce = challenge_payload.get("nonce", "")
-            if isinstance(raw_nonce, str):
-                nonce = raw_nonce.strip()
-
-        role = "operator"
-        scopes = [
-            "operator.admin",
-            "operator.read",
-            "operator.write",
-            "operator.approvals",
-            "operator.pairing",
-        ]
-        client_info = {
-            "id": "openclaw-control-ui",
-            "version": __version__,
-            "platform": "linux",
-            "mode": "ui",
-        }
-        connect_params: dict[str, Any] = {
-            "minProtocol": PROTOCOL_VERSION,
-            "maxProtocol": PROTOCOL_VERSION,
-            "client": client_info,
-            "role": role,
-            "scopes": scopes,
-            "caps": [],
-            "commands": [],
-            "permissions": {},
-            "auth": {"token": self.config.token} if self.config.token else {},
-        }
-        device = _build_connect_device(
-            nonce=nonce,
-            token=self.config.token,
-            client_id=str(client_info["id"]),
-            client_mode=str(client_info["mode"]),
-            role=role,
-            scopes=scopes,
-            platform=str(client_info["platform"]),
-        )
-        if device:
-            connect_params["device"] = device
-
-        response = await self._rpc(
-            "connect",
-            connect_params,
-        )
-        payload = response.get("payload", {})
-        if payload.get("type") != "hello-ok":
-            raise ConnectionError(f"Expected hello-ok, got: {payload}")
-        logger.info("Connected to gateway (protocol v%s)", payload.get("protocol", "?"))
 
     async def close(self) -> None:
         if self._listen_task and not self._listen_task.done():
@@ -394,6 +399,15 @@ class GatewayClient:
         except Exception as exc:
             logger.warning("Failed to delete session %s: %s", session_key, exc)
 
+    async def abort_session(self, session_key: str, *, run_id: str | None = None) -> None:
+        params: dict[str, Any] = {"key": session_key}
+        if run_id:
+            params["runId"] = run_id
+        try:
+            await self._rpc("sessions.abort", params, timeout=min(self.config.request_timeout, 10.0))
+        except Exception as exc:
+            logger.warning("Failed to abort session %s run %s: %s", session_key, run_id or "-", exc)
+
     async def get_effective_tools(self, session_key: str) -> dict[str, Any]:
         response = await self._rpc("tools.effective", {"sessionKey": session_key})
         return response.get("payload", {})
@@ -413,14 +427,26 @@ class GatewayClient:
         msg_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._event_queues[chat_queue_key] = chat_queue
         self._event_queues[msg_queue_key] = msg_queue
+        timeout_ms = max(1, min(int(timeout * 1000), 2_147_483_647))
 
-        await self._rpc(
+        send_response = await self._rpc(
             "sessions.send",
             {
                 "key": session_key,
                 "message": message,
                 "idempotencyKey": idempotency_key,
+                "timeoutMs": timeout_ms,
             },
+        )
+        send_payload = send_response.get("payload", {})
+        run_id = idempotency_key
+        if isinstance(send_payload, dict):
+            raw_run_id = send_payload.get("runId")
+            if isinstance(raw_run_id, str) and raw_run_id.strip():
+                run_id = raw_run_id.strip()
+
+        wait_task = asyncio.create_task(
+            self._wait_for_agent_run(run_id, timeout_ms=timeout_ms)
         )
 
         collected_messages: list[TranscriptMessage] = []
@@ -430,8 +456,31 @@ class GatewayClient:
             while not done:
                 remaining = deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
-                    logger.warning("Timeout waiting for final state on session %s", session_key)
+                    logger.warning(
+                        "Timeout waiting for final state on session %s run %s",
+                        session_key,
+                        run_id,
+                    )
                     break
+                if wait_task.done():
+                    wait_payload = _task_result_or_empty(wait_task)
+                    status = str(wait_payload.get("status", ""))
+                    if status and status != "timeout":
+                        logger.info(
+                            "agent.wait observed terminal status for session %s run %s: %s",
+                            session_key,
+                            run_id,
+                            status,
+                        )
+                        done = True
+                        break
+                    if status == "timeout":
+                        logger.warning(
+                            "agent.wait timed out for session %s run %s",
+                            session_key,
+                            run_id,
+                        )
+                        break
                 try:
                     event = await asyncio.wait_for(chat_queue.get(), timeout=min(0.5, remaining))
                     state = event.get("payload", {}).get("state", "")
@@ -439,6 +488,9 @@ class GatewayClient:
                         done = True
                 except asyncio.TimeoutError:
                     pass
+
+            if not done:
+                await self.abort_session(session_key, run_id=run_id)
 
             collected_messages.extend(
                 await _drain_message_queue(
@@ -464,10 +516,29 @@ class GatewayClient:
             ):
                 collected_messages = history_messages
         finally:
+            if not wait_task.done():
+                wait_task.cancel()
+                try:
+                    await wait_task
+                except asyncio.CancelledError:
+                    pass
             self._event_queues.pop(chat_queue_key, None)
             self._event_queues.pop(msg_queue_key, None)
 
         return _correlate_transcript(Transcript(messages=collected_messages))
+
+    async def _wait_for_agent_run(self, run_id: str, *, timeout_ms: int) -> dict[str, Any]:
+        try:
+            response = await self._rpc(
+                "agent.wait",
+                {"runId": run_id, "timeoutMs": timeout_ms},
+                timeout=(timeout_ms / 1000.0) + 10.0,
+            )
+        except Exception as exc:
+            logger.warning("agent.wait failed for run %s: %s", run_id, exc)
+            return {}
+        payload = response.get("payload", {})
+        return payload if isinstance(payload, dict) else {}
 
     async def get_session_messages(self, session_key: str) -> list[TranscriptMessage]:
         try:
@@ -577,6 +648,13 @@ def _build_connect_device(
     platform: str,
     device_family: str | None = None,
 ) -> dict[str, Any] | None:
+    if os.environ.get("CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return None
     if not nonce:
         return None
 
@@ -646,6 +724,10 @@ def _resolve_node_executable() -> str | None:
 
 
 def _is_transient_gateway_connect_error(exc: Exception) -> bool:
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return True
+    if isinstance(exc, websockets.exceptions.ConnectionClosed):
+        return True
     if isinstance(exc, InvalidStatus):
         return exc.response.status_code in {502, 503, 504}
     if isinstance(exc, InvalidMessage):
@@ -659,6 +741,13 @@ def _describe_connect_error(exc: Exception) -> str:
     if isinstance(exc, InvalidStatus):
         return f"HTTP {exc.response.status_code}"
     return exc.__class__.__name__
+
+
+def _task_result_or_empty(task: asyncio.Task[dict[str, Any]]) -> dict[str, Any]:
+    try:
+        return task.result()
+    except Exception:
+        return {}
 
 
 def _parse_single_message(message_data: dict[str, Any]) -> TranscriptMessage | None:

--- a/clawbench/harness.py
+++ b/clawbench/harness.py
@@ -19,6 +19,7 @@ from rich.console import Console
 from rich.table import Table
 
 from clawbench import __version__
+from clawbench.ablation import build_ablation_profile
 from clawbench.client import GatewayClient, GatewayConfig
 from clawbench.releases import compute_task_snapshot_fingerprint, load_active_release
 from clawbench.schemas import (
@@ -86,6 +87,9 @@ class BenchmarkHarness:
         browser_concurrency: int = 1,
         adapter: str = "openclaw",
         judge_affects_score: bool = False,
+        tool_profile_name: str | None = None,
+        enabled_toolsets: list[str] | None = None,
+        disabled_toolsets: list[str] | None = None,
     ) -> None:
         self.gateway_config = gateway_config
         self.model = model
@@ -111,6 +115,9 @@ class BenchmarkHarness:
         self.concurrency = max(1, int(concurrency))
         self.browser_concurrency = max(1, int(browser_concurrency))
         self.adapter = adapter
+        self.tool_profile_name = tool_profile_name
+        self.enabled_toolsets = enabled_toolsets or []
+        self.disabled_toolsets = disabled_toolsets or []
         self.repo_root = Path(__file__).parent.parent
         self.last_task_runs: dict[str, list[TaskRunResult]] = {}
 
@@ -548,6 +555,9 @@ class BenchmarkHarness:
             "prompt_variant": self.prompt_variant,
             "judge_model": self.judge_model,
             "judge_affects_score": self.judge_affects_score,
+            "tool_profile_name": self.tool_profile_name,
+            "enabled_toolsets": self.enabled_toolsets,
+            "disabled_toolsets": self.disabled_toolsets,
             "benchmark_version": __version__,
             "task_fingerprint": _task_definition_fingerprint(task),
         }
@@ -753,6 +763,15 @@ class BenchmarkHarness:
             for _ in range(count)
         )
         active_release = load_active_release()
+        ablation_profile = build_ablation_profile(
+            model=self.model,
+            adapter=self.adapter,
+            prompt_profile=self.prompt_variant,
+            harness_version=__version__,
+            tool_profile_name=self.tool_profile_name,
+            enabled_toolsets=self.enabled_toolsets,
+            disabled_toolsets=self.disabled_toolsets,
+        )
         result = BenchmarkResult(
             submission_id=str(uuid.uuid4()),
             model=self.model,
@@ -770,6 +789,7 @@ class BenchmarkHarness:
                 "judge_model": self.judge_model,
                 "judge_affects_score": self.judge_affects_score,
                 "adapter": self.adapter,
+                "ablation_profile": ablation_profile.model_dump(),
                 "known_adapters": list(KNOWN_ADAPTERS),
                 "executable_adapters": sorted(EXECUTABLE_ADAPTERS),
                 "subsets": self.subsets,

--- a/clawbench/queue.py
+++ b/clawbench/queue.py
@@ -28,7 +28,14 @@ logger = logging.getLogger(__name__)
 HF_TOKEN = os.environ.get("HF_TOKEN", "")
 
 # Local fallback when HF is unavailable
-LOCAL_QUEUE_DIR = Path("/data/queue") if Path("/data").exists() else Path("data/queue")
+def _resolve_local_queue_dir() -> Path:
+    override = os.environ.get("CLAWBENCH_LOCAL_QUEUE_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path("/data/queue") if Path("/data").exists() else Path("data/queue")
+
+
+LOCAL_QUEUE_DIR = _resolve_local_queue_dir()
 
 
 class JobStatus(str, Enum):
@@ -66,7 +73,7 @@ class SubmissionRequest(BaseModel):
             "runs_per_task": self.runs_per_task,
             "max_parallel_lanes": self.max_parallel_lanes,
             "tier": self.tier or "",
-            "task_ids": [task_id.strip() for task_id in self.task_ids if task_id.strip()],
+            "task_ids": sorted({task_id.strip() for task_id in self.task_ids if task_id.strip()}),
             "scenario": self.scenario or "",
             "prompt_variant": self.prompt_variant,
         }

--- a/clawbench/queue.py
+++ b/clawbench/queue.py
@@ -50,6 +50,7 @@ class SubmissionRequest(BaseModel):
     runs_per_task: int = Field(default=3, ge=1, le=10)
     max_parallel_lanes: int = Field(default=1, ge=1, le=8)
     tier: str | None = None  # Filter to a specific tier
+    task_ids: list[str] = Field(default_factory=list)
     scenario: str | None = None
     prompt_variant: str = "clear"
     submitter: str = ""  # HF username
@@ -65,6 +66,7 @@ class SubmissionRequest(BaseModel):
             "runs_per_task": self.runs_per_task,
             "max_parallel_lanes": self.max_parallel_lanes,
             "tier": self.tier or "",
+            "task_ids": [task_id.strip() for task_id in self.task_ids if task_id.strip()],
             "scenario": self.scenario or "",
             "prompt_variant": self.prompt_variant,
         }

--- a/clawbench/worker.py
+++ b/clawbench/worker.py
@@ -1090,12 +1090,13 @@ class EvalWorker:
                 ]
             )
         try:
-            self._patch_openclaw_config(config_pairs)
             state_dir = Path(
                 gateway_env.get("OPENCLAW_STATE_DIR")
                 or os.environ.get("OPENCLAW_STATE_DIR")
                 or os.path.expanduser("~/.openclaw")
             )
+            config_path = Path(gateway_env.get("OPENCLAW_CONFIG_PATH") or (state_dir / "openclaw.json"))
+            self._patch_openclaw_config(config_pairs, config_path=config_path)
             self._write_eval_exec_approvals(state_dir)
         except Exception as exc:
             logger.warning("Direct openclaw.json patch failed: %s", exc)
@@ -1135,9 +1136,15 @@ class EvalWorker:
         tmp_path.write_text(json.dumps(approvals, indent=2), encoding="utf-8")
         tmp_path.replace(approvals_path)
 
-    def _patch_openclaw_config(self, pairs: list[tuple[str, object]]) -> None:
-        state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
-        config_path = state_dir / "openclaw.json"
+    def _patch_openclaw_config(
+        self,
+        pairs: list[tuple[str, object]],
+        *,
+        config_path: Path | None = None,
+    ) -> None:
+        if config_path is None:
+            state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
+            config_path = state_dir / "openclaw.json"
         if not config_path.exists():
             logger.warning("openclaw.json not found at %s; skipping direct patch", config_path)
             return

--- a/clawbench/worker.py
+++ b/clawbench/worker.py
@@ -35,6 +35,12 @@ STALE_EVALUATION_SECONDS = max(
     int(os.environ.get("CLAWBENCH_STALE_EVALUATION_SECONDS", "1800")),
 )
 OPENCLAW_EVAL_EXEC_HOSTS = {"auto", "gateway", "sandbox", "node"}
+OPENCLAW_EVAL_SYSTEM_PROMPT = (
+    "You are running an OpenClaw benchmark task. Complete the user's request in the current "
+    "workspace using the available tools when needed. For file, code, browser, shell, or memory "
+    "tasks, make the requested changes directly and verify them when practical. Do not ask "
+    "follow-up questions during the benchmark. Keep any final reply brief."
+)
 
 
 @dataclass
@@ -676,6 +682,7 @@ class EvalWorker:
         if self._active_model:
             _set_nested(data, "agents.defaults.model.primary", self._active_model)
             _set_nested(data, "agents.defaults.subagents.model.primary", self._active_model)
+            self._apply_eval_model_defaults(data, self._active_model)
 
         tmp_path = cfg_path.with_suffix(".json.tmp")
         tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -1128,8 +1135,7 @@ class EvalWorker:
         tmp_path.write_text(json.dumps(approvals, indent=2), encoding="utf-8")
         tmp_path.replace(approvals_path)
 
-    @staticmethod
-    def _patch_openclaw_config(pairs: list[tuple[str, object]]) -> None:
+    def _patch_openclaw_config(self, pairs: list[tuple[str, object]]) -> None:
         state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
         config_path = state_dir / "openclaw.json"
         if not config_path.exists():
@@ -1147,11 +1153,49 @@ class EvalWorker:
             if cursor.get(parts[-1]) != value:
                 cursor[parts[-1]] = value
                 changed = True
+        if self._active_model:
+            changed = self._apply_eval_model_defaults(data, self._active_model) or changed
         if not changed:
             return
         tmp_path = config_path.with_suffix(".json.tmp")
         tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         tmp_path.replace(config_path)
+
+    @staticmethod
+    def _apply_eval_model_defaults(data: dict, model: str) -> bool:
+        """Force eval model parameters that keep benchmark turns low-latency."""
+        agents = data.setdefault("agents", {})
+        if not isinstance(agents, dict):
+            data["agents"] = agents = {}
+        defaults = agents.setdefault("defaults", {})
+        if not isinstance(defaults, dict):
+            agents["defaults"] = defaults = {}
+        models = defaults.setdefault("models", {})
+        if not isinstance(models, dict):
+            defaults["models"] = models = {}
+        entry = models.setdefault(model, {})
+        if not isinstance(entry, dict):
+            entry = {}
+            models[model] = entry
+        params = entry.setdefault("params", {})
+        if not isinstance(params, dict):
+            params = {}
+            entry["params"] = params
+        changed = False
+        if defaults.get("systemPromptOverride") != OPENCLAW_EVAL_SYSTEM_PROMPT:
+            defaults["systemPromptOverride"] = OPENCLAW_EVAL_SYSTEM_PROMPT
+            changed = True
+        if params.get("fastMode") is not True:
+            params["fastMode"] = True
+            changed = True
+        if model.startswith("openai/"):
+            if params.get("transport") != "sse":
+                params["transport"] = "sse"
+                changed = True
+            if params.get("openaiWsWarmup") is not False:
+                params["openaiWsWarmup"] = False
+                changed = True
+        return changed
 
     def _find_gateway_cmd(self) -> list[str] | None:
         import shutil

--- a/clawbench/worker.py
+++ b/clawbench/worker.py
@@ -34,6 +34,7 @@ STALE_EVALUATION_SECONDS = max(
     JOB_HEARTBEAT_INTERVAL_SECONDS * 4,
     int(os.environ.get("CLAWBENCH_STALE_EVALUATION_SECONDS", "1800")),
 )
+OPENCLAW_EVAL_EXEC_HOSTS = {"auto", "gateway", "sandbox", "node"}
 
 
 @dataclass
@@ -45,6 +46,12 @@ class ParallelLane:
     port: int = 0
     state_dir: Path | None = None
     log_path: Path | None = None
+
+    @property
+    def home_dir(self) -> Path | None:
+        if self.state_dir is None:
+            return None
+        return self.state_dir.parent / "home"
 
     @property
     def ws_url(self) -> str:
@@ -302,6 +309,7 @@ class EvalWorker:
             prompt_variant=job.request.prompt_variant,
             prepare_run=prepare_run,
             progress_callback=progress_callback,
+            tool_profile_name=os.environ.get("CLAWBENCH_TOOL_PROFILE_NAME", "") or None,
         )
         return await harness.run()
 
@@ -372,6 +380,7 @@ class EvalWorker:
                 tier=job.request.tier,
                 scenario=job.request.scenario,
                 prompt_variant=job.request.prompt_variant,
+                tool_profile_name=os.environ.get("CLAWBENCH_TOOL_PROFILE_NAME", "") or None,
             )
             return summary_harness.compose_result_from_task_stats(
                 ordered_stats,
@@ -385,7 +394,8 @@ class EvalWorker:
             )
         finally:
             self._stop_parallel_gateways()
-            shutil.rmtree(job_root, ignore_errors=True)
+            if os.environ.get("CLAWBENCH_KEEP_PARALLEL_LANE_ROOT", "").strip() != "1":
+                shutil.rmtree(job_root, ignore_errors=True)
 
     async def _run_parallel_lane(self, job, lane: ParallelLane, progress: JobProgressTracker):
         gateway_cmd = self._find_gateway_cmd()
@@ -434,6 +444,7 @@ class EvalWorker:
             progress_callback=progress_callback,
             print_report=False,
             quiet=True,
+            tool_profile_name=os.environ.get("CLAWBENCH_TOOL_PROFILE_NAME", "") or None,
         )
         result = await harness.run()
         await self._sync_job_progress(job.job_id, progress.clear_lane(lane.index))
@@ -448,6 +459,9 @@ class EvalWorker:
         return load_all_tasks(
             tier=job.request.tier,
             scenario=job.request.scenario,
+            task_ids=list(getattr(job.request, "task_ids", []) or None)
+            if getattr(job.request, "task_ids", None)
+            else None,
             prompt_variant=job.request.prompt_variant,
         )
 
@@ -507,9 +521,35 @@ class EvalWorker:
     def _materialize_lane_runtime(self, lane: ParallelLane, job_root: Path) -> None:
         lane_root = job_root / f"lane-{lane.index}"
         lane.state_dir = lane_root / "state"
+        lane_home = lane.home_dir
+        if lane_home is not None:
+            (lane_home / ".config").mkdir(parents=True, exist_ok=True)
         lane.log_path = lane_root / "gateway.log"
         lane.port = GATEWAY_PORT + (lane.index * GATEWAY_PORT_SPACING)
         self._seed_lane_state_dir(lane.state_dir)
+
+    def _run_lane_prepare_hook(self, lane: ParallelLane) -> None:
+        hook = os.environ.get("CLAWBENCH_LANE_PREPARE_CMD", "").strip()
+        if not hook:
+            return
+        if lane.state_dir is None:
+            raise RuntimeError(f"Lane {lane.index + 1} state dir missing before prepare hook")
+        lane_home = lane.home_dir
+        if lane_home is None:
+            raise RuntimeError(f"Lane {lane.index + 1} home dir missing before prepare hook")
+        (lane_home / ".config").mkdir(parents=True, exist_ok=True)
+        hook_env = {
+            **os.environ,
+            "HOME": str(lane_home),
+            "OPENCLAW_HOME": str(lane_home),
+            "OPENCLAW_STATE_DIR": str(lane.state_dir),
+            "OPENCLAW_CONFIG_PATH": str(lane.state_dir / "openclaw.json"),
+            "XDG_CONFIG_HOME": str(lane_home / ".config"),
+            "CLAWBENCH_LANE_INDEX": str(lane.index),
+            "CLAWBENCH_LANE_PORT": str(lane.port),
+        }
+        logger.info("Running lane %d prepare hook", lane.index + 1)
+        subprocess.run([hook], env=hook_env, check=True)
 
     def _seed_lane_state_dir(self, target_state_dir: Path) -> None:
         source_state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR", os.path.expanduser("~/.openclaw")))
@@ -629,6 +669,10 @@ class EvalWorker:
         _set_nested(data, "browser.headless", True)
         _set_nested(data, "browser.noSandbox", True)
         _set_nested(data, "agents.defaults.skipBootstrap", True)
+        _set_nested(data, "tools.exec.host", self._openclaw_eval_exec_host())
+        _set_nested(data, "tools.exec.security", "full")
+        _set_nested(data, "tools.exec.ask", "off")
+        _set_nested(data, "approvals.exec.enabled", False)
         if self._active_model:
             _set_nested(data, "agents.defaults.model.primary", self._active_model)
             _set_nested(data, "agents.defaults.subagents.model.primary", self._active_model)
@@ -636,6 +680,7 @@ class EvalWorker:
         tmp_path = cfg_path.with_suffix(".json.tmp")
         tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         tmp_path.replace(cfg_path)
+        self._write_eval_exec_approvals(lane_state_dir)
 
     def _order_task_stats(self, tasks: list[TaskDefinition], combined_stats: list) -> list:
         stats_by_id = {}
@@ -730,6 +775,7 @@ class EvalWorker:
                     "token",
                     "--token",
                     gateway_token,
+                    "--compact",
                 ],
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
@@ -767,6 +813,12 @@ class EvalWorker:
             raise RuntimeError(
                 f"Gateway /health did not respond within {health_deadline_sec}s. Log:\n{self._read_gateway_log()}"
             )
+
+        await self._wait_for_gateway_ready_marker(
+            process=self._gateway_process,
+            log_reader=lambda: self._read_gateway_log(limit=20_000),
+            description="Gateway",
+        )
 
         # Phase B: control-plane probe with retries (see the parallel
         # variant in _ensure_parallel_gateway for the detailed rationale).
@@ -817,21 +869,30 @@ class EvalWorker:
         # Re-inject the host config's env + plugins before every restart.
         if lane.state_dir is not None:
             self._reinject_host_env_to_lane(lane.state_dir)
+            self._run_lane_prepare_hook(lane)
         if lane.state_dir is None or lane.log_path is None:
             raise RuntimeError(f"Lane {lane.index + 1} runtime was not materialized before gateway startup")
+        lane_home = lane.home_dir
+        if lane_home is None:
+            raise RuntimeError(f"Lane {lane.index + 1} home was not materialized before gateway startup")
+        (lane_home / ".config").mkdir(parents=True, exist_ok=True)
 
         logger.info("Starting lane %d gateway on port %d", lane.index + 1, lane.port)
         gateway_token = os.environ.get("OPENCLAW_GATEWAY_TOKEN", "clawbench-internal-token")
         gateway_env = {
             **os.environ,
-            "OPENCLAW_HOME": os.environ.get("OPENCLAW_HOME", os.path.expanduser("~")),
+            "HOME": str(lane_home),
+            "OPENCLAW_HOME": str(lane_home),
             "OPENCLAW_STATE_DIR": str(lane.state_dir),
+            "OPENCLAW_CONFIG_PATH": str(lane.state_dir / "openclaw.json"),
+            "XDG_CONFIG_HOME": str(lane_home / ".config"),
             "OPENCLAW_SKIP_GMAIL_WATCHER": "1",
             "OPENCLAW_SKIP_CANVAS_HOST": "1",
             "OPENCLAW_NO_RESPAWN": "1",
         }
         self._configure_browser_runtime(gateway_cmd, gateway_env)
         lane.log_path.parent.mkdir(parents=True, exist_ok=True)
+        lane.log_path.write_text("", encoding="utf-8")
         log_handle = lane.log_path.open("a", encoding="utf-8")
         try:
             process = subprocess.Popen(
@@ -849,6 +910,7 @@ class EvalWorker:
                     "token",
                     "--token",
                     gateway_token,
+                    "--compact",
                 ],
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
@@ -890,6 +952,12 @@ class EvalWorker:
                 f"Lane {lane.index + 1} gateway /health did not respond within {health_deadline_sec}s. "
                 f"Log:\n{self._read_parallel_gateway_log(lane)}"
             )
+
+        await self._wait_for_gateway_ready_marker(
+            process=process,
+            log_reader=lambda: self._read_parallel_gateway_log(lane, limit=20_000),
+            description=f"Lane {lane.index + 1} gateway",
+        )
 
         # Phase B: control-plane probe with explicit retries. A healthy
         # /health response does not guarantee sessions.create works
@@ -1002,6 +1070,10 @@ class EvalWorker:
             ("agents.defaults.skipBootstrap", True),
             ("browser.headless", True),
             ("browser.noSandbox", True),
+            ("tools.exec.host", self._openclaw_eval_exec_host()),
+            ("tools.exec.security", "full"),
+            ("tools.exec.ask", "off"),
+            ("approvals.exec.enabled", False),
         ]
         if self._active_model:
             config_pairs.extend(
@@ -1012,8 +1084,49 @@ class EvalWorker:
             )
         try:
             self._patch_openclaw_config(config_pairs)
+            state_dir = Path(
+                gateway_env.get("OPENCLAW_STATE_DIR")
+                or os.environ.get("OPENCLAW_STATE_DIR")
+                or os.path.expanduser("~/.openclaw")
+            )
+            self._write_eval_exec_approvals(state_dir)
         except Exception as exc:
             logger.warning("Direct openclaw.json patch failed: %s", exc)
+
+    @staticmethod
+    def _openclaw_eval_exec_host() -> str:
+        value = os.environ.get("OPENCLAW_EXEC_HOST", "gateway").strip().lower()
+        if value in OPENCLAW_EVAL_EXEC_HOSTS:
+            return value
+        logger.warning("Invalid OPENCLAW_EXEC_HOST=%r; using gateway", value)
+        return "gateway"
+
+    @staticmethod
+    def _write_eval_exec_approvals(state_dir: Path) -> None:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        approvals_path = state_dir / "exec-approvals.json"
+        approvals = {
+            "version": 1,
+            "socket": {
+                "path": str(approvals_path.with_suffix(".sock")),
+                "token": "clawbench-eval-token",
+            },
+            "defaults": {
+                "security": "full",
+                "ask": "off",
+                "askFallback": "full",
+            },
+            "agents": {
+                "*": {
+                    "security": "full",
+                    "ask": "off",
+                    "askFallback": "full",
+                }
+            },
+        }
+        tmp_path = approvals_path.with_suffix(".json.tmp")
+        tmp_path.write_text(json.dumps(approvals, indent=2), encoding="utf-8")
+        tmp_path.replace(approvals_path)
 
     @staticmethod
     def _patch_openclaw_config(pairs: list[tuple[str, object]]) -> None:
@@ -1059,13 +1172,15 @@ class EvalWorker:
         # Use a generous dedicated config for the probe. A healthy gateway
         # usually responds to sessions.create in under a second, but plugin
         # initialization (especially OpenRouter model list fetch) can add
-        # 10-30s after /health reports 200. The 60s outer bound ensures we
-        # don't give up during a cold-start scenario.
+        # 10-30s after /health reports 200. On cold Docker lanes OpenClaw may
+        # also install provider runtime SDKs during the first sessions.create,
+        # so keep this bound configurable and separate from steady-state RPCs.
+        probe_timeout = float(os.environ.get("CLAWBENCH_GATEWAY_PROBE_TIMEOUT_SECONDS", "180"))
         probe_config = GatewayConfig(
             url=gateway_config.url,
             token=gateway_config.token,
             connect_timeout=gateway_config.connect_timeout,
-            request_timeout=30.0,
+            request_timeout=probe_timeout,
         )
 
         async def _probe() -> None:
@@ -1076,25 +1191,67 @@ class EvalWorker:
                 await client.delete_session(session_key)
 
         try:
-            await asyncio.wait_for(_probe(), timeout=60.0)
+            await asyncio.wait_for(_probe(), timeout=probe_timeout + 10.0)
         except asyncio.TimeoutError as exc:
             raise RuntimeError(
-                "Gateway control-plane probe timed out after 60s "
+                f"Gateway control-plane probe timed out after {probe_timeout:.0f}s "
                 "(sessions.create hung on a freshly-started gateway); "
                 "lane will be retried by the queue."
             ) from exc
 
-    def _read_gateway_log(self) -> str:
+    async def _wait_for_gateway_ready_marker(self, process: subprocess.Popen, log_reader, description: str) -> None:
+        # OpenClaw 2026.4.26 can answer /health before channels and sidecars
+        # finish startup. Probing sessions.create during that window can hold the
+        # session write lock for minutes. Some lane gateway modes do not emit
+        # the final ready marker, so wait for it briefly after sidecar startup
+        # and then let the bounded control-plane probe decide.
+        ready_deadline_sec = int(os.environ.get("CLAWBENCH_GATEWAY_READY_TIMEOUT_SECONDS", "420"))
+        marker_grace_sec = int(os.environ.get("CLAWBENCH_GATEWAY_READY_MARKER_GRACE_SECONDS", "90"))
+        saw_sidecar_start = False
+        sidecar_start_elapsed: int | None = None
+        for elapsed in range(ready_deadline_sec):
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"{description} exited with code {process.returncode}. Log:\n{log_reader()[-4_000:]}"
+                )
+
+            log_text = log_reader()
+            if "[gateway] ready" in log_text:
+                logger.info("%s ready after %ss", description, elapsed)
+                return
+            if "[gateway] starting channels and sidecars" in log_text:
+                saw_sidecar_start = True
+                if sidecar_start_elapsed is None:
+                    sidecar_start_elapsed = elapsed
+            if sidecar_start_elapsed is not None and elapsed - sidecar_start_elapsed >= marker_grace_sec:
+                logger.info(
+                    "%s did not emit ready marker %ss after sidecar startup; probing control plane",
+                    description,
+                    marker_grace_sec,
+                )
+                return
+            if not saw_sidecar_start and elapsed >= 15:
+                return
+            await asyncio.sleep(1)
+
+        logger.warning(
+            "%s did not log ready within %ss; probing control plane anyway. Log:\n%s",
+            description,
+            ready_deadline_sec,
+            log_reader()[-4_000:],
+        )
+
+    def _read_gateway_log(self, limit: int = 4_000) -> str:
         try:
-            return Path("/tmp/gateway.log").read_text(encoding="utf-8", errors="replace")[-4_000:]
+            return Path("/tmp/gateway.log").read_text(encoding="utf-8", errors="replace")[-limit:]
         except Exception:
             return "(no gateway log)"
 
-    def _read_parallel_gateway_log(self, lane: ParallelLane) -> str:
+    def _read_parallel_gateway_log(self, lane: ParallelLane, limit: int = 4_000) -> str:
         if lane.log_path is None:
             return "(no gateway log)"
         try:
-            return lane.log_path.read_text(encoding="utf-8", errors="replace")[-4_000:]
+            return lane.log_path.read_text(encoding="utf-8", errors="replace")[-limit:]
         except Exception:
             return "(no gateway log)"
 

--- a/scripts/container_cherry_single.sh
+++ b/scripts/container_cherry_single.sh
@@ -1,35 +1,24 @@
 #!/bin/bash
-# Single-model sweep with fresh gateway + bumped Node heap to prevent OOM.
+# Cherry-pick variant of container_sweep_single.sh: runs ONLY the tasks listed
+# in $CHERRY_TASKS (comma-separated task IDs), with state-dir isolation.
 #
-# Invocation (from host):
-#   docker run -d --name clawbench-sweep-<LABEL> \
-#     -e SWEEP_LABEL=<label> -e SWEEP_MODEL=<routed-model> -e SWEEP_PROFILE=<abs-profile-path> \
-#     -v .../scripts:/home/node/app/scripts:ro \
-#     -v .../data:/data \
-#     -v .../data/container-home-openclaw:/home/node/.openclaw \
-#     -v .../profiles:/home/node/app/profiles:ro \
-#     --memory 8g \
-#     clawbench-clawbench:latest \
-#     bash /home/node/app/scripts/container_sweep_single.sh
-#
-# Differences vs container_sweep.sh:
-# - Bumps gateway Node.js heap via NODE_OPTIONS=--max-old-space-size=4096 (prevents 2GB OOM we saw at ~4h)
-# - One model per container (no shared-gateway drift between models)
-# - Force-clears run_cache for THIS model before running (prevents cache-replay masking)
-# - Writes to the same $LOGDIR/docker_${label}_${SWEEP_OUT_TAG}.json as the original sweep
-#   so generate_drift_report.py picks it up without changes
+# Required env vars:
+#   SWEEP_LABEL   (e.g. opus47)
+#   SWEEP_MODEL   (e.g. anthropic/claude-opus-4-7)
+#   SWEEP_PROFILE (absolute path in container)
+#   SWEEP_LOGDIR  (default /data/drift_2026-04-20-cherry)
+#   SWEEP_OUT_TAG (default v2026-4-20-cherry)
+#   CHERRY_TASKS  (comma-separated task IDs, e.g. "t2-ctx-pronoun-resolve,t3-fin-budget-monthly")
 
 set -u
 
-: "${SWEEP_LABEL:?SWEEP_LABEL required (e.g. glm, minimax, kimi)}"
-: "${SWEEP_MODEL:?SWEEP_MODEL required (e.g. openrouter/z-ai/glm-5.1)}"
-: "${SWEEP_PROFILE:?SWEEP_PROFILE required (absolute path in container)}"
+: "${SWEEP_LABEL:?SWEEP_LABEL required}"
+: "${SWEEP_MODEL:?SWEEP_MODEL required}"
+: "${SWEEP_PROFILE:?SWEEP_PROFILE required}"
+: "${CHERRY_TASKS:?CHERRY_TASKS required (comma-separated task IDs)}"
 
-# Optional overrides (defaults target the v4.14 drift sweep):
-#   SWEEP_LOGDIR — where JSONs and logs go (default /data/drift_2026-04-14)
-#   SWEEP_OUT_TAG — tag embedded in output filename (default v2026-4-14)
-: "${SWEEP_LOGDIR:=/data/drift_2026-04-14}"
-: "${SWEEP_OUT_TAG:=v2026-4-14}"
+: "${SWEEP_LOGDIR:=/data/drift_2026-04-20-cherry}"
+: "${SWEEP_OUT_TAG:=v2026-4-20-cherry}"
 
 cd /data
 
@@ -39,9 +28,6 @@ mkdir -p "$LOGDIR"
 export OPENCLAW_GATEWAY_TOKEN="local-dev-token-for-testing"
 export CLAWBENCH_RUN_CACHE_DIR="/data/run_cache"
 mkdir -p "$CLAWBENCH_RUN_CACHE_DIR"
-
-# OOM fix: give the gateway Node process a 4GB old-space ceiling instead of the default ~2GB.
-# Scoped via env so we don't stomp on other Node processes (clawbench itself is python).
 export NODE_OPTIONS="--max-old-space-size=4096"
 # OpenClaw 4.22+ has slower agents.create / sessions.create on cold start
 # (we observed 72s for opus-4-7). Bump RPC timeouts so the harness doesn't
@@ -51,38 +37,20 @@ export CLAWBENCH_REQUEST_TIMEOUT="${CLAWBENCH_REQUEST_TIMEOUT:-300}"
 export CLAWBENCH_PER_RUN_BUDGET_SECONDS="${CLAWBENCH_PER_RUN_BUDGET_SECONDS:-900}"
 export HERMES_STEP_TIMEOUT_SECONDS="${HERMES_STEP_TIMEOUT_SECONDS:-180}"
 
-# State-dir isolation: the shared /home/node/.openclaw mount accumulates cruft
-# across sweeps (agents/, workspace/, logs/, memory/, stale openclaw.json.*.tmp)
-# which triggers gateway hot-reload churn and cascading `RPC agents.create timed
-# out after 60s` failures. Give each sweep a pristine state dir that carries
-# over only the config (openclaw.json, identity/, devices/, exec-approvals.json,
-# tasks/, subagents/, flows/, cron/) and leaves runtime state empty.
+# State-dir isolation (same as container_sweep_single.sh)
 SRC_STATE="/home/node/.openclaw"
 FRESH_STATE="/tmp/openclaw-state-${SWEEP_LABEL}-$$"
 echo "[state-isolate] cloning config from $SRC_STATE to $FRESH_STATE"
 mkdir -p "$FRESH_STATE"
-# Copy the main config (skip the .tmp/.bak/.clobbered/.pre-* cruft that can
-# confuse the loader — only the canonical openclaw.json is needed).
-if [ -f "$SRC_STATE/openclaw.json" ]; then
-  cp "$SRC_STATE/openclaw.json" "$FRESH_STATE/openclaw.json"
-fi
-if [ -f "$SRC_STATE/exec-approvals.json" ]; then
-  cp "$SRC_STATE/exec-approvals.json" "$FRESH_STATE/exec-approvals.json"
-fi
-# Carry over static config dirs — these are read-mostly and don't accumulate
-# per-run cruft. SKIP: agents/ workspace*/ logs/ memory/ cache/ browser/ canvas/
-# which all grow unboundedly across sweeps.
+[ -f "$SRC_STATE/openclaw.json" ] && cp "$SRC_STATE/openclaw.json" "$FRESH_STATE/openclaw.json"
+[ -f "$SRC_STATE/exec-approvals.json" ] && cp "$SRC_STATE/exec-approvals.json" "$FRESH_STATE/exec-approvals.json"
 for d in identity devices tasks subagents flows cron; do
-  if [ -d "$SRC_STATE/$d" ]; then
-    cp -r "$SRC_STATE/$d" "$FRESH_STATE/$d"
-  fi
+  [ -d "$SRC_STATE/$d" ] && cp -r "$SRC_STATE/$d" "$FRESH_STATE/$d"
 done
-# Ensure runtime dirs exist but are empty
 mkdir -p "$FRESH_STATE/agents" "$FRESH_STATE/workspace" "$FRESH_STATE/logs" "$FRESH_STATE/memory" "$FRESH_STATE/cache"
 export OPENCLAW_STATE_DIR="$FRESH_STATE"
 export OPENCLAW_CONFIG_PATH="$FRESH_STATE/openclaw.json"
 echo "[state-isolate] OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR"
-du -sh "$FRESH_STATE" 2>/dev/null | sed 's/^/[state-isolate] size: /'
 
 python - <<'PY'
 import json
@@ -118,7 +86,7 @@ approvals = {
     "version": 1,
     "socket": {
         "path": str(approvals_path.with_suffix(".sock")),
-        "token": "container-single-eval-token",
+        "token": "container-cherry-eval-token",
     },
     "defaults": {"security": "full", "ask": "off", "askFallback": "full"},
     "agents": {"*": {"security": "full", "ask": "off", "askFallback": "full"}},
@@ -126,21 +94,21 @@ approvals = {
 approvals_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
 PY
 
-# Map label -> cache subdir (matches what clawbench writes)
+# Map model to cache subdir (for archiving)
 case "$SWEEP_MODEL" in
   anthropic/claude-opus-4-7)        CACHE_SUB="anthropic_claude-opus-4-7" ;;
-  anthropic/claude-sonnet-4-7)      CACHE_SUB="anthropic_claude-sonnet-4-7" ;;
   anthropic/claude-opus-4-6)        CACHE_SUB="anthropic_claude-opus-4-6" ;;
   anthropic/claude-sonnet-4-6)      CACHE_SUB="anthropic_claude-sonnet-4-6" ;;
   openai/gpt-5.5)                   CACHE_SUB="openai_gpt-5.5" ;;
   openai/gpt-5.4)                   CACHE_SUB="openai_gpt-5.4" ;;
-  openai/gpt-5.2)                   CACHE_SUB="openai_gpt-5.2" ;;
   google/gemini-3.1-pro-preview)    CACHE_SUB="google_gemini-3.1-pro-preview" ;;
   openrouter/z-ai/glm-5.1)          CACHE_SUB="openrouter_z-ai_glm-5.1" ;;
   openrouter/qwen/qwen3.6-plus)     CACHE_SUB="openrouter_qwen_qwen3.6-plus" ;;
   openrouter/minimax/minimax-m2.7)  CACHE_SUB="openrouter_minimax_minimax-m2.7" ;;
   openrouter/moonshotai/kimi-k2.6)  CACHE_SUB="openrouter_moonshotai_kimi-k2.6" ;;
   openrouter/moonshotai/kimi-k2.5)  CACHE_SUB="openrouter_moonshotai_kimi-k2.5" ;;
+  openrouter/deepseek/deepseek-v4-pro) CACHE_SUB="openrouter_deepseek_deepseek-v4-pro" ;;
+  deepseek/deepseek-v4-pro)         CACHE_SUB="deepseek_deepseek-v4-pro" ;;
   deepseek/v4-pro)                  CACHE_SUB="deepseek_v4-pro" ;;
   *) CACHE_SUB="" ;;
 esac
@@ -149,52 +117,52 @@ OUT="$LOGDIR/docker_${SWEEP_LABEL}_${SWEEP_OUT_TAG}.json"
 LOG="$LOGDIR/docker_${SWEEP_LABEL}_${SWEEP_OUT_TAG}.log"
 GWLOG="$LOGDIR/gateway_${SWEEP_LABEL}.log"
 
-echo "===== SINGLE-MODEL SWEEP START $(date '+%Y-%m-%d %H:%M:%S') ====="
+echo "===== CHERRY-PICK SWEEP $(date '+%Y-%m-%d %H:%M:%S') ====="
 echo "label:   $SWEEP_LABEL"
 echo "model:   $SWEEP_MODEL"
-echo "profile: $SWEEP_PROFILE"
+echo "tasks:   $CHERRY_TASKS"
 echo "out:     $OUT"
-echo "gwlog:   $GWLOG"
-echo "NODE_OPTIONS: $NODE_OPTIONS"
 
-# Force-clear this model's run_cache so we actually re-run (no replays)
+# Force-clear this model's run_cache (including fixed-task slots — so they
+# actually re-run against the new image instead of hitting old cache).
 if [ -n "$CACHE_SUB" ] && [ -d "$CLAWBENCH_RUN_CACHE_DIR/$CACHE_SUB" ]; then
   echo "clearing cache: $CLAWBENCH_RUN_CACHE_DIR/$CACHE_SUB"
   rm -rf "$CLAWBENCH_RUN_CACHE_DIR/$CACHE_SUB"
 fi
-
-# Also remove any stale result JSON so we don't skip-on-idempotence
-if [ -f "$OUT" ]; then
-  echo "removing stale result: $OUT"
-  rm -f "$OUT"
-fi
+[ -f "$OUT" ] && rm -f "$OUT"
 
 # Start gateway with bumped heap
 echo "Starting gateway on :18789 (heap=4GB) ..."
 openclaw gateway --port 18789 > "$GWLOG" 2>&1 &
 GATEWAY_PID=$!
-echo "gateway pid=$GATEWAY_PID"
-
 ready=0
 for i in $(seq 1 120); do
-  if curl -sf -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" http://127.0.0.1:18789/health > /dev/null 2>&1; then
-    echo "Gateway healthy after ${i}s"
+  if curl -sf -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" http://127.0.0.1:18789/ready > /dev/null 2>&1; then
+    echo "Gateway ready after ${i}s"
     ready=1
     break
   fi
   sleep 1
 done
 if [ $ready -ne 1 ]; then
-  echo "ERROR: gateway failed to come up within 120s"
+  echo "ERROR: gateway failed to become ready within 120s"
   tail -30 "$GWLOG"
   exit 1
 fi
 
-echo "===== $(date '+%H:%M:%S') starting $SWEEP_LABEL ($SWEEP_MODEL) ====="
-# NOTE: --profile intentionally OMITTED unless USE_PROFILE=1 is set. The
-# legacy frontier_*.yaml profile format is incompatible with OpenClaw
-# 4.22+ (loads n_tools_total=0). Running with the default openclaw tool
-# stack — identical across all models, so comparisons stay valid.
+# Build -t args from comma-separated list
+TASK_ARGS=()
+IFS=',' read -ra TASK_ARR <<< "$CHERRY_TASKS"
+for t in "${TASK_ARR[@]}"; do
+  TASK_ARGS+=("-t" "$t")
+done
+
+echo "===== $(date '+%H:%M:%S') running clawbench with tasks: ${TASK_ARR[*]} ====="
+# NOTE: --profile intentionally OMITTED. The legacy frontier_*.yaml profile
+# format is incompatible with OpenClaw 4.22+ (loads n_tools_total=0,
+# starves the agent of tools, all runs fail with environment_unavailable
+# or timeout). Running with the default openclaw tool stack — same for
+# all models, so the comparison stays apples-to-apples.
 PROFILE_ARG=""
 if [ -n "${USE_PROFILE:-}" ] && [ -f "$SWEEP_PROFILE" ]; then
   PROFILE_ARG="--profile $SWEEP_PROFILE"
@@ -205,6 +173,7 @@ clawbench run \
   --concurrency "${CLAWBENCH_CONCURRENCY:-1}" \
   $PROFILE_ARG \
   --judge-model "anthropic/claude-sonnet-4-6" \
+  "${TASK_ARGS[@]}" \
   -o "$OUT" \
   > "$LOG" 2>&1
 status=$?
@@ -216,20 +185,14 @@ else
   tail -20 "$LOG"
 fi
 
-# Archive the cache for future audits (preserves transcripts per sweep tag)
+# Archive cache to v2026-4-20-cherry tag
 # shellcheck disable=SC1091
-source "$(dirname "$0")/_archive_cache.sh" 2>/dev/null && archive_run_cache || echo "[archive] helper missing, skipping"
+source "$(dirname "$0")/_archive_cache.sh" 2>/dev/null && archive_run_cache || echo "[archive] helper missing"
 
-echo ""
-echo "===== SINGLE-MODEL SWEEP END $(date '+%Y-%m-%d %H:%M:%S') ====="
 kill $GATEWAY_PID 2>/dev/null
 wait $GATEWAY_PID 2>/dev/null
-echo "gateway stopped"
 
-# Clean up the isolated state dir (don't accumulate /tmp cruft across sweeps).
-if [ -n "${FRESH_STATE:-}" ] && [ -d "$FRESH_STATE" ]; then
-  echo "[state-isolate] removing $FRESH_STATE"
-  rm -rf "$FRESH_STATE"
-fi
+# Clean up isolated state dir
+[ -n "${FRESH_STATE:-}" ] && [ -d "$FRESH_STATE" ] && rm -rf "$FRESH_STATE"
 
 exit $status

--- a/scripts/container_lane_eval.sh
+++ b/scripts/container_lane_eval.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Run one OpenClaw model/profile through the HF-style isolated lane worker.
+set -Eeuo pipefail
+
+: "${SWEEP_MODEL:?SWEEP_MODEL required}"
+: "${SWEEP_LABEL:?SWEEP_LABEL required}"
+: "${SWEEP_OUT_TAG:=lane-container}"
+: "${SWEEP_LANES:=3}"
+: "${SWEEP_RUNS:=1}"
+: "${SWEEP_LOGDIR:=/data/results}"
+: "${CLAWBENCH_PER_RUN_BUDGET_SECONDS:=900}"
+: "${CLAWBENCH_PER_TURN_TIMEOUT_SECONDS:=300}"
+: "${OPENCLAW_EXEC_HOST:=gateway}"
+
+cd /home/node/app
+export CLAWBENCH_LOCAL_QUEUE_DIR="${CLAWBENCH_LOCAL_QUEUE_DIR:-/data/queue/$SWEEP_LABEL}"
+mkdir -p "$SWEEP_LOGDIR" /data/results "$CLAWBENCH_LOCAL_QUEUE_DIR" /data/run_cache /data/lane_runtime
+
+export HF_TOKEN=""
+export OPENCLAW_GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-dev-token-for-testing}"
+export OPENCLAW_SKIP_GMAIL_WATCHER=1
+export OPENCLAW_SKIP_CANVAS_HOST=1
+export OPENCLAW_NO_RESPAWN=1
+export CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY=1
+export CLAWBENCH_PER_RUN_BUDGET_SECONDS
+export CLAWBENCH_PER_TURN_TIMEOUT_SECONDS
+export CLAWBENCH_CONNECT_TIMEOUT="${CLAWBENCH_CONNECT_TIMEOUT:-180}"
+export CLAWBENCH_REQUEST_TIMEOUT="${CLAWBENCH_REQUEST_TIMEOUT:-300}"
+export CLAWBENCH_GATEWAY_HEALTH_TIMEOUT_SECONDS="${CLAWBENCH_GATEWAY_HEALTH_TIMEOUT_SECONDS:-240}"
+export CLAWBENCH_LANE_STARTUP_STAGGER_SECONDS="${CLAWBENCH_LANE_STARTUP_STAGGER_SECONDS:-90}"
+export CLAWBENCH_GATEWAY_READY_MARKER_GRACE_SECONDS="${CLAWBENCH_GATEWAY_READY_MARKER_GRACE_SECONDS:-90}"
+export CLAWBENCH_KEEP_PARALLEL_LANE_ROOT="${CLAWBENCH_KEEP_PARALLEL_LANE_ROOT:-0}"
+export CLAWBENCH_PARALLEL_LANE_ROOT="/data/lane_runtime/$SWEEP_LABEL"
+export CLAWBENCH_TOOL_PROFILE_NAME="${CLAWBENCH_TOOL_PROFILE_NAME:-$SWEEP_LABEL}"
+export NODE_OPTIONS="${NODE_OPTIONS:-"--max-old-space-size=4096"}"
+if command -v npm >/dev/null 2>&1; then
+  export NODE_PATH="${NODE_PATH:-$(npm root -g 2>/dev/null || true)}"
+fi
+
+SRC_STATE="${OPENCLAW_CONFIG_SOURCE:-/config/openclaw}"
+if [ ! -d "$SRC_STATE" ]; then
+  SRC_STATE="/home/node/.openclaw"
+fi
+
+safe_model="${SWEEP_MODEL//\//_}"
+safe_model="${safe_model//:/_}"
+OUT="$SWEEP_LOGDIR/${SWEEP_LABEL}_openclaw_${safe_model}_${SWEEP_OUT_TAG}.json"
+LOG="$SWEEP_LOGDIR/${SWEEP_LABEL}_openclaw_${safe_model}_${SWEEP_OUT_TAG}.log"
+export SWEEP_OUTPUT_PATH="$OUT"
+
+FRESH_HOME="/tmp/openclaw-home-${SWEEP_LABEL}-$$"
+FRESH_STATE="$FRESH_HOME/.openclaw"
+rm -rf "$FRESH_HOME" "$CLAWBENCH_PARALLEL_LANE_ROOT"
+mkdir -p "$FRESH_STATE" "$FRESH_HOME/.config"
+if [ -f "$SRC_STATE/openclaw.json" ]; then
+  cp "$SRC_STATE/openclaw.json" "$FRESH_STATE/openclaw.json"
+fi
+if [ -d "$SRC_STATE/plugins" ]; then
+  mkdir -p "$FRESH_STATE/plugins"
+  cp -R "$SRC_STATE/plugins/." "$FRESH_STATE/plugins/" 2>/dev/null || true
+fi
+mkdir -p \
+  "$FRESH_STATE/agents" \
+  "$FRESH_STATE/workspace" \
+  "$FRESH_STATE/logs" \
+  "$FRESH_STATE/memory" \
+  "$FRESH_STATE/cache" \
+  "$FRESH_STATE/identity" \
+  "$FRESH_STATE/devices" \
+  "$FRESH_STATE/tasks" \
+  "$FRESH_STATE/subagents" \
+  "$FRESH_STATE/flows" \
+  "$FRESH_STATE/cron"
+
+export HOME="$FRESH_HOME"
+export OPENCLAW_HOME="$FRESH_HOME"
+export OPENCLAW_STATE_DIR="$FRESH_STATE"
+export OPENCLAW_CONFIG_PATH="$FRESH_STATE/openclaw.json"
+export XDG_CONFIG_HOME="$FRESH_HOME/.config"
+
+python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cfg_path = Path(os.environ["OPENCLAW_CONFIG_PATH"])
+if not cfg_path.exists():
+    raise SystemExit("missing openclaw.json")
+data = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+def set_nested(root, dotted, value):
+    cursor = root
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        child = cursor.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            cursor[part] = child
+        cursor = child
+    cursor[parts[-1]] = value
+
+agents = data.setdefault("agents", {})
+if isinstance(agents, dict):
+    agents["list"] = []
+
+channels = data.get("channels")
+if isinstance(channels, dict):
+    for channel in channels.values():
+        if isinstance(channel, dict):
+            channel["enabled"] = False
+            exec_approvals = channel.get("execApprovals")
+            if not isinstance(exec_approvals, dict):
+                exec_approvals = {}
+                channel["execApprovals"] = exec_approvals
+            exec_approvals["enabled"] = False
+
+plugins = data.setdefault("plugins", {})
+stale = {"marxbiotech-git-tools", "lab"}
+allow = plugins.get("allow")
+if isinstance(allow, list):
+    plugins["allow"] = [item for item in allow if item not in stale]
+entries = plugins.get("entries")
+if isinstance(entries, dict):
+    for item in stale:
+        entries.pop(item, None)
+
+set_nested(data, "browser.headless", True)
+set_nested(data, "browser.noSandbox", True)
+set_nested(data, "gateway.reload.mode", "off")
+set_nested(data, "agents.defaults.skipBootstrap", True)
+set_nested(data, "agents.defaults.sandbox.mode", "off")
+set_nested(data, "agents.defaults.model.primary", os.environ["SWEEP_MODEL"])
+set_nested(data, "agents.defaults.subagents.model.primary", os.environ["SWEEP_MODEL"])
+set_nested(data, "tools.exec.host", os.environ.get("OPENCLAW_EXEC_HOST", "gateway"))
+set_nested(data, "tools.exec.security", "full")
+set_nested(data, "tools.exec.ask", "off")
+set_nested(data, "approvals.exec.enabled", False)
+
+cfg_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+approvals_path = cfg_path.with_name("exec-approvals.json")
+approvals = {
+    "version": 1,
+    "socket": {
+        "path": str(approvals_path.with_suffix(".sock")),
+        "token": "container-lane-eval-token",
+    },
+    "defaults": {"security": "full", "ask": "off", "askFallback": "full"},
+    "agents": {"*": {"security": "full", "ask": "off", "askFallback": "full"}},
+}
+approvals_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
+PY
+
+if [ "${CLAWBENCH_ENABLE_GBRAIN:-0}" = "1" ]; then
+  export CLAWBENCH_LANE_PREPARE_CMD="${CLAWBENCH_LANE_PREPARE_CMD:-/home/node/app/scripts/setup_gbrain_runtime.sh}"
+  "$CLAWBENCH_LANE_PREPARE_CMD"
+fi
+
+echo "===== CONTAINER LANE EVAL START $(date '+%Y-%m-%d %H:%M:%S') ====="
+echo "label:    $SWEEP_LABEL"
+echo "model:    $SWEEP_MODEL"
+echo "runs:     $SWEEP_RUNS"
+echo "lanes:    $SWEEP_LANES"
+echo "tasks:    ${SWEEP_TASKS:-${CHERRY_TASKS:-all}}"
+echo "out:      $OUT"
+echo "log:      $LOG"
+echo "home:     $HOME"
+echo "state:    $OPENCLAW_STATE_DIR"
+openclaw --version 2>/dev/null || true
+
+set +e
+python - <<'PY' > "$LOG" 2>&1
+import asyncio
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from clawbench.queue import JobQueue, JobStatus, SubmissionRequest
+from clawbench.worker import EvalWorker, RESULTS_DIR
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+async def main() -> int:
+    queue = JobQueue()
+    queue._jobs.clear()
+    queue._save_local()
+    task_ids_raw = os.environ.get("SWEEP_TASKS") or os.environ.get("CHERRY_TASKS") or ""
+    task_ids = [item.strip() for item in task_ids_raw.split(",") if item.strip()]
+    request = SubmissionRequest(
+        model=os.environ["SWEEP_MODEL"],
+        runs_per_task=int(os.environ["SWEEP_RUNS"]),
+        max_parallel_lanes=int(os.environ["SWEEP_LANES"]),
+        task_ids=task_ids,
+        prompt_variant=os.environ.get("SWEEP_PROMPT_VARIANT", "clear"),
+        judge_model=os.environ.get("CLAWBENCH_JUDGE_MODEL", ""),
+        notes=os.environ.get("SWEEP_LABEL", ""),
+    )
+    job = await queue.submit(request)
+    worker = EvalWorker(queue)
+    await worker._process_job(job)
+    final = await queue.get_status(job.job_id)
+    print(json.dumps(final.model_dump() if final else {}, indent=2), flush=True)
+    if final is None or final.status != JobStatus.FINISHED or not final.result_id:
+        return 1
+    result_path = RESULTS_DIR / f"{final.result_id}.json"
+    output_path = Path(os.environ["SWEEP_OUTPUT_PATH"])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(result_path, output_path)
+    return 0
+
+raise SystemExit(asyncio.run(main()))
+PY
+status=$?
+set -e
+
+echo "===== lane eval exit=$status $(date '+%Y-%m-%d %H:%M:%S') ====="
+tail -120 "$LOG" 2>/dev/null || true
+exit "$status"

--- a/scripts/container_lane_eval.sh
+++ b/scripts/container_lane_eval.sh
@@ -131,10 +131,26 @@ set_nested(data, "agents.defaults.skipBootstrap", True)
 set_nested(data, "agents.defaults.sandbox.mode", "off")
 set_nested(data, "agents.defaults.model.primary", os.environ["SWEEP_MODEL"])
 set_nested(data, "agents.defaults.subagents.model.primary", os.environ["SWEEP_MODEL"])
+set_nested(
+    data,
+    "agents.defaults.systemPromptOverride",
+    "You are running an OpenClaw benchmark task. Complete the user's request in the current "
+    "workspace using the available tools when needed. For file, code, browser, shell, or memory "
+    "tasks, make the requested changes directly and verify them when practical. Do not ask "
+    "follow-up questions during the benchmark. Keep any final reply brief.",
+)
 set_nested(data, "tools.exec.host", os.environ.get("OPENCLAW_EXEC_HOST", "gateway"))
 set_nested(data, "tools.exec.security", "full")
 set_nested(data, "tools.exec.ask", "off")
 set_nested(data, "approvals.exec.enabled", False)
+
+models = data.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
+model_entry = models.setdefault(os.environ["SWEEP_MODEL"], {})
+params = model_entry.setdefault("params", {})
+params["fastMode"] = True
+if os.environ["SWEEP_MODEL"].startswith("openai/"):
+    params["transport"] = "sse"
+    params["openaiWsWarmup"] = False
 
 cfg_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/container_lane_eval.sh
+++ b/scripts/container_lane_eval.sh
@@ -167,11 +167,6 @@ approvals = {
 approvals_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
 PY
 
-if [ "${CLAWBENCH_ENABLE_GBRAIN:-0}" = "1" ]; then
-  export CLAWBENCH_LANE_PREPARE_CMD="${CLAWBENCH_LANE_PREPARE_CMD:-/home/node/app/scripts/setup_gbrain_runtime.sh}"
-  "$CLAWBENCH_LANE_PREPARE_CMD"
-fi
-
 echo "===== CONTAINER LANE EVAL START $(date '+%Y-%m-%d %H:%M:%S') ====="
 echo "label:    $SWEEP_LABEL"
 echo "model:    $SWEEP_MODEL"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,7 +107,7 @@ async def test_gateway_client_retries_transient_drain_errors(monkeypatch: pytest
     async def fake_wait_event(self, event_name: str, *, timeout: float):
         return {"payload": {"nonce": ""}}
 
-    async def fake_rpc(self, method: str, params=None):
+    async def fake_rpc(self, method: str, params=None, **kwargs):
         return {"payload": {"type": "hello-ok", "protocol": 3}}
 
     async def fake_listener(self):
@@ -144,7 +144,7 @@ async def test_gateway_client_retries_half_closed_handshake_errors(
     async def fake_wait_event(self, event_name: str, *, timeout: float):
         return {"payload": {"nonce": ""}}
 
-    async def fake_rpc(self, method: str, params=None):
+    async def fake_rpc(self, method: str, params=None, **kwargs):
         return {"payload": {"type": "hello-ok", "protocol": 3}}
 
     async def fake_listener(self):
@@ -226,3 +226,71 @@ async def test_rpc_timeout_cleans_pending_request():
 
     assert sent_frames[0]["method"] == "sessions.create"
     assert client._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_send_and_wait_passes_gateway_timeout_and_waits_for_run():
+    client = GatewayClient(GatewayConfig(request_timeout=1))
+    session_key = "session-1"
+    calls: list[tuple[str, dict | None, dict]] = []
+
+    async def fake_rpc(method: str, params=None, **kwargs):
+        calls.append((method, params, kwargs))
+        if method == "sessions.send":
+            return {"ok": True, "payload": {"runId": "run-1"}}
+        if method == "agent.wait":
+            return {"ok": True, "payload": {"runId": "run-1", "status": "completed"}}
+        if method == "sessions.get":
+            return {
+                "ok": True,
+                "payload": {
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Done."}],
+                        }
+                    ]
+                },
+            }
+        return {"ok": True, "payload": {}}
+
+    client._rpc = fake_rpc  # type: ignore[method-assign]
+
+    transcript = await client.send_and_wait(session_key, "hello", timeout=1.5)
+
+    send_call = next(call for call in calls if call[0] == "sessions.send")
+    assert send_call[1] == {
+        "key": session_key,
+        "message": "hello",
+        "idempotencyKey": send_call[1]["idempotencyKey"],
+        "timeoutMs": 1500,
+    }
+    wait_call = next(call for call in calls if call[0] == "agent.wait")
+    assert wait_call[1] == {"runId": "run-1", "timeoutMs": 1500}
+    assert wait_call[2]["timeout"] == 11.5
+    assert [message.text for message in transcript.assistant_messages] == ["Done."]
+
+
+@pytest.mark.asyncio
+async def test_send_and_wait_aborts_run_when_no_terminal_state_arrives():
+    client = GatewayClient(GatewayConfig(request_timeout=1))
+    session_key = "session-1"
+    calls: list[tuple[str, dict | None, dict]] = []
+
+    async def fake_rpc(method: str, params=None, **kwargs):
+        calls.append((method, params, kwargs))
+        if method == "sessions.send":
+            return {"ok": True, "payload": {"runId": "run-timeout"}}
+        if method == "agent.wait":
+            await asyncio.sleep(60)
+        if method == "sessions.abort":
+            return {"ok": True, "payload": {"status": "aborted"}}
+        if method == "sessions.get":
+            return {"ok": True, "payload": {"messages": []}}
+        return {"ok": True, "payload": {}}
+
+    client._rpc = fake_rpc  # type: ignore[method-assign]
+
+    await client.send_and_wait(session_key, "hello", timeout=0.01)
+
+    assert ("sessions.abort", {"key": session_key, "runId": "run-timeout"}, {"timeout": 1}) in calls

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -23,6 +23,12 @@ def test_submission_request_defaults_to_single_parallel_lane():
     assert request.task_ids == []
 
 
+def test_local_queue_dir_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWBENCH_LOCAL_QUEUE_DIR", str(tmp_path / "queue"))
+
+    assert queue_module._resolve_local_queue_dir() == tmp_path / "queue"
+
+
 def test_submission_request_fingerprint_includes_judge_score_gate():
     advisory = SubmissionRequest(model="anthropic/claude-sonnet-4-6", judge_model="judge")
     weighted = SubmissionRequest(
@@ -42,6 +48,19 @@ def test_submission_request_fingerprint_includes_task_ids():
     )
 
     assert all_tasks.active_fingerprint() != subset.active_fingerprint()
+
+
+def test_submission_request_fingerprint_canonicalizes_task_ids():
+    first = SubmissionRequest(
+        model="anthropic/claude-sonnet-4-6",
+        task_ids=[" t2-demo ", "t1-demo", "t2-demo"],
+    )
+    second = SubmissionRequest(
+        model="anthropic/claude-sonnet-4-6",
+        task_ids=["t1-demo", "t2-demo"],
+    )
+
+    assert first.active_fingerprint() == second.active_fingerprint()
 
 
 def test_save_local_replaces_queue_file_atomically(tmp_path, monkeypatch):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -20,6 +20,7 @@ def test_submission_request_defaults_to_single_parallel_lane():
     assert request.max_parallel_lanes == 1
     assert request.runs_per_task == 3
     assert request.judge_affects_score is False
+    assert request.task_ids == []
 
 
 def test_submission_request_fingerprint_includes_judge_score_gate():
@@ -31,6 +32,16 @@ def test_submission_request_fingerprint_includes_judge_score_gate():
     )
 
     assert advisory.active_fingerprint() != weighted.active_fingerprint()
+
+
+def test_submission_request_fingerprint_includes_task_ids():
+    all_tasks = SubmissionRequest(model="anthropic/claude-sonnet-4-6")
+    subset = SubmissionRequest(
+        model="anthropic/claude-sonnet-4-6",
+        task_ids=["t1-fs-quick-note"],
+    )
+
+    assert all_tasks.active_fingerprint() != subset.active_fingerprint()
 
 
 def test_save_local_replaces_queue_file_atomically(tmp_path, monkeypatch):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -137,6 +137,35 @@ def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
     }
 
 
+def test_configure_browser_runtime_uses_gateway_env_config_path(tmp_path: Path, monkeypatch):
+    worker = EvalWorker(JobQueue())
+    worker.set_active_model("openai-codex/gpt-5.4")
+    parent_state = tmp_path / "parent"
+    lane_state = tmp_path / "lane"
+    parent_state.mkdir()
+    lane_state.mkdir()
+    parent_config = parent_state / "openclaw.json"
+    lane_config = lane_state / "openclaw.json"
+    parent_config.write_text("{}", encoding="utf-8")
+    lane_config.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(parent_state))
+
+    worker._configure_browser_runtime(
+        ["node", "/openclaw/dist/cli.js"],
+        {
+            "OPENCLAW_STATE_DIR": str(lane_state),
+            "OPENCLAW_CONFIG_PATH": str(lane_config),
+        },
+    )
+
+    assert json.loads(parent_config.read_text(encoding="utf-8")) == {}
+    lane_data = json.loads(lane_config.read_text(encoding="utf-8"))
+    assert lane_data["agents"]["defaults"]["model"]["primary"] == "openai-codex/gpt-5.4"
+    assert lane_data["tools"]["exec"] == {"host": "gateway", "security": "full", "ask": "off"}
+    assert (lane_state / "exec-approvals.json").exists()
+    assert not (parent_state / "exec-approvals.json").exists()
+
+
 def test_eval_model_defaults_pin_openai_to_sse_transport() -> None:
     data: dict[str, object] = {}
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -6,7 +6,14 @@ from types import SimpleNamespace
 import pytest
 
 from clawbench.queue import Job, JobQueue, JobStatus, SubmissionRequest
-from clawbench.worker import GATEWAY_PORT, GATEWAY_PORT_SPACING, EvalWorker, JobProgressTracker, ParallelLane
+from clawbench.worker import (
+    GATEWAY_PORT,
+    GATEWAY_PORT_SPACING,
+    OPENCLAW_EVAL_SYSTEM_PROMPT,
+    EvalWorker,
+    JobProgressTracker,
+    ParallelLane,
+)
 
 
 class DummyTask:
@@ -119,12 +126,27 @@ def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
             "defaults": {
                 "skipBootstrap": True,
                 "model": {"primary": "openai-codex/gpt-5.4"},
+                "models": {"openai-codex/gpt-5.4": {"params": {"fastMode": True}}},
+                "systemPromptOverride": OPENCLAW_EVAL_SYSTEM_PROMPT,
                 "subagents": {"model": {"primary": "openai-codex/gpt-5.4"}},
             }
         },
         "browser": {"headless": True, "noSandbox": True},
         "tools": {"exec": {"host": "gateway", "security": "full", "ask": "off"}},
         "approvals": {"exec": {"enabled": False}},
+    }
+
+
+def test_eval_model_defaults_pin_openai_to_sse_transport() -> None:
+    data: dict[str, object] = {}
+
+    changed = EvalWorker._apply_eval_model_defaults(data, "openai/gpt-5.5")
+
+    assert changed is True
+    assert data["agents"]["defaults"]["models"]["openai/gpt-5.5"]["params"] == {
+        "fastMode": True,
+        "transport": "sse",
+        "openaiWsWarmup": False,
     }
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -91,7 +91,12 @@ def test_configure_browser_runtime_sets_benchmark_safe_openclaw_config(monkeypat
     assert json.loads(config_path.read_text(encoding="utf-8")) == {
         "agents": {"defaults": {"skipBootstrap": True}},
         "browser": {"headless": True, "noSandbox": True},
+        "tools": {"exec": {"host": "gateway", "security": "full", "ask": "off"}},
+        "approvals": {"exec": {"enabled": False}},
     }
+    approvals = json.loads((state_dir / "exec-approvals.json").read_text(encoding="utf-8"))
+    assert approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
+    assert approvals["agents"]["*"] == {"security": "full", "ask": "off", "askFallback": "full"}
 
 
 def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
@@ -118,6 +123,8 @@ def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
             }
         },
         "browser": {"headless": True, "noSandbox": True},
+        "tools": {"exec": {"host": "gateway", "security": "full", "ask": "off"}},
+        "approvals": {"exec": {"enabled": False}},
     }
 
 
@@ -215,6 +222,11 @@ def test_materialize_lane_runtime_spaces_ports_and_copies_auth(tmp_path: Path, m
     assert lane1.port == GATEWAY_PORT + GATEWAY_PORT_SPACING
     assert lane1.state_dir is not None
     assert (lane1.state_dir / "agents" / "main" / "agent" / "auth-profiles.json").exists()
+    lane_cfg = json.loads((lane1.state_dir / "openclaw.json").read_text(encoding="utf-8"))
+    assert lane_cfg["tools"]["exec"] == {"host": "gateway", "security": "full", "ask": "off"}
+    assert lane_cfg["approvals"]["exec"] == {"enabled": False}
+    lane_approvals = json.loads((lane1.state_dir / "exec-approvals.json").read_text(encoding="utf-8"))
+    assert lane_approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route OpenClaw eval turns through the run lifecycle explicitly: pass `timeoutMs` to `sessions.send`, wait with `agent.wait`, and abort timed-out runs before cleanup.
- Harden containerized full-suite lanes with isolated HOME/state, gateway startup grace, full/no-ask exec defaults, and the reusable lane helper scripts.
- Fix the container image and queue request plumbing needed for real full-suite sweeps: copy helper scripts into the image, install Playwright from `/tmp`, preserve `task_ids`, and include task subsets in active fingerprints.
- Stabilize OpenAI eval transport by pinning native OpenAI models to SSE (`transport: "sse"`, `openaiWsWarmup: false`) and applying the concise eval system prompt/fast mode defaults for benchmark runs.

## Root Cause
There were two separate failure modes stacked together.

First, OpenClaw `/health` could become ready before the gateway control-plane methods used by ClawBench were reliably available. That made early `sessions.create`, `sessions.send`, `agent.wait`, or `tools.effective` calls fail or hang around startup, which looked like WebSocket starvation from ClawBench. The companion OpenClaw PR makes those startup-unavailable methods explicitly retryable.

Second, OpenAI direct-provider evals were taking the OpenAI Responses WebSocket path inside OpenClaw (`streamStrategy: openai-websocket`). In this Docker/lane harness, those turns could sit until the model idle/run timeout without receiving a first item, while direct OpenAI Responses SSE sanity checks succeeded and Anthropic evals completed normally. For benchmark stability, ClawBench now forces OpenAI eval models onto SSE; the failing `gpt-5.5` smoke went from a zero-token timeout to a passing run.

A third harness bug made debugging misleading: `SWEEP_TASKS` was passed as `task_ids`, but `SubmissionRequest` did not declare that field, so Pydantic dropped it. The container helper could silently run the default corpus instead of the requested subset. This is now modeled, fingerprinted, and tested.

## Validation
- `PYTHONPATH=. /Users/zhentongfan/Desktop/openclaw/clawbench/.venv/bin/ruff check clawbench/worker.py clawbench/queue.py tests/test_worker.py tests/test_queue.py`
- `PYTHONPATH=. /Users/zhentongfan/Desktop/openclaw/clawbench/.venv/bin/pytest tests/test_worker.py tests/test_queue.py -q` (33 passed)
- `bash -n scripts/container_lane_eval.sh`
- Docker image rebuilt successfully with `OPENCLAW_IMAGE=openclaw:gateway-ready-pr`.
- GPT-5.5 smoke after SSE pin: `openai/gpt-5.5`, `t1-fs-quick-note`, 1 lane x 1 run exited 0; score 1.000; total run 37.2s; gateway health/connect ready immediately after startup.
- Full comparison is currently running with the patched ClawBench image and OpenClaw PR image: 40 tasks x 3 runs x 3 lanes for `openai/gpt-5.5`, followed by `anthropic/claude-opus-4-7`. Early GPT-5.5 progress has all three lanes active, including browser lane, with no OOM/crash/idle-timeout signatures in logs.

## Related OpenClaw PR
- openclaw/openclaw#76012 (`fix(gateway): make startup control-plane retries explicit`)
