### PR TITLE
ci: default crabbox owned capacity to standard

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -30,7 +30,7 @@ runner class, reusable warm state, or a Blacksmith alternative.
 AWS/owned-capacity flow for Python tests:
 
 ```sh
-crabbox warmup --idle-timeout 90m
+crabbox warmup --class standard --idle-timeout 90m
 crabbox actions hydrate --id <cbx_id-or-slug>
 crabbox run --id <cbx_id-or-slug> --timing-json --shell -- "python -m pytest -q"
 ```
@@ -55,6 +55,32 @@ Stop boxes you created before handoff:
 ```sh
 crabbox stop <cbx_id-or-slug>
 ```
+
+## Owned AWS Capacity
+
+When AWS capacity is under pressure, do not start with `class=beast`.
+`beast` begins at 48xlarge instances and can burn 192 vCPU quota per request.
+ClawBench's owned-cloud default is `standard`; escalate to `fast`, then
+`large`, and only use `beast` when the work is explicitly CPU-bound and the
+smaller class already failed the goal.
+
+Keep capacity hints enabled so brokered AWS leases print selected
+region/market, quota pressure, Spot fallback, and high-pressure class warnings.
+The ClawBench repo config sets `capacity.hints: true`; use
+`CRABBOX_CAPACITY_HINTS=0` only when debugging hint rendering itself.
+
+Use `beast` only for exceptional lanes:
+
+- full benchmark sweeps where wall time is dominated by CPU, not dependency
+  install or network;
+- release/blocker validation where a maintainer explicitly asks for the largest
+  owned AWS class;
+- performance profiling where the point is to compare high-core behavior.
+
+Do not use `beast` for ordinary `python -m pytest -q`, docs-only work, small
+task repros, Blacksmith outage triage, or focused lint/type/test checks. Those
+should use `standard` first and `fast` only when the extra cores materially
+help.
 
 ## Useful Commands
 

--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -1,10 +1,11 @@
 profile: clawbench-check
 provider: aws
-class: beast
+class: standard
 capacity:
   market: spot
   strategy: most-available
   fallback: on-demand-after-120s
+  hints: true
   regions:
     - eu-west-1
 actions:


### PR DESCRIPTION
## What does this PR do?

Ports the latest OpenClaw Crabbox capacity guidance into ClawBench and updates the repo default owned AWS class.

## Why?

ClawBench should follow the same pressure-safe Crabbox defaults as OpenClaw: start with `standard`, keep capacity hints enabled, and reserve `beast` for exceptional CPU-bound lanes.

## Changes

- Change `.crabbox.yaml` from `class: beast` to `class: standard`.
- Enable `capacity.hints: true` for brokered AWS lease diagnostics.
- Update the ClawBench Crabbox skill with the owned-capacity escalation policy.

## Tests

- [x] `git diff --check`
- [x] `crabbox config show -json`
- [x] YAML parse check for `.crabbox.yaml`
- [x] `actionlint -config-file .github/actionlint.yaml .github/workflows/crabbox-hydrate.yml .github/workflows/ci-check-testbox.yml`
