### PR TITLE
[codex] Fix OpenClaw Codex OpenAI eval auth flow

### DIFF
--- a/clawbench/adapters/openclaw.py
+++ b/clawbench/adapters/openclaw.py
@@ -20,7 +20,6 @@ import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from clawbench.adapters import register_adapter
 from clawbench.adapters.base import (
@@ -37,16 +36,12 @@ from clawbench.canonical import (
 )
 from clawbench.client import GatewayClient, GatewayConfig
 from clawbench.environment_files import (
-    memory_visible_in_transcript,
     resolve_json_path,
     verify_memory_fallback,
 )
 from clawbench.schemas import (
-    CronState,
     MemoryState,
     PromptVariant,
-    SessionState,
-    Transcript,
 )
 from clawbench.session_labels import unique_session_label
 from clawbench.simulated_user import UserSimulator

--- a/clawbench/adapters/openclaw.py
+++ b/clawbench/adapters/openclaw.py
@@ -8,17 +8,19 @@ simulated-user turns, and resolves `StateQuery` assertions against the
 gateway's `memory.search` / `sessions.resolve` / `cron.list` / arbitrary
 `_rpc(method)` surface.
 
-The legacy harness still owns the executable CLI path for now; this
-adapter is the canonical wrapper used by adapter-level tests and later
-harness wiring.
+The benchmark harness now routes OpenClaw through this adapter, matching
+the same canonical task/run lifecycle used by other harness adapters.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 from clawbench.adapters import register_adapter
 from clawbench.adapters.base import (
@@ -35,17 +37,22 @@ from clawbench.canonical import (
 )
 from clawbench.client import GatewayClient, GatewayConfig
 from clawbench.environment_files import (
+    memory_visible_in_transcript,
     resolve_json_path,
     verify_memory_fallback,
 )
 from clawbench.schemas import (
+    CronState,
     MemoryState,
     PromptVariant,
+    SessionState,
+    Transcript,
 )
 from clawbench.session_labels import unique_session_label
 from clawbench.simulated_user import UserSimulator
 
 logger = logging.getLogger(__name__)
+CODEX_OPENAI_AUTH_PROFILE_ID = "openai-codex:clawbench-env"
 
 
 @dataclass
@@ -130,6 +137,11 @@ class OpenClawAdapter(AgentAdapter):
         agent_id = await self.client.create_agent(
             name=agent_name, workspace=str(ctx.workspace)
         )
+        _ensure_codex_openai_agent_auth_profile(ctx.model, agent_id)
+        # OpenClaw 2026.4.x persists agent changes through the gateway config
+        # and may restart immediately after agents.create. Reconnect before
+        # creating sessions so subsequent phase traffic is on the fresh socket.
+        await self.client.reconnect()
         ctx.adapter_state["agent_id"] = agent_id
         ctx.adapter_state.setdefault("session_keys", [])
 
@@ -191,13 +203,20 @@ class OpenClawAdapter(AgentAdapter):
             )
 
         session_keys: list[str] = ctx.adapter_state.setdefault("session_keys", [])
+        session_model = _openclaw_session_model(ctx.model)
         session_key = await self.client.create_session(
-            model=ctx.model,
+            model=session_model,
             agent_id=agent_id,
             label=unique_session_label(
                 f"clawbench-{ctx.task.id}-run{ctx.run_index}-phase{phase.name}"
             ),
         )
+        if _should_bind_codex_openai_auth_profile(ctx.model):
+            self.client.set_session_auth_profile_override(
+                session_key,
+                agent_id=agent_id,
+                auth_profile_id=CODEX_OPENAI_AUTH_PROFILE_ID,
+            )
         session_keys.append(session_key)
         ctx.adapter_state["last_session_key"] = session_key
 
@@ -465,3 +484,57 @@ class OpenClawAdapter(AgentAdapter):
 
 
 __all__ = ["OpenClawAdapter", "OpenClawAdapterConfig"]
+
+
+def _should_bind_codex_openai_auth_profile(model: str) -> bool:
+    runtime = (
+        os.environ.get("CLAWBENCH_OPENCLAW_AGENT_RUNTIME")
+        or os.environ.get("OPENCLAW_AGENT_RUNTIME")
+        or ""
+    ).strip()
+    if runtime != "codex":
+        return False
+    if not model.startswith("openai/"):
+        return False
+    return bool(os.environ.get("OPENAI_API_KEY", "").strip())
+
+
+def _openclaw_session_model(model: str) -> str:
+    if not _should_bind_codex_openai_auth_profile(model):
+        return model
+    return f"openai-codex/{model.split('/', 1)[1]}"
+
+
+def _ensure_codex_openai_agent_auth_profile(model: str, agent_id: str) -> None:
+    if not _should_bind_codex_openai_auth_profile(model):
+        return
+    state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
+    agent_dir = state_dir / "agents" / agent_id / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    store_path = agent_dir / "auth-profiles.json"
+    try:
+        store = json.loads(store_path.read_text(encoding="utf-8")) if store_path.exists() else {}
+    except Exception:
+        store = {}
+    if not isinstance(store, dict):
+        store = {}
+    store["version"] = int(store.get("version") or 1)
+    profiles = store.setdefault("profiles", {})
+    if not isinstance(profiles, dict):
+        profiles = {}
+        store["profiles"] = profiles
+    credential = {
+        "type": "api_key",
+        "provider": "openai-codex",
+        "keyRef": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+    }
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if openai_key:
+        # OpenClaw 2026.4.x expects the concrete key in auth-profiles.json;
+        # newer runtimes can resolve keyRef. The file lives in ephemeral eval
+        # state, never in the repository.
+        credential["key"] = openai_key
+    profiles[CODEX_OPENAI_AUTH_PROFILE_ID] = credential
+    tmp_path = store_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(store, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(store_path)

--- a/clawbench/client.py
+++ b/clawbench/client.py
@@ -1,4 +1,4 @@
-"""Gateway client using WebSocket protocol v3."""
+"""Gateway client using OpenClaw's WebSocket protocol."""
 
 from __future__ import annotations
 
@@ -11,8 +11,10 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import websockets
@@ -20,11 +22,12 @@ from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import InvalidMessage, InvalidStatus
 
 from clawbench import __version__
-from clawbench.schemas import TokenUsage, ToolCall, Transcript, TranscriptMessage
+from clawbench.schemas import TokenUsage, ToolCall, ToolResult, Transcript, TranscriptMessage
 
 logger = logging.getLogger(__name__)
 
-PROTOCOL_VERSION = 3
+MIN_PROTOCOL_VERSION = 3
+MAX_PROTOCOL_VERSION = 4
 DEVICE_IDENTITY_HELPER_JS = r"""
 const crypto = require("crypto");
 const fs = require("fs");
@@ -232,6 +235,14 @@ class GatewayClient:
                     max_size=10 * 1024 * 1024,
                     open_timeout=attempt_timeout,
                     additional_headers={"Origin": host},
+                    # The benchmark uses loopback gateway sockets and can issue
+                    # long-lived RPCs (notably agent.wait while a provider call
+                    # is in flight). Python websockets' default keepalive can
+                    # close the connection before the gateway surfaces the
+                    # actual model/provider result, contaminating runs as infra
+                    # timeouts. The gateway already owns run-level timeouts.
+                    ping_interval=None,
+                    ping_timeout=None,
                 )
                 self._listen_task = asyncio.create_task(self._listener())
                 challenge = await self._wait_event(
@@ -259,8 +270,8 @@ class GatewayClient:
                     "mode": "ui",
                 }
                 connect_params: dict[str, Any] = {
-                    "minProtocol": PROTOCOL_VERSION,
-                    "maxProtocol": PROTOCOL_VERSION,
+                    "minProtocol": MIN_PROTOCOL_VERSION,
+                    "maxProtocol": MAX_PROTOCOL_VERSION,
                     "client": client_info,
                     "role": role,
                     "scopes": scopes,
@@ -316,6 +327,10 @@ class GatewayClient:
             await self._ws.close()
             self._ws = None
 
+    async def reconnect(self) -> None:
+        await self.close()
+        await self.connect()
+
     async def create_session(
         self,
         *,
@@ -336,6 +351,58 @@ class GatewayClient:
         if not key:
             raise RuntimeError(f"sessions.create returned no key: {payload}")
         return key
+
+    def set_session_auth_profile_override(
+        self,
+        session_key: str,
+        *,
+        agent_id: str,
+        auth_profile_id: str,
+        source: str = "user",
+    ) -> bool:
+        """Patch the local OpenClaw session store with an auth profile override.
+
+        OpenClaw 2026.4.x does not expose auth profile selection through the
+        gateway session-create/patch RPC schema, but the Codex harness only
+        forwards a non-model auth profile when it is session-bound. The eval
+        container owns the gateway state dir, so patching the just-created
+        session entry is the least invasive compatibility path.
+        """
+        if not session_key.strip() or not auth_profile_id.strip() or not agent_id.strip():
+            return False
+        state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
+        store_path = state_dir / "agents" / agent_id / "sessions" / "sessions.json"
+        if not store_path.exists():
+            logger.warning("session store not found at %s; cannot set auth profile override", store_path)
+            return False
+        try:
+            store = json.loads(store_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("failed to read session store %s: %s", store_path, exc)
+            return False
+        if not isinstance(store, dict):
+            return False
+        entry_key = session_key if session_key in store else next(
+            (key for key in store if isinstance(key, str) and key.lower() == session_key.lower()),
+            "",
+        )
+        if not entry_key or not isinstance(store.get(entry_key), dict):
+            logger.warning("session %s not found in %s; cannot set auth profile override", session_key, store_path)
+            return False
+        entry = store[entry_key]
+        if (
+            entry.get("authProfileOverride") == auth_profile_id
+            and entry.get("authProfileOverrideSource") == source
+        ):
+            return True
+        entry["authProfileOverride"] = auth_profile_id
+        entry["authProfileOverrideSource"] = source
+        entry.pop("authProfileOverrideCompactionCount", None)
+        entry["updatedAt"] = int(time.time() * 1000)
+        tmp_path = store_path.with_suffix(".json.tmp")
+        tmp_path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+        tmp_path.replace(store_path)
+        return True
 
     async def create_agent(
         self,
@@ -578,17 +645,14 @@ class GatewayClient:
         effective_timeout = timeout if timeout is not None else self.config.request_timeout
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
+        await self._ws.send(json.dumps(frame))
         try:
-            await self._ws.send(json.dumps(frame))
             response = await asyncio.wait_for(future, timeout=effective_timeout)
         except asyncio.TimeoutError:
             self._pending.pop(request_id, None)
             raise TimeoutError(
                 f"RPC {method} timed out after {effective_timeout:.1f}s"
             )
-        except Exception:
-            self._pending.pop(request_id, None)
-            raise
 
         if not response.get("ok", False):
             error = response.get("error", {})
@@ -757,6 +821,7 @@ def _parse_single_message(message_data: dict[str, Any]) -> TranscriptMessage | N
 
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
+    tool_results: list[ToolResult] = []
     tool_result_for: str | None = None
     tool_result_content = ""
     usage = _parse_usage_payload(message_data.get("usage", {}))
@@ -775,31 +840,97 @@ def _parse_single_message(message_data: dict[str, Any]) -> TranscriptMessage | N
             if block_type == "output_text":
                 text_parts.append(block.get("text", ""))
                 continue
-            if block_type in {"tool_use", "toolCall"}:
-                arguments = block.get("input", block.get("arguments", {}))
+            normalized_block_type = block_type.replace("-", "_").lower()
+            if normalized_block_type in {
+                "function_call",
+                "functioncall",
+                "tool_call",
+                "toolcall",
+                "tool_search_call",
+                "toolsearchcall",
+                "tool_use",
+                "tooluse",
+            }:
+                arguments = block.get(
+                    "input",
+                    block.get(
+                        "arguments",
+                        block.get("args", block.get("parameters", {})),
+                    ),
+                )
                 if isinstance(arguments, str):
                     try:
                         arguments = json.loads(arguments)
                     except json.JSONDecodeError:
                         arguments = {"raw": arguments}
+                raw_name = (
+                    block.get("name")
+                    or block.get("tool")
+                    or block.get("function")
+                    or block.get("title")
+                    or block_type
+                )
                 tool_calls.append(
                     ToolCall(
-                        id=block.get("id", ""),
-                        name=block.get("name", ""),
+                        id=(
+                            block.get("id")
+                            or block.get("call_id")
+                            or block.get("callId")
+                            or block.get("toolCallId")
+                            or block.get("tool_call_id")
+                            or ""
+                        ),
+                        name=raw_name if isinstance(raw_name, str) else block_type,
                         input=arguments if isinstance(arguments, dict) else {},
                     )
                 )
                 continue
-            if block_type in {"tool_result", "toolResult"}:
+            if normalized_block_type in {
+                "function_call_output",
+                "functioncalloutput",
+                "tool_call_output",
+                "toolcalloutput",
+                "tool_output",
+                "tool_result",
+                "tool_search_output",
+                "toolsearchoutput",
+                "toolresult",
+            }:
                 tool_result_for = (
                     block.get("tool_use_id")
+                    or block.get("toolUseId")
                     or block.get("toolCallId")
                     or block.get("tool_call_id")
+                    or block.get("call_id")
+                    or block.get("callId")
                     or block.get("id")
                 )
-                tool_result_content = _flatten_tool_content(block.get("content", ""))
+                tool_result_content = _flatten_tool_content(
+                    block.get("content", block.get("output", block.get("text", "")))
+                )
+                if tool_result_for:
+                    tool_results.append(
+                        ToolResult(id=str(tool_result_for), content=tool_result_content)
+                    )
                 if tool_result_content:
                     text_parts.append(tool_result_content)
+
+    if role.lower().replace("_", "") in {"tool", "toolresult"}:
+        tool_result_for = (
+            tool_result_for
+            or message_data.get("toolCallId")
+            or message_data.get("tool_call_id")
+            or message_data.get("toolUseId")
+            or message_data.get("tool_use_id")
+            or message_data.get("call_id")
+            or message_data.get("callId")
+        )
+        if not tool_result_content:
+            tool_result_content = "\n".join(part for part in text_parts if part)
+        if tool_result_for and not tool_results:
+            tool_results.append(
+                ToolResult(id=str(tool_result_for), content=tool_result_content)
+            )
 
     # Some providers surface assistant failures in a dedicated error field
     # with empty content blocks. Preserve that signal in transcript text.
@@ -818,6 +949,7 @@ def _parse_single_message(message_data: dict[str, Any]) -> TranscriptMessage | N
         role=role,
         text="\n".join(part for part in text_parts if part),
         tool_calls=tool_calls,
+        tool_results=tool_results,
         tool_result_for=tool_result_for,
         tool_result_content=tool_result_content,
         usage=usage,
@@ -942,13 +1074,27 @@ def _correlate_transcript(transcript: Transcript) -> Transcript:
         for tool_call in message.tool_calls:
             if tool_call.id:
                 by_id[tool_call.id] = tool_call
-        if message.tool_result_for and message.tool_result_for in by_id:
-            tool_call = by_id[message.tool_result_for]
-            if message.tool_result_content:
+        result_pairs = list(message.tool_results)
+        if message.tool_result_for and not any(
+            result.id == message.tool_result_for
+            and result.content == message.tool_result_content
+            for result in result_pairs
+        ):
+            result_pairs.append(
+                ToolResult(
+                    id=message.tool_result_for,
+                    content=message.tool_result_content,
+                )
+            )
+        for result in result_pairs:
+            if result.id not in by_id:
+                continue
+            tool_call = by_id[result.id]
+            if result.content:
                 if tool_call.output:
-                    tool_call.output = f"{tool_call.output}\n{message.tool_result_content}".strip()
+                    tool_call.output = f"{tool_call.output}\n{result.content}".strip()
                 else:
-                    tool_call.output = message.tool_result_content
+                    tool_call.output = result.content
             if tool_call.success is None:
                 tool_call.success = not _looks_like_error(tool_call.output)
             if tool_call.success is False and not tool_call.error:

--- a/clawbench/schemas.py
+++ b/clawbench/schemas.py
@@ -135,6 +135,13 @@ class ToolCall(BaseModel):
     error: str = ""
 
 
+class ToolResult(BaseModel):
+    """A single tool result extracted from the transcript."""
+
+    id: str
+    content: str = ""
+
+
 class TokenUsage(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
@@ -155,6 +162,16 @@ class TokenUsage(BaseModel):
             total_cost_usd=self.total_cost_usd + other.total_cost_usd,
         )
 
+    @property
+    def component_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.reasoning_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+        )
+
 
 class EfficiencyResult(BaseModel):
     duration_ms: int = 0
@@ -163,6 +180,7 @@ class EfficiencyResult(BaseModel):
     reasoning_tokens: int = 0
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    component_tokens: int = 0
     total_tokens: int = 0
     estimated_cost_usd: float = 0.0
 
@@ -175,15 +193,29 @@ class EfficiencyResult(BaseModel):
             reasoning_tokens=usage.reasoning_tokens,
             cache_read_tokens=usage.cache_read_tokens,
             cache_write_tokens=usage.cache_write_tokens,
+            component_tokens=usage.component_tokens,
             total_tokens=usage.total_tokens,
             estimated_cost_usd=usage.total_cost_usd,
         )
+
+    @model_validator(mode="after")
+    def _populate_component_tokens(self) -> EfficiencyResult:
+        if self.component_tokens == 0:
+            self.component_tokens = (
+                self.input_tokens
+                + self.output_tokens
+                + self.reasoning_tokens
+                + self.cache_read_tokens
+                + self.cache_write_tokens
+            )
+        return self
 
 
 class TranscriptMessage(BaseModel):
     role: str
     text: str = ""
     tool_calls: list[ToolCall] = Field(default_factory=list)
+    tool_results: list[ToolResult] = Field(default_factory=list)
     tool_result_for: str | None = None
     tool_result_content: str = ""
     timestamp_ms: int = 0

--- a/clawbench/worker.py
+++ b/clawbench/worker.py
@@ -35,12 +35,60 @@ STALE_EVALUATION_SECONDS = max(
     int(os.environ.get("CLAWBENCH_STALE_EVALUATION_SECONDS", "1800")),
 )
 OPENCLAW_EVAL_EXEC_HOSTS = {"auto", "gateway", "sandbox", "node"}
-OPENCLAW_EVAL_SYSTEM_PROMPT = (
-    "You are running an OpenClaw benchmark task. Complete the user's request in the current "
-    "workspace using the available tools when needed. For file, code, browser, shell, or memory "
-    "tasks, make the requested changes directly and verify them when practical. Do not ask "
-    "follow-up questions during the benchmark. Keep any final reply brief."
-)
+CODEX_OPENAI_AUTH_PROFILE_ID = "openai-codex:clawbench-env"
+
+
+def _serialize_browser_lanes_enabled() -> bool:
+    return os.environ.get("CLAWBENCH_SERIALIZE_BROWSER_LANES", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _openclaw_legacy_config_enabled() -> bool:
+    return os.environ.get("CLAWBENCH_OPENCLAW_LEGACY_CONFIG", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _disable_gateway_device_identity_enabled() -> bool:
+    return os.environ.get("CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _set_nested(data: dict, path: str, value: object) -> bool:
+    parts = path.split(".")
+    cursor = data
+    for part in parts[:-1]:
+        child = cursor.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            cursor[part] = child
+        cursor = child
+    if cursor.get(parts[-1]) == value:
+        return False
+    cursor[parts[-1]] = value
+    return True
+
+
+def _openclaw_agent_dir(state_dir: Path) -> Path:
+    return state_dir / "agents" / "main" / "agent"
+
+
+def _openclaw_seed_agent_dirs(state_dir: Path) -> list[Path]:
+    return [
+        state_dir / "agents" / "main" / "agent",
+        state_dir / "agents" / "dev" / "agent",
+    ]
 
 
 @dataclass
@@ -307,7 +355,6 @@ class EvalWorker:
             model=job.request.model,
             provider=job.request.provider,
             judge_model=job.request.judge_model or os.environ.get("CLAWBENCH_JUDGE_MODEL", ""),
-            judge_affects_score=job.request.judge_affects_score,
             runs_per_task=job.request.runs_per_task,
             tier=job.request.tier,
             task_ids=[task.id for task in tasks],
@@ -381,7 +428,6 @@ class EvalWorker:
                 model=job.request.model,
                 provider=job.request.provider,
                 judge_model=job.request.judge_model or os.environ.get("CLAWBENCH_JUDGE_MODEL", ""),
-                judge_affects_score=job.request.judge_affects_score,
                 runs_per_task=job.request.runs_per_task,
                 tier=job.request.tier,
                 scenario=job.request.scenario,
@@ -440,7 +486,6 @@ class EvalWorker:
             model=job.request.model,
             provider=job.request.provider,
             judge_model=job.request.judge_model or os.environ.get("CLAWBENCH_JUDGE_MODEL", ""),
-            judge_affects_score=job.request.judge_affects_score,
             runs_per_task=job.request.runs_per_task,
             task_ids=[task.id for task in lane.tasks],
             scenario=job.request.scenario,
@@ -479,7 +524,9 @@ class EvalWorker:
         effective_lanes = max(1, min(requested_parallel_lanes, len(tasks)))
         browser_tasks = [task for task in tasks if task.family.value == "browser"]
         other_tasks = [task for task in tasks if task.family.value != "browser"]
-        dedicate_browser_lane = bool(browser_tasks) and effective_lanes > 1
+        dedicate_browser_lane = (
+            _serialize_browser_lanes_enabled() and bool(browser_tasks) and effective_lanes > 1
+        )
 
         worker_lane_count = max(1, effective_lanes - (1 if dedicate_browser_lane else 0))
         lanes = [ParallelLane(index=index) for index in range(worker_lane_count)]
@@ -530,9 +577,34 @@ class EvalWorker:
         lane_home = lane.home_dir
         if lane_home is not None:
             (lane_home / ".config").mkdir(parents=True, exist_ok=True)
+            self._seed_lane_codex_home(lane_home)
         lane.log_path = lane_root / "gateway.log"
         lane.port = GATEWAY_PORT + (lane.index * GATEWAY_PORT_SPACING)
         self._seed_lane_state_dir(lane.state_dir)
+
+    def _seed_lane_codex_home(self, lane_home: Path) -> None:
+        configured_source = os.environ.get("CODEX_CONFIG_SOURCE", "").strip()
+        candidates = []
+        if configured_source:
+            candidates.append(Path(configured_source))
+        candidates.append(Path(os.environ.get("HOME", os.path.expanduser("~"))) / ".codex")
+
+        source = next((candidate for candidate in candidates if candidate.exists()), None)
+        if source is None or not source.is_dir():
+            return
+
+        target = lane_home / ".codex"
+        target.mkdir(parents=True, exist_ok=True)
+        for name in ("auth.json", "config.toml"):
+            src = source / name
+            if not src.is_file():
+                continue
+            dst = target / name
+            shutil.copy2(src, dst)
+            try:
+                dst.chmod(0o600)
+            except OSError:
+                pass
 
     def _run_lane_prepare_hook(self, lane: ParallelLane) -> None:
         hook = os.environ.get("CLAWBENCH_LANE_PREPARE_CMD", "").strip()
@@ -550,6 +622,8 @@ class EvalWorker:
             "OPENCLAW_HOME": str(lane_home),
             "OPENCLAW_STATE_DIR": str(lane.state_dir),
             "OPENCLAW_CONFIG_PATH": str(lane.state_dir / "openclaw.json"),
+            "OPENCLAW_AGENT_DIR": str(_openclaw_agent_dir(lane.state_dir)),
+            "PI_CODING_AGENT_DIR": str(_openclaw_agent_dir(lane.state_dir)),
             "XDG_CONFIG_HOME": str(lane_home / ".config"),
             "CLAWBENCH_LANE_INDEX": str(lane.index),
             "CLAWBENCH_LANE_PORT": str(lane.port),
@@ -641,18 +715,30 @@ class EvalWorker:
             return
 
         # 1. Disable chat channels so the gateway doesn't try to connect to
-        #    Telegram/Discord/Slack on startup (they thrash when 4 lanes share one token).
+        #    Telegram/Discord/Slack on startup (they thrash when lanes share one token).
+        #    WhatsApp config from older local state is rejected by newer OpenClaw schemas,
+        #    so drop it entirely from benchmark lane state.
         channels = data.get("channels")
         if isinstance(channels, dict):
+            channels.pop("whatsapp", None)
+            legacy_config = _openclaw_legacy_config_enabled()
             for channel_name in ("telegram", "discord", "slack"):
                 channel = channels.get(channel_name)
-                if isinstance(channel, dict) and channel.get("enabled") is not False:
+                if isinstance(channel, dict):
                     channel["enabled"] = False
+                    if legacy_config:
+                        channel["streaming"] = "off"
+                    else:
+                        streaming = channel.get("streaming")
+                        if isinstance(streaming, dict):
+                            streaming["mode"] = "off"
+                        else:
+                            channel["streaming"] = {"mode": "off"}
 
         # 2. Drop stale plugins that emit config warnings and slow gateway boot.
         plugins = data.get("plugins")
         if isinstance(plugins, dict):
-            stale_plugins = {"marxbiotech-git-tools"}
+            stale_plugins = {"marxbiotech-git-tools", "whatsapp"}
             allow = plugins.get("allow")
             if isinstance(allow, list):
                 plugins["allow"] = [p for p in allow if p not in stale_plugins]
@@ -679,10 +765,29 @@ class EvalWorker:
         _set_nested(data, "tools.exec.security", "full")
         _set_nested(data, "tools.exec.ask", "off")
         _set_nested(data, "approvals.exec.enabled", False)
+        if _disable_gateway_device_identity_enabled():
+            _set_nested(data, "gateway.controlUi.allowInsecureAuth", True)
+            _set_nested(data, "gateway.controlUi.dangerouslyDisableDeviceAuth", True)
+        agent_runtime = self._openclaw_agent_runtime()
+        if agent_runtime:
+            _set_nested(data, "agents.defaults.agentRuntime.id", agent_runtime)
+        else:
+            self._strip_agent_runtime_policy(data)
+            self._sanitize_non_codex_plugins(data)
         if self._active_model:
             _set_nested(data, "agents.defaults.model.primary", self._active_model)
             _set_nested(data, "agents.defaults.subagents.model.primary", self._active_model)
-            self._apply_eval_model_defaults(data, self._active_model)
+            self._ensure_openai_provider_config(data, self._active_model)
+            self._ensure_openai_codex_provider_config(data, self._active_model)
+            self._ensure_openrouter_provider_config(data, self._active_model)
+            if agent_runtime:
+                self._set_model_agent_runtime_policy(data, self._active_model, agent_runtime)
+                self._ensure_codex_openai_auth_profile(
+                    data,
+                    lane_state_dir,
+                    self._active_model,
+                    agent_runtime,
+                )
 
         tmp_path = cfg_path.with_suffix(".json.tmp")
         tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -759,38 +864,39 @@ class EvalWorker:
             "OPENCLAW_SKIP_CANVAS_HOST": "1",
             "OPENCLAW_NO_RESPAWN": "1",
         }
+        gateway_env.setdefault(
+            "OPENCLAW_AGENT_DIR",
+            str(_openclaw_agent_dir(Path(gateway_env["OPENCLAW_STATE_DIR"]))),
+        )
+        gateway_env.setdefault("PI_CODING_AGENT_DIR", gateway_env["OPENCLAW_AGENT_DIR"])
         self._configure_browser_runtime(gateway_cmd, gateway_env)
         try:
             Path("/tmp/gateway.log").write_text("", encoding="utf-8")
         except Exception:
             pass
 
-        log_handle = Path("/tmp/gateway.log").open("a", encoding="utf-8")
-        try:
-            self._gateway_process = subprocess.Popen(
-                [
-                    *gateway_cmd,
-                    "gateway",
-                    "run",
-                    "--allow-unconfigured",
-                    "--dev",
-                    "--bind",
-                    "loopback",
-                    "--port",
-                    str(GATEWAY_PORT),
-                    "--auth",
-                    "token",
-                    "--token",
-                    gateway_token,
-                    "--compact",
-                ],
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-                env=gateway_env,
-                start_new_session=True,  # own process group so we can reap chromium grandchildren on shutdown
-            )
-        finally:
-            log_handle.close()
+        self._gateway_process = subprocess.Popen(
+            [
+                *gateway_cmd,
+                "gateway",
+                "run",
+                "--allow-unconfigured",
+                "--dev",
+                "--bind",
+                "loopback",
+                "--port",
+                str(GATEWAY_PORT),
+                "--auth",
+                "token",
+                "--token",
+                gateway_token,
+                "--compact",
+            ],
+            stdout=open("/tmp/gateway.log", "a", encoding="utf-8"),
+            stderr=subprocess.STDOUT,
+            env=gateway_env,
+            start_new_session=True,  # own process group so we can reap chromium grandchildren on shutdown
+        )
 
         import httpx
 
@@ -826,6 +932,17 @@ class EvalWorker:
             log_reader=lambda: self._read_gateway_log(limit=20_000),
             description="Gateway",
         )
+        # The dev gateway normalizes OpenClaw state during startup and may
+        # rewrite exec approval defaults. Reassert the eval-local approval
+        # socket before any session/control-plane work can spawn tools.
+        self._write_eval_exec_approvals(Path(gateway_env["OPENCLAW_STATE_DIR"]))
+        if self._active_model and self._openclaw_agent_runtime():
+            self._ensure_codex_openai_auth_profile(
+                {},
+                Path(gateway_env["OPENCLAW_STATE_DIR"]),
+                self._active_model,
+                self._openclaw_agent_runtime(),
+            )
 
         # Phase B: control-plane probe with retries (see the parallel
         # variant in _ensure_parallel_gateway for the detailed rationale).
@@ -892,6 +1009,8 @@ class EvalWorker:
             "OPENCLAW_HOME": str(lane_home),
             "OPENCLAW_STATE_DIR": str(lane.state_dir),
             "OPENCLAW_CONFIG_PATH": str(lane.state_dir / "openclaw.json"),
+            "OPENCLAW_AGENT_DIR": str(_openclaw_agent_dir(lane.state_dir)),
+            "PI_CODING_AGENT_DIR": str(_openclaw_agent_dir(lane.state_dir)),
             "XDG_CONFIG_HOME": str(lane_home / ".config"),
             "OPENCLAW_SKIP_GMAIL_WATCHER": "1",
             "OPENCLAW_SKIP_CANVAS_HOST": "1",
@@ -965,6 +1084,14 @@ class EvalWorker:
             log_reader=lambda: self._read_parallel_gateway_log(lane, limit=20_000),
             description=f"Lane {lane.index + 1} gateway",
         )
+        self._write_eval_exec_approvals(lane.state_dir)
+        if self._active_model and self._openclaw_agent_runtime():
+            self._ensure_codex_openai_auth_profile(
+                {},
+                lane.state_dir,
+                self._active_model,
+                self._openclaw_agent_runtime(),
+            )
 
         # Phase B: control-plane probe with explicit retries. A healthy
         # /health response does not guarantee sessions.create works
@@ -1082,6 +1209,13 @@ class EvalWorker:
             ("tools.exec.ask", "off"),
             ("approvals.exec.enabled", False),
         ]
+        if _disable_gateway_device_identity_enabled():
+            config_pairs.extend(
+                [
+                    ("gateway.controlUi.allowInsecureAuth", True),
+                    ("gateway.controlUi.dangerouslyDisableDeviceAuth", True),
+                ]
+            )
         if self._active_model:
             config_pairs.extend(
                 [
@@ -1089,14 +1223,21 @@ class EvalWorker:
                     ("agents.defaults.subagents.model.primary", self._active_model),
                 ]
             )
+        agent_runtime = self._openclaw_agent_runtime()
+        if agent_runtime:
+            config_pairs.append(("agents.defaults.agentRuntime.id", agent_runtime))
         try:
+            self._patch_openclaw_config(
+                config_pairs,
+                strip_agent_runtime=not bool(agent_runtime),
+            )
+            if self._active_model and agent_runtime:
+                self._patch_openclaw_model_runtime(self._active_model, agent_runtime)
             state_dir = Path(
                 gateway_env.get("OPENCLAW_STATE_DIR")
                 or os.environ.get("OPENCLAW_STATE_DIR")
                 or os.path.expanduser("~/.openclaw")
             )
-            config_path = Path(gateway_env.get("OPENCLAW_CONFIG_PATH") or (state_dir / "openclaw.json"))
-            self._patch_openclaw_config(config_pairs, config_path=config_path)
             self._write_eval_exec_approvals(state_dir)
         except Exception as exc:
             logger.warning("Direct openclaw.json patch failed: %s", exc)
@@ -1108,6 +1249,90 @@ class EvalWorker:
             return value
         logger.warning("Invalid OPENCLAW_EXEC_HOST=%r; using gateway", value)
         return "gateway"
+
+    @staticmethod
+    def _openclaw_agent_runtime() -> str:
+        if _openclaw_legacy_config_enabled():
+            return ""
+        return (
+            os.environ.get("CLAWBENCH_OPENCLAW_AGENT_RUNTIME")
+            or os.environ.get("OPENCLAW_AGENT_RUNTIME")
+            or ""
+        ).strip()
+
+    @staticmethod
+    def _set_model_agent_runtime_policy(
+        data: dict,
+        model_ref: str,
+        agent_runtime: str,
+    ) -> None:
+        if _openclaw_legacy_config_enabled():
+            return
+        agents = data.setdefault("agents", {})
+        if not isinstance(agents, dict):
+            return
+        defaults = agents.setdefault("defaults", {})
+        if not isinstance(defaults, dict):
+            return
+        models = defaults.get("models")
+        if not isinstance(models, dict):
+            models = {}
+        for model_cfg in models.values():
+            if isinstance(model_cfg, dict):
+                model_cfg.pop("agentRuntime", None)
+
+        if agent_runtime == "codex":
+            plugins = data.setdefault("plugins", {})
+            if isinstance(plugins, dict):
+                allow = plugins.get("allow")
+                if isinstance(allow, list) and "codex" not in allow:
+                    allow.append("codex")
+
+    @staticmethod
+    def _patch_openclaw_model_runtime(model_ref: str, agent_runtime: str) -> None:
+        if _openclaw_legacy_config_enabled():
+            return
+        state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
+        config_path = state_dir / "openclaw.json"
+        if not config_path.exists():
+            return
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        EvalWorker._set_model_agent_runtime_policy(data, model_ref, agent_runtime)
+        tmp_path = config_path.with_suffix(".json.tmp")
+        tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp_path.replace(config_path)
+
+    @staticmethod
+    def _strip_agent_runtime_policy(data: dict) -> bool:
+        agents = data.get("agents")
+        if not isinstance(agents, dict):
+            return False
+        defaults = agents.get("defaults")
+        if not isinstance(defaults, dict):
+            return False
+        changed = defaults.pop("agentRuntime", None) is not None
+        models = defaults.get("models")
+        if isinstance(models, dict):
+            for model_cfg in models.values():
+                if isinstance(model_cfg, dict):
+                    changed = model_cfg.pop("agentRuntime", None) is not None or changed
+        return changed
+
+    @staticmethod
+    def _sanitize_non_codex_plugins(data: dict) -> bool:
+        plugins = data.get("plugins")
+        if not isinstance(plugins, dict):
+            return False
+        changed = False
+        allow = plugins.get("allow")
+        if isinstance(allow, list) and "codex" in allow:
+            plugins["allow"] = [item for item in allow if item != "codex"]
+            changed = True
+        entries = plugins.get("entries")
+        if isinstance(entries, dict) and "codex" in entries:
+            entries.pop("codex", None)
+            changed = True
+        return changed
 
     @staticmethod
     def _write_eval_exec_approvals(state_dir: Path) -> None:
@@ -1136,20 +1361,95 @@ class EvalWorker:
         tmp_path.write_text(json.dumps(approvals, indent=2), encoding="utf-8")
         tmp_path.replace(approvals_path)
 
+    @staticmethod
+    def _ensure_codex_openai_auth_profile(
+        data: dict,
+        state_dir: Path,
+        model_ref: str,
+        agent_runtime: str,
+    ) -> bool:
+        if agent_runtime != "codex" or not model_ref.startswith("openai/"):
+            return False
+        changed = False
+        auth = data.setdefault("auth", {})
+        if not isinstance(auth, dict):
+            return False
+        profiles = auth.setdefault("profiles", {})
+        if not isinstance(profiles, dict):
+            return False
+        desired_profile = {
+            "provider": "openai-codex",
+            "mode": "api_key",
+            "displayName": "ClawBench OPENAI_API_KEY",
+        }
+        if profiles.get(CODEX_OPENAI_AUTH_PROFILE_ID) != desired_profile:
+            profiles[CODEX_OPENAI_AUTH_PROFILE_ID] = desired_profile
+            changed = True
+        order = auth.setdefault("order", {})
+        if isinstance(order, dict):
+            current_order = order.get("openai-codex")
+            if not isinstance(current_order, list):
+                current_order = []
+            next_order = [
+                CODEX_OPENAI_AUTH_PROFILE_ID,
+                *[item for item in current_order if item != CODEX_OPENAI_AUTH_PROFILE_ID],
+            ]
+            if order.get("openai-codex") != next_order:
+                order["openai-codex"] = next_order
+                changed = True
+
+        desired_credential = {
+            "type": "api_key",
+            "provider": "openai-codex",
+            "keyRef": {
+                "source": "env",
+                "provider": "default",
+                "id": "OPENAI_API_KEY",
+            },
+        }
+        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            desired_credential["key"] = openai_key
+        for agent_dir in _openclaw_seed_agent_dirs(state_dir):
+            agent_dir.mkdir(parents=True, exist_ok=True)
+            store_path = agent_dir / "auth-profiles.json"
+            try:
+                store = json.loads(store_path.read_text(encoding="utf-8")) if store_path.exists() else {}
+            except Exception:
+                store = {}
+            if not isinstance(store, dict):
+                store = {}
+            store_profiles = store.setdefault("profiles", {})
+            if not isinstance(store_profiles, dict):
+                store_profiles = {}
+                store["profiles"] = store_profiles
+            store["version"] = int(store.get("version") or 1)
+            if store_profiles.get(CODEX_OPENAI_AUTH_PROFILE_ID) != desired_credential:
+                store_profiles[CODEX_OPENAI_AUTH_PROFILE_ID] = desired_credential
+                tmp_path = store_path.with_suffix(".json.tmp")
+                tmp_path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+                tmp_path.replace(store_path)
+        return changed
+
+    @staticmethod
     def _patch_openclaw_config(
-        self,
         pairs: list[tuple[str, object]],
         *,
-        config_path: Path | None = None,
+        strip_agent_runtime: bool = False,
     ) -> None:
-        if config_path is None:
-            state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
-            config_path = state_dir / "openclaw.json"
+        state_dir = Path(os.environ.get("OPENCLAW_STATE_DIR") or os.path.expanduser("~/.openclaw"))
+        config_path = state_dir / "openclaw.json"
         if not config_path.exists():
             logger.warning("openclaw.json not found at %s; skipping direct patch", config_path)
             return
         data = json.loads(config_path.read_text(encoding="utf-8"))
-        changed = False
+        changed = (
+            EvalWorker._strip_agent_runtime_policy(data)
+            if strip_agent_runtime or _openclaw_legacy_config_enabled()
+            else False
+        )
+        if strip_agent_runtime or _openclaw_legacy_config_enabled():
+            changed = EvalWorker._sanitize_non_codex_plugins(data) or changed
         for key, value in pairs:
             parts = key.split(".")
             cursor = data
@@ -1160,8 +1460,23 @@ class EvalWorker:
             if cursor.get(parts[-1]) != value:
                 cursor[parts[-1]] = value
                 changed = True
-        if self._active_model:
-            changed = self._apply_eval_model_defaults(data, self._active_model) or changed
+        model_ref = ""
+        defaults = data.get("agents", {}).get("defaults", {})
+        if isinstance(defaults, dict):
+            model_cfg = defaults.get("model")
+            if isinstance(model_cfg, dict):
+                model_ref = str(model_cfg.get("primary") or "")
+        changed = EvalWorker._ensure_openai_provider_config(data, model_ref) or changed
+        changed = EvalWorker._ensure_openai_codex_provider_config(data, model_ref) or changed
+        changed = EvalWorker._ensure_openrouter_provider_config(data, model_ref) or changed
+        agent_runtime = ""
+        defaults_agent_runtime = data.get("agents", {}).get("defaults", {}).get("agentRuntime", {})
+        if isinstance(defaults_agent_runtime, dict):
+            agent_runtime = str(defaults_agent_runtime.get("id") or "")
+        changed = (
+            EvalWorker._ensure_codex_openai_auth_profile(data, state_dir, model_ref, agent_runtime)
+            or changed
+        )
         if not changed:
             return
         tmp_path = config_path.with_suffix(".json.tmp")
@@ -1169,39 +1484,204 @@ class EvalWorker:
         tmp_path.replace(config_path)
 
     @staticmethod
-    def _apply_eval_model_defaults(data: dict, model: str) -> bool:
-        """Force eval model parameters that keep benchmark turns low-latency."""
-        agents = data.setdefault("agents", {})
-        if not isinstance(agents, dict):
-            data["agents"] = agents = {}
-        defaults = agents.setdefault("defaults", {})
-        if not isinstance(defaults, dict):
-            agents["defaults"] = defaults = {}
-        models = defaults.setdefault("models", {})
-        if not isinstance(models, dict):
-            defaults["models"] = models = {}
-        entry = models.setdefault(model, {})
-        if not isinstance(entry, dict):
-            entry = {}
-            models[model] = entry
-        params = entry.setdefault("params", {})
-        if not isinstance(params, dict):
-            params = {}
-            entry["params"] = params
+    def _ensure_openai_provider_config(data: dict, model_ref: str) -> bool:
+        if not model_ref.startswith("openai/") or len(model_ref.split("/", 1)) != 2:
+            return False
+        model_id = model_ref.split("/", 1)[1]
         changed = False
-        if defaults.get("systemPromptOverride") != OPENCLAW_EVAL_SYSTEM_PROMPT:
-            defaults["systemPromptOverride"] = OPENCLAW_EVAL_SYSTEM_PROMPT
+        models_cfg = data.setdefault("models", {})
+        if not isinstance(models_cfg, dict):
+            return False
+        providers = models_cfg.setdefault("providers", {})
+        if not isinstance(providers, dict):
+            return False
+        provider_cfg = providers.get("openai")
+        if not isinstance(provider_cfg, dict):
+            provider_cfg = {}
+            providers["openai"] = provider_cfg
             changed = True
-        if params.get("fastMode") is not True:
-            params["fastMode"] = True
+        desired = {
+            "baseUrl": "https://api.openai.com/v1",
+            "api": "openai-responses",
+            "apiKey": "OPENAI_API_KEY",
+            "auth": "api-key",
+        }
+        for key, value in desired.items():
+            if provider_cfg.get(key) != value:
+                provider_cfg[key] = value
+                changed = True
+        model_entries = provider_cfg.get("models")
+        if not isinstance(model_entries, list):
+            model_entries = []
+            provider_cfg["models"] = model_entries
             changed = True
-        if model.startswith("openai/"):
-            if params.get("transport") != "sse":
-                params["transport"] = "sse"
+        desired_model = {
+            "id": model_id,
+            "name": model_id,
+            "api": "openai-responses",
+            "reasoning": True,
+            "input": ["text", "image"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 1050000,
+            "maxTokens": 128000,
+        }
+        for item in model_entries:
+            if isinstance(item, dict) and item.get("id") == model_id:
+                for key, value in desired_model.items():
+                    if item.get(key) != value:
+                        item[key] = value
+                        changed = True
+                break
+        else:
+            model_entries.append(desired_model)
+            changed = True
+        return changed
+
+    @staticmethod
+    def _ensure_openai_codex_provider_config(data: dict, model_ref: str) -> bool:
+        if model_ref.startswith("openai/"):
+            model_id = model_ref.split("/", 1)[1]
+        elif model_ref.startswith("openai-codex/"):
+            model_id = model_ref.split("/", 1)[1]
+        else:
+            return False
+        changed = False
+        models_cfg = data.setdefault("models", {})
+        if not isinstance(models_cfg, dict):
+            return False
+        providers = models_cfg.setdefault("providers", {})
+        if not isinstance(providers, dict):
+            return False
+        provider_cfg = providers.get("openai-codex")
+        if not isinstance(provider_cfg, dict):
+            provider_cfg = {}
+            providers["openai-codex"] = provider_cfg
+            changed = True
+        desired = {
+            "baseUrl": "https://api.openai.com/v1",
+            "api": "openai-responses",
+            "apiKey": "OPENAI_API_KEY",
+            "auth": "api-key",
+        }
+        for key, value in desired.items():
+            if provider_cfg.get(key) != value:
+                provider_cfg[key] = value
                 changed = True
-            if params.get("openaiWsWarmup") is not False:
-                params["openaiWsWarmup"] = False
+        model_entries = provider_cfg.get("models")
+        if not isinstance(model_entries, list):
+            model_entries = []
+            provider_cfg["models"] = model_entries
+            changed = True
+        desired_model = {
+            "id": model_id,
+            "name": model_id,
+            "api": "openai-responses",
+            "reasoning": True,
+            "input": ["text", "image"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 1050000,
+            "maxTokens": 128000,
+        }
+        for item in model_entries:
+            if isinstance(item, dict) and item.get("id") == model_id:
+                for key, value in desired_model.items():
+                    if item.get(key) != value:
+                        item[key] = value
+                        changed = True
+                break
+        else:
+            model_entries.append(desired_model)
+            changed = True
+        return changed
+
+    @staticmethod
+    def _ensure_openrouter_provider_config(data: dict, model_ref: str) -> bool:
+        if not model_ref.startswith("openrouter/") or len(model_ref.split("/", 1)) != 2:
+            return False
+        model_id = model_ref.split("/", 1)[1]
+        openrouter_timeout_seconds = int(
+            os.environ.get("CLAWBENCH_OPENROUTER_TIMEOUT_SECONDS") or "900"
+        )
+        changed = _set_nested(
+            data,
+            "agents.defaults.thinkingDefault",
+            os.environ.get("CLAWBENCH_OPENROUTER_THINKING_DEFAULT", "low").strip() or "low",
+        )
+        changed = _set_nested(
+            data,
+            "agents.defaults.timeoutSeconds",
+            int(os.environ.get("CLAWBENCH_OPENROUTER_AGENT_TIMEOUT_SECONDS") or "1200"),
+        ) or changed
+        agents_cfg = data.setdefault("agents", {})
+        if isinstance(agents_cfg, dict):
+            defaults_cfg = agents_cfg.setdefault("defaults", {})
+            if isinstance(defaults_cfg, dict):
+                model_defaults = defaults_cfg.setdefault("models", {})
+                if isinstance(model_defaults, dict):
+                    model_cfg = model_defaults.setdefault(model_ref, {})
+                    if not isinstance(model_cfg, dict):
+                        model_cfg = {}
+                        model_defaults[model_ref] = model_cfg
+                        changed = True
+                    params_cfg = model_cfg.setdefault("params", {})
+                    if not isinstance(params_cfg, dict):
+                        params_cfg = {}
+                        model_cfg["params"] = params_cfg
+                        changed = True
+                    extra_body = params_cfg.setdefault("extra_body", {})
+                    if not isinstance(extra_body, dict):
+                        extra_body = {}
+                        params_cfg["extra_body"] = extra_body
+                        changed = True
+                    desired_extra_body = {
+                        "include_reasoning": False,
+                        "reasoning": {"exclude": True},
+                    }
+                    for key, value in desired_extra_body.items():
+                        if extra_body.get(key) != value:
+                            extra_body[key] = value
+                            changed = True
+        models_cfg = data.setdefault("models", {})
+        if not isinstance(models_cfg, dict):
+            return False
+        providers = models_cfg.setdefault("providers", {})
+        if not isinstance(providers, dict):
+            return False
+        provider_cfg = providers.get("openrouter")
+        if not isinstance(provider_cfg, dict):
+            provider_cfg = {}
+            providers["openrouter"] = provider_cfg
+        desired = {
+            "baseUrl": "https://openrouter.ai/api/v1",
+            "api": "openai-completions",
+            "apiKey": "OPENROUTER_API_KEY",
+            "timeoutSeconds": openrouter_timeout_seconds,
+        }
+        for key, value in desired.items():
+            if provider_cfg.get(key) != value:
+                provider_cfg[key] = value
                 changed = True
+        model_entries = provider_cfg.get("models")
+        if not isinstance(model_entries, list):
+            model_entries = []
+            provider_cfg["models"] = model_entries
+            changed = True
+        desired_model = {
+            "id": model_id,
+            "name": model_id,
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+        }
+        for item in model_entries:
+            if isinstance(item, dict) and item.get("id") == model_id:
+                for key, value in desired_model.items():
+                    if item.get(key) != value:
+                        item[key] = value
+                        changed = True
+                break
+        else:
+            model_entries.append(desired_model)
+            changed = True
         return changed
 
     def _find_gateway_cmd(self) -> list[str] | None:

--- a/scripts/container_adapter_eval.sh
+++ b/scripts/container_adapter_eval.sh
@@ -1,0 +1,802 @@
+#!/bin/bash
+# Fair adapter lane runner.
+#
+# Runs one adapter/model pair inside a container-owned workspace/state dir.
+# Use docker run with full container privileges when measuring harnesses:
+#   docker run --rm --privileged --cap-add=ALL \
+#     --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
+#     --user root --env-file .tmp/docker_eval.env \
+#     -e SWEEP_ADAPTER=hermes -e SWEEP_MODEL=openai/gpt-5.4 \
+#     -e SWEEP_LABEL=hermes-gpt54 -e SWEEP_OUT_TAG=fair-20260425 \
+#     -v "$PWD/data/fair-container:/data" \
+#     -v "$PWD/data/container-home-openclaw:/config/openclaw:ro" \
+#     clawbench-fair:latest
+
+set -u
+
+: "${SWEEP_ADAPTER:?SWEEP_ADAPTER required (openclaw|hermes)}"
+: "${SWEEP_MODEL:?SWEEP_MODEL required (e.g. openai/gpt-5.4)}"
+: "${SWEEP_LABEL:?SWEEP_LABEL required}"
+: "${SWEEP_OUT_TAG:=fair-container}"
+: "${SWEEP_LOGDIR:=/data/fair_results}"
+: "${SWEEP_RUNS:=1}"
+: "${SWEEP_CONCURRENCY:=1}"
+: "${SWEEP_BROWSER_CONCURRENCY:=1}"
+: "${CLAWBENCH_PER_RUN_BUDGET_SECONDS:=300}"
+: "${CLAWBENCH_PER_TURN_TIMEOUT_SECONDS:=180}"
+: "${HERMES_MAX_ITERATIONS:=90}"
+: "${HERMES_STEP_TIMEOUT_SECONDS:=60}"
+: "${OPENCLAW_EXEC_HOST:=gateway}"
+: "${CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING:=searchable}"
+
+cd /home/node/app
+mkdir -p "$SWEEP_LOGDIR" /data/run_cache
+
+export OPENCLAW_GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-dev-token-for-testing}"
+export OPENCLAW_GATEWAY_URL="${OPENCLAW_GATEWAY_URL:-ws://127.0.0.1:18789}"
+export OPENCLAW_SKIP_GMAIL_WATCHER=1
+export OPENCLAW_SKIP_CANVAS_HOST=1
+export OPENCLAW_NO_RESPAWN=1
+export CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY="${CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY:-0}"
+export NODE_OPTIONS="${NODE_OPTIONS:-"--max-old-space-size=4096"}"
+if command -v npm >/dev/null 2>&1; then
+  export NODE_PATH="${NODE_PATH:-$(npm root -g 2>/dev/null || true)}"
+fi
+export CLAWBENCH_PER_RUN_BUDGET_SECONDS
+export CLAWBENCH_PER_TURN_TIMEOUT_SECONDS
+export HERMES_AGENT_REPO="${HERMES_AGENT_REPO:-/opt/hermes-agent}"
+export HERMES_DRIVER="${HERMES_DRIVER:-ai_agent}"
+export HERMES_TOOLSETS="${HERMES_TOOLSETS:-hermes-api-server}"
+export HERMES_MAX_ITERATIONS
+export HERMES_STEP_TIMEOUT_SECONDS
+export TERMINAL_ENV="${TERMINAL_ENV:-local}"
+
+write_eval_exec_approvals() {
+  python - "$FRESH_STATE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_dir = Path(sys.argv[1])
+state_dir.mkdir(parents=True, exist_ok=True)
+approvals_path = state_dir / "exec-approvals.json"
+approvals = {
+    "version": 1,
+    "socket": {
+        "path": str(approvals_path.with_suffix(".sock")),
+        "token": "container-eval-token",
+    },
+    "defaults": {
+        "security": "full",
+        "ask": "off",
+        "askFallback": "full",
+    },
+    "agents": {
+        "*": {
+            "security": "full",
+            "ask": "off",
+            "askFallback": "full",
+        }
+    },
+}
+tmp_path = approvals_path.with_suffix(".json.tmp")
+tmp_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
+tmp_path.replace(approvals_path)
+PY
+}
+
+safe_model="${SWEEP_MODEL//\//_}"
+safe_model="${safe_model//:/_}"
+safe_label="${SWEEP_LABEL//\//_}"
+safe_label="${safe_label//:/_}"
+export CLAWBENCH_RUN_CACHE_DIR="/data/run_cache/$safe_label"
+mkdir -p "$CLAWBENCH_RUN_CACHE_DIR"
+cache_sub="${SWEEP_ADAPTER}-${safe_model}"
+cache_paths=("$CLAWBENCH_RUN_CACHE_DIR/$cache_sub")
+if [ "$SWEEP_ADAPTER" = "openclaw" ]; then
+  cache_paths+=("$CLAWBENCH_RUN_CACHE_DIR/$safe_model")
+fi
+
+SRC_STATE="${OPENCLAW_CONFIG_SOURCE:-/config/openclaw}"
+if [ ! -d "$SRC_STATE" ]; then
+  SRC_STATE="/home/node/.openclaw"
+fi
+FRESH_HOME="/tmp/openclaw-home-${SWEEP_LABEL}-$$"
+FRESH_STATE="$FRESH_HOME/.openclaw"
+rm -rf "$FRESH_HOME"
+mkdir -p "$FRESH_STATE" "$FRESH_HOME/.config"
+if [ -f "$SRC_STATE/openclaw.json" ]; then
+  cp "$SRC_STATE/openclaw.json" "$FRESH_STATE/openclaw.json"
+fi
+CODEX_STATE_SOURCE="${CODEX_CONFIG_SOURCE:-/config/codex}"
+if [ -d "$CODEX_STATE_SOURCE" ]; then
+  mkdir -p "$FRESH_HOME/.codex"
+  for codex_file in auth.json config.toml; do
+    if [ -f "$CODEX_STATE_SOURCE/$codex_file" ]; then
+      cp "$CODEX_STATE_SOURCE/$codex_file" "$FRESH_HOME/.codex/$codex_file"
+      chmod 600 "$FRESH_HOME/.codex/$codex_file" 2>/dev/null || true
+    fi
+  done
+fi
+mkdir -p \
+  "$FRESH_STATE/agents" \
+  "$FRESH_STATE/workspace" \
+  "$FRESH_STATE/logs" \
+  "$FRESH_STATE/memory" \
+  "$FRESH_STATE/cache" \
+  "$FRESH_STATE/identity" \
+  "$FRESH_STATE/devices" \
+  "$FRESH_STATE/tasks" \
+  "$FRESH_STATE/subagents" \
+  "$FRESH_STATE/flows" \
+  "$FRESH_STATE/cron"
+chmod -R 777 "$FRESH_STATE" 2>/dev/null || true
+export HOME="$FRESH_HOME"
+export OPENCLAW_HOME="$FRESH_HOME"
+export OPENCLAW_STATE_DIR="$FRESH_STATE"
+export OPENCLAW_CONFIG_PATH="$FRESH_STATE/openclaw.json"
+export OPENCLAW_AGENT_DIR="$FRESH_STATE/agents/main/agent"
+export PI_CODING_AGENT_DIR="$OPENCLAW_AGENT_DIR"
+export OPENCLAW_REPO="${OPENCLAW_REPO:-/app}"
+export XDG_CONFIG_HOME="$FRESH_HOME/.config"
+export HERMES_HOME_BASE="${HERMES_HOME_BASE:-$FRESH_HOME/.hermes}"
+export HERMES_HOME="$HERMES_HOME_BASE"
+mkdir -p "$HERMES_HOME"
+SWEEP_AGENT_RUNTIME="${SWEEP_AGENT_RUNTIME:-${CLAWBENCH_OPENCLAW_AGENT_RUNTIME:-${OPENCLAW_AGENT_RUNTIME:-}}}"
+if [ -n "$SWEEP_AGENT_RUNTIME" ]; then
+  export OPENCLAW_AGENT_RUNTIME="$SWEEP_AGENT_RUNTIME"
+  export CLAWBENCH_OPENCLAW_AGENT_RUNTIME="$SWEEP_AGENT_RUNTIME"
+fi
+case "$SWEEP_MODEL:${SWEEP_AGENT_RUNTIME:-}" in
+  *:codex|codex/*)
+    export OPENCLAW_CODEX_APP_SERVER_MODE="${OPENCLAW_CODEX_APP_SERVER_MODE:-yolo}"
+    export OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY="${OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY:-never}"
+    export OPENCLAW_CODEX_APP_SERVER_SANDBOX="${OPENCLAW_CODEX_APP_SERVER_SANDBOX:-danger-full-access}"
+    ;;
+esac
+case "$SWEEP_MODEL" in
+  codex/*)
+    export OPENCLAW_CODEX_APP_SERVER_MODE="${OPENCLAW_CODEX_APP_SERVER_MODE:-yolo}"
+    export OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY="${OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY:-never}"
+    export OPENCLAW_CODEX_APP_SERVER_SANDBOX="${OPENCLAW_CODEX_APP_SERVER_SANDBOX:-danger-full-access}"
+    ;;
+esac
+
+if [ "$SWEEP_ADAPTER" = "hermes" ]; then
+  unset HERMES_PROVIDER
+  case "$SWEEP_MODEL" in
+    openai/*)
+      if [ -z "${OPENAI_API_KEY:-}" ] && [ -n "${HERMES_API_KEY:-}" ]; then
+        export OPENAI_API_KEY="$HERMES_API_KEY"
+      fi
+      export HERMES_BASE_URL="${HERMES_BASE_URL:-${OPENAI_BASE_URL:-https://api.openai.com/v1}}"
+      export OPENAI_BASE_URL="$HERMES_BASE_URL"
+      if [ -n "${OPENAI_API_KEY:-}" ]; then
+        export HERMES_API_KEY="$OPENAI_API_KEY"
+      fi
+      unset ANTHROPIC_API_KEY ANTHROPIC_TOKEN CLAUDE_CODE_OAUTH_TOKEN OPENROUTER_API_KEY
+      ;;
+    anthropic/*)
+      unset OPENAI_API_KEY OPENAI_BASE_URL HERMES_API_KEY HERMES_BASE_URL OPENROUTER_API_KEY
+      ;;
+    *)
+      if [ -n "${HERMES_BASE_URL:-}" ]; then
+        export OPENAI_BASE_URL="$HERMES_BASE_URL"
+      elif [ -z "${OPENAI_BASE_URL:-}" ] && [ -n "${OPENAI_API_KEY:-}" ]; then
+        export OPENAI_BASE_URL="https://api.openai.com/v1"
+      fi
+      if [ -n "${HERMES_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+        export OPENAI_API_KEY="$HERMES_API_KEY"
+      fi
+      ;;
+  esac
+fi
+
+provider_auth_missing() {
+  local provider="$1"
+  local env_hint="$2"
+  cat >&2 <<EOF
+Missing provider auth for SWEEP_MODEL=$SWEEP_MODEL ($provider).
+Set $env_hint in the container environment. For Docker runs, pass the
+provider variable explicitly, e.g. "docker run -e $env_hint ..."; with
+Testbox, run through "clawbench-testbox-env docker run -e $env_hint ...".
+Set CLAWBENCH_ALLOW_MISSING_PROVIDER_AUTH=1 only for control-plane smoke tests.
+EOF
+  exit 78
+}
+
+if [ "${CLAWBENCH_ALLOW_MISSING_PROVIDER_AUTH:-}" != "1" ]; then
+  case "$SWEEP_MODEL" in
+    openai/*)
+      [ -n "${OPENAI_API_KEY:-}" ] || provider_auth_missing "openai" "OPENAI_API_KEY"
+      ;;
+    openrouter/*)
+      [ -n "${OPENROUTER_API_KEY:-}" ] || provider_auth_missing "openrouter" "OPENROUTER_API_KEY"
+      ;;
+    anthropic/*|claude/*)
+      [ -n "${ANTHROPIC_API_KEY:-${ANTHROPIC_API_TOKEN:-}}" ] || provider_auth_missing "anthropic" "ANTHROPIC_API_KEY"
+      ;;
+  esac
+fi
+
+python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+cfg_path = Path(os.environ["OPENCLAW_CONFIG_PATH"])
+if not cfg_path.exists():
+    raise SystemExit(0)
+
+data = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+agents = data.get("agents")
+if isinstance(agents, dict):
+    # Keep static defaults, but never seed eval containers with old session-specific
+    # agent records from the developer machine.
+    agents["list"] = []
+
+channels = data.get("channels")
+if isinstance(channels, dict):
+    channels.pop("whatsapp", None)
+    for channel in channels.values():
+        if isinstance(channel, dict):
+            channel["enabled"] = False
+            exec_approvals = channel.get("execApprovals")
+            if not isinstance(exec_approvals, dict):
+                exec_approvals = {}
+                channel["execApprovals"] = exec_approvals
+            exec_approvals["enabled"] = False
+
+plugins = data.get("plugins")
+if isinstance(plugins, dict):
+    stale = {"marxbiotech-git-tools", "lab", "whatsapp"}
+    allow = plugins.get("allow")
+    if isinstance(allow, list):
+        plugins["allow"] = [item for item in allow if item not in stale]
+    entries = plugins.get("entries")
+    if isinstance(entries, dict):
+        for item in stale:
+            entries.pop(item, None)
+
+
+def set_nested(root, dotted, value):
+    cursor = root
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        child = cursor.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            cursor[part] = child
+        cursor = child
+    cursor[parts[-1]] = value
+
+
+def set_model_agent_runtime_policy(root, model_ref, agent_runtime):
+    agents = root.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        return
+    defaults = agents.setdefault("defaults", {})
+    if not isinstance(defaults, dict):
+        return
+    models = defaults.get("models")
+    if not isinstance(models, dict):
+        models = {}
+    for model_cfg in models.values():
+        if isinstance(model_cfg, dict):
+            model_cfg.pop("agentRuntime", None)
+
+    if agent_runtime == "codex":
+        plugins_cfg = root.setdefault("plugins", {})
+        if isinstance(plugins_cfg, dict):
+            allow = plugins_cfg.get("allow")
+            if isinstance(allow, list) and "codex" not in allow:
+                allow.append("codex")
+
+
+def strip_agent_runtime_policy(root):
+    agents = root.get("agents")
+    if not isinstance(agents, dict):
+        return
+    defaults = agents.get("defaults")
+    if not isinstance(defaults, dict):
+        return
+    defaults.pop("agentRuntime", None)
+    models = defaults.get("models")
+    if isinstance(models, dict):
+        for model_cfg in models.values():
+            if isinstance(model_cfg, dict):
+                model_cfg.pop("agentRuntime", None)
+
+
+def ensure_openai_provider_config(root, model_ref):
+    if not model_ref.startswith("openai/") or len(model_ref.split("/", 1)) != 2:
+        return
+    model_id = model_ref.split("/", 1)[1]
+    models_cfg = root.setdefault("models", {})
+    if not isinstance(models_cfg, dict):
+        return
+    providers = models_cfg.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        return
+    provider_cfg = providers.get("openai")
+    if not isinstance(provider_cfg, dict):
+        provider_cfg = {}
+        providers["openai"] = provider_cfg
+    provider_cfg["baseUrl"] = "https://api.openai.com/v1"
+    provider_cfg["api"] = "openai-responses"
+    provider_cfg["apiKey"] = "OPENAI_API_KEY"
+    provider_cfg["auth"] = "api-key"
+    model_entries = provider_cfg.get("models")
+    if not isinstance(model_entries, list):
+        model_entries = []
+        provider_cfg["models"] = model_entries
+    desired_model = {
+        "id": model_id,
+        "name": model_id,
+        "api": "openai-responses",
+        "reasoning": True,
+        "input": ["text", "image"],
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        "contextWindow": 1050000,
+        "maxTokens": 128000,
+    }
+    for item in model_entries:
+        if isinstance(item, dict) and item.get("id") == model_id:
+            item.update(desired_model)
+            break
+    else:
+        model_entries.append(desired_model)
+
+
+def ensure_openai_codex_provider_config(root, model_ref):
+    if model_ref.startswith("openai/") and len(model_ref.split("/", 1)) == 2:
+        model_id = model_ref.split("/", 1)[1]
+    elif model_ref.startswith("openai-codex/") and len(model_ref.split("/", 1)) == 2:
+        model_id = model_ref.split("/", 1)[1]
+    else:
+        return
+    models_cfg = root.setdefault("models", {})
+    if not isinstance(models_cfg, dict):
+        return
+    providers = models_cfg.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        return
+    provider_cfg = providers.get("openai-codex")
+    if not isinstance(provider_cfg, dict):
+        provider_cfg = {}
+        providers["openai-codex"] = provider_cfg
+    provider_cfg["baseUrl"] = "https://api.openai.com/v1"
+    provider_cfg["api"] = "openai-responses"
+    provider_cfg["apiKey"] = "OPENAI_API_KEY"
+    provider_cfg["auth"] = "api-key"
+    model_entries = provider_cfg.get("models")
+    if not isinstance(model_entries, list):
+        model_entries = []
+        provider_cfg["models"] = model_entries
+    desired_model = {
+        "id": model_id,
+        "name": model_id,
+        "api": "openai-responses",
+        "reasoning": True,
+        "input": ["text", "image"],
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        "contextWindow": 1050000,
+        "maxTokens": 128000,
+    }
+    for item in model_entries:
+        if isinstance(item, dict) and item.get("id") == model_id:
+            item.update(desired_model)
+            break
+    else:
+        model_entries.append(desired_model)
+
+
+def ensure_codex_openai_auth_profile(root, state_dir, model_ref, agent_runtime):
+    if agent_runtime != "codex" or not model_ref.startswith("openai/"):
+        return
+    profile_id = "openai-codex:clawbench-env"
+    auth = root.setdefault("auth", {})
+    if isinstance(auth, dict):
+        profiles = auth.setdefault("profiles", {})
+        if isinstance(profiles, dict):
+            profiles[profile_id] = {
+                "provider": "openai-codex",
+                "mode": "api_key",
+                "displayName": "ClawBench OPENAI_API_KEY",
+            }
+        order = auth.setdefault("order", {})
+        if isinstance(order, dict):
+            current = order.get("openai-codex")
+            if not isinstance(current, list):
+                current = []
+            order["openai-codex"] = [profile_id, *[item for item in current if item != profile_id]]
+
+    for agent_name in ("main", "dev"):
+        agent_dir = Path(state_dir) / "agents" / agent_name / "agent"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        store_path = agent_dir / "auth-profiles.json"
+        try:
+            store = json.loads(store_path.read_text(encoding="utf-8")) if store_path.exists() else {}
+        except Exception:
+            store = {}
+        if not isinstance(store, dict):
+            store = {}
+        store["version"] = int(store.get("version") or 1)
+        store_profiles = store.setdefault("profiles", {})
+        if not isinstance(store_profiles, dict):
+            store_profiles = {}
+            store["profiles"] = store_profiles
+        credential = {
+            "type": "api_key",
+            "provider": "openai-codex",
+            "keyRef": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+        }
+        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            credential["key"] = openai_key
+        store_profiles[profile_id] = credential
+        store_path.write_text(json.dumps(store, indent=2) + "\n", encoding="utf-8")
+
+
+def ensure_codex_plugin_allowed(root, loading):
+    if loading not in {"searchable", "direct"}:
+        raise SystemExit(f"invalid CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING={loading!r}")
+    plugins_cfg = root.setdefault("plugins", {})
+    if not isinstance(plugins_cfg, dict):
+        return
+    allow = plugins_cfg.setdefault("allow", [])
+    if isinstance(allow, list) and "codex" not in allow:
+        allow.append("codex")
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        codex = entries.get("codex")
+        if isinstance(codex, dict):
+            codex.pop("config", None)
+
+
+def parse_optional_bool_env(name):
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return None
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"invalid {name}={raw!r}; expected true or false")
+
+
+set_nested(data, "browser.headless", True)
+set_nested(data, "browser.noSandbox", True)
+set_nested(data, "gateway.reload.mode", "off")
+set_nested(data, "agents.defaults.skipBootstrap", True)
+set_nested(data, "agents.defaults.sandbox.mode", "off")
+exec_host = os.environ.get("OPENCLAW_EXEC_HOST", "gateway").strip().lower()
+if exec_host not in {"auto", "gateway", "sandbox", "node"}:
+    raise SystemExit(f"invalid OPENCLAW_EXEC_HOST={exec_host!r}")
+set_nested(data, "tools.exec.host", exec_host)
+set_nested(data, "tools.exec.security", "full")
+set_nested(data, "tools.exec.ask", "off")
+set_nested(data, "approvals.exec.enabled", False)
+if parse_optional_bool_env("CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY") is True:
+    set_nested(data, "gateway.controlUi.allowInsecureAuth", True)
+    set_nested(data, "gateway.controlUi.dangerouslyDisableDeviceAuth", True)
+model = os.environ.get("SWEEP_MODEL", "").strip()
+if model:
+    set_nested(data, "agents.defaults.model.primary", model)
+    set_nested(data, "agents.defaults.subagents.model.primary", model)
+    ensure_openai_provider_config(data, model)
+    ensure_openai_codex_provider_config(data, model)
+agent_runtime = os.environ.get("SWEEP_AGENT_RUNTIME", "").strip()
+legacy_config = os.environ.get("CLAWBENCH_OPENCLAW_LEGACY_CONFIG", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+if agent_runtime and not legacy_config:
+    set_nested(data, "agents.defaults.agentRuntime.id", agent_runtime)
+    if model:
+        set_model_agent_runtime_policy(data, model, agent_runtime)
+        ensure_codex_openai_auth_profile(data, os.environ["OPENCLAW_STATE_DIR"], model, agent_runtime)
+elif legacy_config:
+    strip_agent_runtime_policy(data)
+if agent_runtime == "codex" or model.startswith("codex/"):
+    ensure_codex_plugin_allowed(
+        data,
+        os.environ.get("CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING", "searchable").strip(),
+    )
+tool_search_enabled = parse_optional_bool_env("CLAWBENCH_OPENCLAW_TOOL_SEARCH")
+if tool_search_enabled is not None:
+    set_nested(data, "tools.toolSearch", tool_search_enabled)
+
+tmp_path = cfg_path.with_suffix(".json.tmp")
+tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+tmp_path.replace(cfg_path)
+PY
+write_eval_exec_approvals || exit 1
+
+if [ "$SWEEP_ADAPTER" = "hermes" ]; then
+python - <<'PY'
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+model = os.environ["SWEEP_MODEL"].strip()
+base_url = (os.environ.get("HERMES_BASE_URL") or os.environ.get("OPENAI_BASE_URL") or "").strip()
+
+provider = "custom"
+effective_model = model
+aux_base_url = ""
+aux_api_mode = ""
+if model.startswith("anthropic/"):
+    provider = "anthropic"
+elif urlparse(base_url).hostname == "api.openai.com" and model.startswith("openai/"):
+    effective_model = model.split("/", 1)[1]
+    aux_base_url = base_url
+    if effective_model.lower().startswith("gpt-5"):
+        aux_api_mode = "codex_responses"
+elif base_url:
+    aux_base_url = base_url
+
+tasks = [
+    "vision",
+    "web_extract",
+    "compression",
+    "session_search",
+    "skills_hub",
+    "approval",
+    "mcp",
+    "title_generation",
+]
+
+lines = [
+    "model:",
+    f"  provider: {provider}",
+    f"  default: {effective_model}",
+]
+if aux_base_url:
+    lines.append(f"  base_url: {aux_base_url}")
+if aux_api_mode:
+    lines.append(f"  api_mode: {aux_api_mode}")
+lines.append("auxiliary:")
+for task in tasks:
+    timeout = 360 if task == "web_extract" else 120 if task in {"vision", "compression"} else 30
+    lines.extend([
+        f"  {task}:",
+        "    provider: main",
+        f"    model: {effective_model}",
+        f"    timeout: {timeout}",
+    ])
+    if aux_base_url:
+        lines.append(f"    base_url: {aux_base_url}")
+    if aux_api_mode:
+        lines.append(f"    api_mode: {aux_api_mode}")
+    if task == "session_search":
+        lines.append("    max_concurrency: 1")
+
+path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+fi
+
+OUT="$SWEEP_LOGDIR/${SWEEP_LABEL}_${SWEEP_ADAPTER}_${safe_model}_${SWEEP_OUT_TAG}.json"
+LOG="$SWEEP_LOGDIR/${SWEEP_LABEL}_${SWEEP_ADAPTER}_${safe_model}_${SWEEP_OUT_TAG}.log"
+GWLOG="$SWEEP_LOGDIR/gateway_${SWEEP_LABEL}_${SWEEP_OUT_TAG}.log"
+HERMES_AGENT_LOG="$SWEEP_LOGDIR/hermes_agent_${SWEEP_LABEL}_${SWEEP_OUT_TAG}.log"
+HERMES_ERROR_LOG="$SWEEP_LOGDIR/hermes_errors_${SWEEP_LABEL}_${SWEEP_OUT_TAG}.log"
+
+echo "===== CONTAINER ADAPTER EVAL START $(date '+%Y-%m-%d %H:%M:%S') ====="
+echo "uid:      $(id -u) ($(id -un 2>/dev/null || true))"
+echo "adapter:  $SWEEP_ADAPTER"
+echo "model:    $SWEEP_MODEL"
+echo "runtime:  ${SWEEP_AGENT_RUNTIME:-default}"
+echo "codex dynamic tools: ${CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING:-default}"
+echo "pi tool search: ${CLAWBENCH_OPENCLAW_TOOL_SEARCH:-default}"
+echo "runs:     $SWEEP_RUNS"
+echo "execHost: $OPENCLAW_EXEC_HOST"
+echo "out:      $OUT"
+echo "cache:    ${cache_paths[*]}"
+echo "home:     $HOME"
+echo "state:    $OPENCLAW_STATE_DIR"
+echo "hermes:   ${HERMES_HOME:-}"
+openclaw --version 2>/dev/null || true
+python - <<'PY' 2>/dev/null || true
+import os, subprocess
+repo = os.environ.get("HERMES_AGENT_REPO", "")
+if repo:
+    try:
+        sha = subprocess.check_output(["git", "-C", repo, "rev-parse", "HEAD"], text=True).strip()
+        print(f"Hermes git: {sha}")
+    except Exception:
+        print(f"Hermes repo: {repo}")
+PY
+
+rm -rf "${cache_paths[@]}"
+rm -f "$OUT" "$LOG"
+
+GATEWAY_PID=""
+preserve_hermes_logs() {
+  if [ -f "${HERMES_HOME:-}/logs/agent.log" ]; then
+    cp "${HERMES_HOME:-}/logs/agent.log" "$HERMES_AGENT_LOG" 2>/dev/null || true
+  fi
+  if [ -f "${HERMES_HOME:-}/logs/errors.log" ]; then
+    cp "${HERMES_HOME:-}/logs/errors.log" "$HERMES_ERROR_LOG" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  preserve_hermes_logs
+  if [ -n "${GATEWAY_PID:-}" ]; then
+    kill "$GATEWAY_PID" 2>/dev/null || true
+    wait "$GATEWAY_PID" 2>/dev/null || true
+  fi
+  rm -rf "${FRESH_HOME:-}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if [ "$SWEEP_ADAPTER" = "openclaw" ]; then
+  echo "Starting OpenClaw gateway on :18789 ..."
+  HOME="$FRESH_HOME" \
+  OPENCLAW_HOME="$FRESH_HOME" \
+  OPENCLAW_STATE_DIR="$FRESH_STATE" \
+  OPENCLAW_CONFIG_PATH="$FRESH_STATE/openclaw.json" \
+  XDG_CONFIG_HOME="$FRESH_HOME/.config" \
+    openclaw gateway run \
+    --allow-unconfigured \
+    --dev \
+    --bind loopback \
+    --port 18789 \
+    --auth token \
+    --token "$OPENCLAW_GATEWAY_TOKEN" \
+    --compact \
+    > "$GWLOG" 2>&1 &
+  GATEWAY_PID=$!
+  ready=0
+  for i in $(seq 1 180); do
+    if curl -sf -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" http://127.0.0.1:18789/healthz > /dev/null 2>&1; then
+      echo "Gateway healthy after ${i}s"
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  if [ "$ready" -ne 1 ]; then
+    echo "ERROR: gateway failed to become healthy"
+    tail -80 "$GWLOG" 2>/dev/null || true
+    exit 1
+  fi
+  # OpenClaw's dev gateway normalizes state during startup and may rewrite
+  # exec approval defaults. Reassert the eval-local approval socket after boot.
+  write_eval_exec_approvals || exit 1
+  python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+model = os.environ.get("SWEEP_MODEL", "").strip()
+runtime = os.environ.get("SWEEP_AGENT_RUNTIME", "").strip()
+if runtime == "codex" and model.startswith("openai/"):
+    profile_id = "openai-codex:clawbench-env"
+    state_dir = Path(os.environ["OPENCLAW_STATE_DIR"])
+    dirs = [
+        state_dir / "agents" / "main" / "agent",
+        state_dir / "agents" / "dev" / "agent",
+    ]
+    for raw in (os.environ.get("OPENCLAW_AGENT_DIR"), os.environ.get("PI_CODING_AGENT_DIR")):
+        if raw:
+            dirs.append(Path(raw))
+    for agent_dir in dict.fromkeys(dirs):
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        store_path = agent_dir / "auth-profiles.json"
+        try:
+            store = json.loads(store_path.read_text(encoding="utf-8")) if store_path.exists() else {}
+        except Exception:
+            store = {}
+        if not isinstance(store, dict):
+            store = {}
+        store["version"] = int(store.get("version") or 1)
+        profiles = store.setdefault("profiles", {})
+        if not isinstance(profiles, dict):
+            profiles = {}
+            store["profiles"] = profiles
+        credential = {
+            "type": "api_key",
+            "provider": "openai-codex",
+            "keyRef": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+        }
+        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            credential["key"] = openai_key
+        profiles[profile_id] = credential
+        store_path.write_text(json.dumps(store, indent=2) + "\n", encoding="utf-8")
+PY
+  if [ -r "/proc/$GATEWAY_PID/environ" ]; then
+    actual_home="$(tr '\0' '\n' < "/proc/$GATEWAY_PID/environ" | awk -F= '$1 == "HOME" { print $2; exit }')"
+    if [ "$actual_home" != "$FRESH_HOME" ]; then
+      echo "ERROR: gateway HOME escaped container eval home: ${actual_home:-<unset>} != $FRESH_HOME"
+      tail -120 "$GWLOG" 2>/dev/null || true
+      exit 1
+    fi
+  fi
+  if [ ! -f "$FRESH_STATE/exec-approvals.json" ] || grep -q '/home/node/.openclaw' "$FRESH_STATE/exec-approvals.json"; then
+    echo "ERROR: exec approvals are not isolated in $FRESH_STATE"
+    exit 1
+  fi
+  echo "Waiting for OpenClaw session control plane ..."
+  python - <<'PY'
+import asyncio
+import os
+import sys
+import time
+
+from clawbench.client import GatewayClient, GatewayConfig
+
+
+async def probe_once(attempt: int) -> None:
+    config = GatewayConfig(
+        url=os.environ["OPENCLAW_GATEWAY_URL"],
+        token=os.environ["OPENCLAW_GATEWAY_TOKEN"],
+        connect_timeout=30.0,
+        request_timeout=30.0,
+    )
+    async with GatewayClient(config) as client:
+        key = await client.create_session(
+            model=os.environ["SWEEP_MODEL"],
+            label=f"clawbench-readiness-probe-{os.getpid()}-{attempt}",
+        )
+        await client.delete_session(key)
+
+
+async def main() -> int:
+    deadline = time.monotonic() + 240
+    attempt = 0
+    last_error = ""
+    while time.monotonic() < deadline:
+        attempt += 1
+        try:
+            await probe_once(attempt)
+            print(f"Gateway session control plane ready after {attempt} attempt(s)")
+            return 0
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            print(f"Gateway control probe {attempt} not ready: {last_error}")
+            await asyncio.sleep(5)
+    print(f"ERROR: gateway session control plane did not become ready: {last_error}", file=sys.stderr)
+    return 1
+
+
+raise SystemExit(asyncio.run(main()))
+PY
+  if [ "$?" -ne 0 ]; then
+    tail -120 "$GWLOG" 2>/dev/null || true
+    exit 1
+  fi
+fi
+
+TASK_ARGS=()
+if [ -n "${CHERRY_TASKS:-}" ]; then
+  IFS=',' read -ra TASK_ARR <<< "$CHERRY_TASKS"
+  for task_id in "${TASK_ARR[@]}"; do
+    TASK_ARGS+=("--task" "$task_id")
+  done
+fi
+
+clawbench run \
+  --adapter "$SWEEP_ADAPTER" \
+  --model "$SWEEP_MODEL" \
+  --runs "$SWEEP_RUNS" \
+  --concurrency "$SWEEP_CONCURRENCY" \
+  --browser-concurrency "$SWEEP_BROWSER_CONCURRENCY" \
+  --no-randomize \
+  "${TASK_ARGS[@]}" \
+  --output "$OUT" \
+  > "$LOG" 2>&1
+status=$?
+preserve_hermes_logs
+
+echo "===== clawbench exit=$status $(date '+%Y-%m-%d %H:%M:%S') ====="
+tail -80 "$LOG" 2>/dev/null || true
+
+exit "$status"

--- a/scripts/container_lane_eval.sh
+++ b/scripts/container_lane_eval.sh
@@ -14,14 +14,18 @@ set -Eeuo pipefail
 
 cd /home/node/app
 export CLAWBENCH_LOCAL_QUEUE_DIR="${CLAWBENCH_LOCAL_QUEUE_DIR:-/data/queue/$SWEEP_LABEL}"
+export CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING="${CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING:-searchable}"
 mkdir -p "$SWEEP_LOGDIR" /data/results "$CLAWBENCH_LOCAL_QUEUE_DIR" /data/run_cache /data/lane_runtime
 
 export HF_TOKEN=""
 export OPENCLAW_GATEWAY_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-local-dev-token-for-testing}"
 export OPENCLAW_SKIP_GMAIL_WATCHER=1
 export OPENCLAW_SKIP_CANVAS_HOST=1
+export OPENCLAW_SKIP_CHANNELS="${OPENCLAW_SKIP_CHANNELS:-1}"
+export OPENCLAW_SKIP_PROVIDERS="${OPENCLAW_SKIP_PROVIDERS:-1}"
+export OPENCLAW_PLUGIN_STAGE_DIR="${OPENCLAW_PLUGIN_STAGE_DIR:-/home/node/.openclaw/plugin-runtime-deps}"
 export OPENCLAW_NO_RESPAWN=1
-export CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY=1
+export CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY="${CLAWBENCH_DISABLE_GATEWAY_DEVICE_IDENTITY:-0}"
 export CLAWBENCH_PER_RUN_BUDGET_SECONDS
 export CLAWBENCH_PER_TURN_TIMEOUT_SECONDS
 export CLAWBENCH_CONNECT_TIMEOUT="${CLAWBENCH_CONNECT_TIMEOUT:-180}"
@@ -35,6 +39,67 @@ export CLAWBENCH_TOOL_PROFILE_NAME="${CLAWBENCH_TOOL_PROFILE_NAME:-$SWEEP_LABEL}
 export NODE_OPTIONS="${NODE_OPTIONS:-"--max-old-space-size=4096"}"
 if command -v npm >/dev/null 2>&1; then
   export NODE_PATH="${NODE_PATH:-$(npm root -g 2>/dev/null || true)}"
+fi
+
+write_eval_exec_approvals() {
+  python - "$FRESH_STATE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_dir = Path(sys.argv[1])
+state_dir.mkdir(parents=True, exist_ok=True)
+approvals_path = state_dir / "exec-approvals.json"
+approvals = {
+    "version": 1,
+    "socket": {
+        "path": str(approvals_path.with_suffix(".sock")),
+        "token": "container-lane-eval-token",
+    },
+    "defaults": {"security": "full", "ask": "off", "askFallback": "full"},
+    "agents": {"*": {"security": "full", "ask": "off", "askFallback": "full"}},
+}
+tmp_path = approvals_path.with_suffix(".json.tmp")
+tmp_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
+tmp_path.replace(approvals_path)
+PY
+}
+
+if [ -n "${CLAWBENCH_TASK_TIMEOUT_SCALE:-}" ] && [ "${CLAWBENCH_TASK_TIMEOUT_SCALE:-1}" != "1" ] && [ "${CLAWBENCH_TASK_TIMEOUT_SCALE:-1.0}" != "1.0" ]; then
+  SOURCE_TASKS_DIR="${CLAWBENCH_TASKS_DIR:-/tasks}"
+  SCALED_TASKS_DIR="/tmp/clawbench-tasks-scaled-${SWEEP_LABEL}-$$"
+  rm -rf "$SCALED_TASKS_DIR"
+  mkdir -p "$SCALED_TASKS_DIR"
+  cp -a "$SOURCE_TASKS_DIR/." "$SCALED_TASKS_DIR/"
+  python3 - "$SCALED_TASKS_DIR" "$CLAWBENCH_TASK_TIMEOUT_SCALE" <<'PY'
+import pathlib
+import re
+import sys
+
+tasks_dir = pathlib.Path(sys.argv[1])
+scale = float(sys.argv[2])
+if scale <= 0 or scale > 20:
+    raise SystemExit(f"invalid CLAWBENCH_TASK_TIMEOUT_SCALE={scale}")
+
+touched = 0
+for yml in tasks_dir.rglob("t*.yaml"):
+    raw = yml.read_text(encoding="utf-8")
+
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        original = int(match.group(2))
+        scaled = max(1, int(round(original * scale)))
+        return f"{key}: {scaled}"
+
+    new = re.sub(r"^(timeout_seconds):\s*(\d+)\s*$", repl, raw, flags=re.MULTILINE)
+    new = re.sub(r"^(    timeout_seconds):\s*(\d+)\s*$", repl, new, flags=re.MULTILINE)
+    new = re.sub(r"^(  timeout_seconds):\s*(\d+)\s*$", repl, new, flags=re.MULTILINE)
+    if new != raw:
+        yml.write_text(new, encoding="utf-8")
+        touched += 1
+print(f"scaled task timeouts in {touched} files by {scale}x")
+PY
+  export CLAWBENCH_TASKS_DIR="$SCALED_TASKS_DIR"
 fi
 
 SRC_STATE="${OPENCLAW_CONFIG_SOURCE:-/config/openclaw}"
@@ -54,10 +119,26 @@ rm -rf "$FRESH_HOME" "$CLAWBENCH_PARALLEL_LANE_ROOT"
 mkdir -p "$FRESH_STATE" "$FRESH_HOME/.config"
 if [ -f "$SRC_STATE/openclaw.json" ]; then
   cp "$SRC_STATE/openclaw.json" "$FRESH_STATE/openclaw.json"
+else
+  printf '{}\n' > "$FRESH_STATE/openclaw.json"
 fi
 if [ -d "$SRC_STATE/plugins" ]; then
   mkdir -p "$FRESH_STATE/plugins"
   cp -R "$SRC_STATE/plugins/." "$FRESH_STATE/plugins/" 2>/dev/null || true
+fi
+if [ -d "$SRC_STATE/agents" ]; then
+  mkdir -p "$FRESH_STATE/agents"
+  cp -R "$SRC_STATE/agents/." "$FRESH_STATE/agents/" 2>/dev/null || true
+fi
+CODEX_STATE_SOURCE="${CODEX_CONFIG_SOURCE:-/config/codex}"
+if [ -d "$CODEX_STATE_SOURCE" ]; then
+  mkdir -p "$FRESH_HOME/.codex"
+  for codex_file in auth.json config.toml; do
+    if [ -f "$CODEX_STATE_SOURCE/$codex_file" ]; then
+      cp "$CODEX_STATE_SOURCE/$codex_file" "$FRESH_HOME/.codex/$codex_file"
+      chmod 600 "$FRESH_HOME/.codex/$codex_file" 2>/dev/null || true
+    fi
+  done
 fi
 mkdir -p \
   "$FRESH_STATE/agents" \
@@ -76,7 +157,55 @@ export HOME="$FRESH_HOME"
 export OPENCLAW_HOME="$FRESH_HOME"
 export OPENCLAW_STATE_DIR="$FRESH_STATE"
 export OPENCLAW_CONFIG_PATH="$FRESH_STATE/openclaw.json"
+export OPENCLAW_AGENT_DIR="$FRESH_STATE/agents/main/agent"
+export PI_CODING_AGENT_DIR="$OPENCLAW_AGENT_DIR"
 export XDG_CONFIG_HOME="$FRESH_HOME/.config"
+SWEEP_AGENT_RUNTIME="${SWEEP_AGENT_RUNTIME:-${CLAWBENCH_OPENCLAW_AGENT_RUNTIME:-${OPENCLAW_AGENT_RUNTIME:-}}}"
+if [ -n "$SWEEP_AGENT_RUNTIME" ]; then
+  export OPENCLAW_AGENT_RUNTIME="$SWEEP_AGENT_RUNTIME"
+  export CLAWBENCH_OPENCLAW_AGENT_RUNTIME="$SWEEP_AGENT_RUNTIME"
+fi
+case "$SWEEP_MODEL:${SWEEP_AGENT_RUNTIME:-}" in
+  *:codex|codex/*)
+    export OPENCLAW_CODEX_APP_SERVER_MODE="${OPENCLAW_CODEX_APP_SERVER_MODE:-yolo}"
+    export OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY="${OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY:-never}"
+    export OPENCLAW_CODEX_APP_SERVER_SANDBOX="${OPENCLAW_CODEX_APP_SERVER_SANDBOX:-danger-full-access}"
+    ;;
+esac
+case "$SWEEP_MODEL" in
+  codex/*)
+    export OPENCLAW_CODEX_APP_SERVER_MODE="${OPENCLAW_CODEX_APP_SERVER_MODE:-yolo}"
+    export OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY="${OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY:-never}"
+    export OPENCLAW_CODEX_APP_SERVER_SANDBOX="${OPENCLAW_CODEX_APP_SERVER_SANDBOX:-danger-full-access}"
+    ;;
+esac
+
+provider_auth_missing() {
+  local provider="$1"
+  local env_hint="$2"
+  cat >&2 <<EOF
+Missing provider auth for SWEEP_MODEL=$SWEEP_MODEL ($provider).
+Set $env_hint in the container environment. For Docker runs, pass the
+provider variable explicitly, e.g. "docker run -e $env_hint ..."; with
+Testbox, run through "clawbench-testbox-env docker run -e $env_hint ...".
+Set CLAWBENCH_ALLOW_MISSING_PROVIDER_AUTH=1 only for control-plane smoke tests.
+EOF
+  exit 78
+}
+
+if [ "${CLAWBENCH_ALLOW_MISSING_PROVIDER_AUTH:-}" != "1" ]; then
+  case "$SWEEP_MODEL" in
+    openai/*)
+      [ -n "${OPENAI_API_KEY:-}" ] || provider_auth_missing "openai" "OPENAI_API_KEY"
+      ;;
+    openrouter/*)
+      [ -n "${OPENROUTER_API_KEY:-}" ] || provider_auth_missing "openrouter" "OPENROUTER_API_KEY"
+      ;;
+    anthropic/*|claude/*)
+      [ -n "${ANTHROPIC_API_KEY:-${ANTHROPIC_API_TOKEN:-}}" ] || provider_auth_missing "anthropic" "ANTHROPIC_API_KEY"
+      ;;
+  esac
+fi
 
 python - <<'PY'
 import json
@@ -99,15 +228,233 @@ def set_nested(root, dotted, value):
         cursor = child
     cursor[parts[-1]] = value
 
+
+def set_model_agent_runtime_policy(root, model_ref, agent_runtime):
+    agents = root.setdefault("agents", {})
+    if not isinstance(agents, dict):
+        return
+    defaults = agents.setdefault("defaults", {})
+    if not isinstance(defaults, dict):
+        return
+    models = defaults.get("models")
+    if isinstance(models, dict):
+        for model_cfg in models.values():
+            if isinstance(model_cfg, dict):
+                model_cfg.pop("agentRuntime", None)
+
+    if agent_runtime == "codex":
+        plugins_cfg = root.setdefault("plugins", {})
+        if isinstance(plugins_cfg, dict):
+            allow = plugins_cfg.get("allow")
+            if isinstance(allow, list) and "codex" not in allow:
+                allow.append("codex")
+
+
+def strip_agent_runtime_policy(root):
+    agents = root.get("agents")
+    if not isinstance(agents, dict):
+        return
+    defaults = agents.get("defaults")
+    if not isinstance(defaults, dict):
+        return
+    defaults.pop("agentRuntime", None)
+    models = defaults.get("models")
+    if isinstance(models, dict):
+        for model_cfg in models.values():
+            if isinstance(model_cfg, dict):
+                model_cfg.pop("agentRuntime", None)
+
+
+def ensure_legacy_openai_model(root, model_ref):
+    # OpenClaw 2026.4.x forward-fills gpt-5.4, but it predates gpt-5.5.
+    # Ensure legacy OpenAI provider config has the API key env var, then seed
+    # only the requested missing legacy model.
+    if not model_ref.startswith("openai/"):
+        return
+    models_cfg = root.setdefault("models", {})
+    if not isinstance(models_cfg, dict):
+        return
+    providers = models_cfg.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        return
+    provider_cfg = providers.get("openai")
+    if not isinstance(provider_cfg, dict):
+        provider_cfg = {}
+        providers["openai"] = provider_cfg
+    provider_cfg.setdefault("baseUrl", "https://api.openai.com/v1")
+    provider_cfg.setdefault("api", "openai-responses")
+    provider_cfg.setdefault("apiKey", "OPENAI_API_KEY")
+    provider_cfg.setdefault("auth", "api-key")
+    legacy_model_ids = {"openai/gpt-5.4": "gpt-5.4", "openai/gpt-5.5": "gpt-5.5"}
+    model_id = legacy_model_ids.get(model_ref)
+    if not model_id:
+        return
+    model_entries = provider_cfg.get("models")
+    if not isinstance(model_entries, list):
+        model_entries = []
+        provider_cfg["models"] = model_entries
+    if not any(isinstance(item, dict) and item.get("id") == model_id for item in model_entries):
+        model_entries.append(
+            {
+                "id": model_id,
+                "name": model_id,
+                "api": "openai-responses",
+                "reasoning": True,
+                "input": ["text", "image"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                "contextWindow": 1050000,
+                "maxTokens": 128000,
+            }
+        )
+
+
+def ensure_openai_codex_provider_config(root, model_ref):
+    if model_ref.startswith("openai/") and len(model_ref.split("/", 1)) == 2:
+        model_id = model_ref.split("/", 1)[1]
+    elif model_ref.startswith("openai-codex/") and len(model_ref.split("/", 1)) == 2:
+        model_id = model_ref.split("/", 1)[1]
+    else:
+        return
+    models_cfg = root.setdefault("models", {})
+    if not isinstance(models_cfg, dict):
+        return
+    providers = models_cfg.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        return
+    provider_cfg = providers.get("openai-codex")
+    if not isinstance(provider_cfg, dict):
+        provider_cfg = {}
+        providers["openai-codex"] = provider_cfg
+    provider_cfg["baseUrl"] = "https://api.openai.com/v1"
+    provider_cfg["api"] = "openai-responses"
+    provider_cfg["apiKey"] = "OPENAI_API_KEY"
+    provider_cfg["auth"] = "api-key"
+    model_entries = provider_cfg.get("models")
+    if not isinstance(model_entries, list):
+        model_entries = []
+        provider_cfg["models"] = model_entries
+    desired_model = {
+        "id": model_id,
+        "name": model_id,
+        "api": "openai-responses",
+        "reasoning": True,
+        "input": ["text", "image"],
+        "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        "contextWindow": 1050000,
+        "maxTokens": 128000,
+    }
+    for item in model_entries:
+        if isinstance(item, dict) and item.get("id") == model_id:
+            item.update(desired_model)
+            break
+    else:
+        model_entries.append(desired_model)
+
+
+def ensure_codex_openai_auth_profile(root, state_dir, model_ref, agent_runtime):
+    if agent_runtime != "codex" or not model_ref.startswith("openai/"):
+        return
+    profile_id = "openai-codex:clawbench-env"
+    auth = root.setdefault("auth", {})
+    if isinstance(auth, dict):
+        profiles = auth.setdefault("profiles", {})
+        if isinstance(profiles, dict):
+            profiles[profile_id] = {
+                "provider": "openai-codex",
+                "mode": "api_key",
+                "displayName": "ClawBench OPENAI_API_KEY",
+            }
+        order = auth.setdefault("order", {})
+        if isinstance(order, dict):
+            current = order.get("openai-codex")
+            if not isinstance(current, list):
+                current = []
+            order["openai-codex"] = [profile_id, *[item for item in current if item != profile_id]]
+
+    for agent_name in ("main", "dev"):
+        agent_dir = Path(state_dir) / "agents" / agent_name / "agent"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        store_path = agent_dir / "auth-profiles.json"
+        try:
+            store = json.loads(store_path.read_text(encoding="utf-8")) if store_path.exists() else {}
+        except Exception:
+            store = {}
+        if not isinstance(store, dict):
+            store = {}
+        store["version"] = int(store.get("version") or 1)
+        store_profiles = store.setdefault("profiles", {})
+        if not isinstance(store_profiles, dict):
+            store_profiles = {}
+            store["profiles"] = store_profiles
+        credential = {
+            "type": "api_key",
+            "provider": "openai-codex",
+            "keyRef": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+        }
+        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        if openai_key:
+            credential["key"] = openai_key
+        store_profiles[profile_id] = credential
+        store_path.write_text(json.dumps(store, indent=2) + "\n", encoding="utf-8")
+
+
+def sanitize_legacy_plugins(root, model_ref):
+    plugins_cfg = root.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return
+    legacy_stale = {"openai"}
+    if not model_ref.startswith("codex/"):
+        legacy_stale.add("codex")
+    allow = plugins_cfg.get("allow")
+    if isinstance(allow, list):
+        plugins_cfg["allow"] = [item for item in allow if item not in legacy_stale]
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        for item in legacy_stale:
+            entries.pop(item, None)
+
+
+def ensure_codex_plugin_allowed(root, loading):
+    if loading not in {"searchable", "direct"}:
+        raise SystemExit(f"invalid CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING={loading!r}")
+    plugins_cfg = root.setdefault("plugins", {})
+    if not isinstance(plugins_cfg, dict):
+        return
+    allow = plugins_cfg.setdefault("allow", [])
+    if isinstance(allow, list) and "codex" not in allow:
+        allow.append("codex")
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        codex = entries.get("codex")
+        if isinstance(codex, dict):
+            codex.pop("config", None)
+
+
+def parse_optional_bool_env(name):
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return None
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    raise SystemExit(f"invalid {name}={raw!r}; expected true or false")
+
 agents = data.setdefault("agents", {})
 if isinstance(agents, dict):
     agents["list"] = []
 
 channels = data.get("channels")
 if isinstance(channels, dict):
+    channels.pop("whatsapp", None)
     for channel in channels.values():
         if isinstance(channel, dict):
             channel["enabled"] = False
+            streaming = channel.get("streaming")
+            if isinstance(streaming, dict):
+                streaming["mode"] = "off"
+            else:
+                channel["streaming"] = {"mode": "off"}
             exec_approvals = channel.get("execApprovals")
             if not isinstance(exec_approvals, dict):
                 exec_approvals = {}
@@ -115,7 +462,7 @@ if isinstance(channels, dict):
             exec_approvals["enabled"] = False
 
 plugins = data.setdefault("plugins", {})
-stale = {"marxbiotech-git-tools", "lab"}
+stale = {"marxbiotech-git-tools", "lab", "whatsapp"}
 allow = plugins.get("allow")
 if isinstance(allow, list):
     plugins["allow"] = [item for item in allow if item not in stale]
@@ -131,45 +478,116 @@ set_nested(data, "agents.defaults.skipBootstrap", True)
 set_nested(data, "agents.defaults.sandbox.mode", "off")
 set_nested(data, "agents.defaults.model.primary", os.environ["SWEEP_MODEL"])
 set_nested(data, "agents.defaults.subagents.model.primary", os.environ["SWEEP_MODEL"])
-set_nested(
-    data,
-    "agents.defaults.systemPromptOverride",
-    "You are running an OpenClaw benchmark task. Complete the user's request in the current "
-    "workspace using the available tools when needed. For file, code, browser, shell, or memory "
-    "tasks, make the requested changes directly and verify them when practical. Do not ask "
-    "follow-up questions during the benchmark. Keep any final reply brief.",
-)
 set_nested(data, "tools.exec.host", os.environ.get("OPENCLAW_EXEC_HOST", "gateway"))
 set_nested(data, "tools.exec.security", "full")
 set_nested(data, "tools.exec.ask", "off")
 set_nested(data, "approvals.exec.enabled", False)
+model_ref = os.environ["SWEEP_MODEL"].strip()
+ensure_legacy_openai_model(data, model_ref)
+ensure_openai_codex_provider_config(data, model_ref)
+agent_runtime = os.environ.get("SWEEP_AGENT_RUNTIME", "").strip()
+legacy_config = os.environ.get("CLAWBENCH_OPENCLAW_LEGACY_CONFIG", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+if agent_runtime and not legacy_config:
+    set_nested(data, "agents.defaults.agentRuntime.id", agent_runtime)
+    set_model_agent_runtime_policy(data, model_ref, agent_runtime)
+    ensure_codex_openai_auth_profile(data, os.environ["OPENCLAW_STATE_DIR"], model_ref, agent_runtime)
+elif legacy_config:
+    strip_agent_runtime_policy(data)
+    sanitize_legacy_plugins(data, model_ref)
+else:
+    strip_agent_runtime_policy(data)
+    sanitize_legacy_plugins(data, model_ref)
+if agent_runtime == "codex" or model_ref.startswith("codex/"):
+    ensure_codex_plugin_allowed(
+        data,
+        os.environ.get("CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING", "searchable").strip(),
+    )
+tool_search_enabled = parse_optional_bool_env("CLAWBENCH_OPENCLAW_TOOL_SEARCH")
+if tool_search_enabled is not None:
+    set_nested(data, "tools.toolSearch", tool_search_enabled)
 
-models = data.setdefault("agents", {}).setdefault("defaults", {}).setdefault("models", {})
-model_entry = models.setdefault(os.environ["SWEEP_MODEL"], {})
-params = model_entry.setdefault("params", {})
-params["fastMode"] = True
-if os.environ["SWEEP_MODEL"].startswith("openai/"):
-    params["transport"] = "sse"
-    params["openaiWsWarmup"] = False
+if model_ref.startswith("openrouter/") and len(model_ref.split("/", 1)) == 2:
+    model_id = model_ref.split("/", 1)[1]
+    openrouter_timeout_seconds = int(os.environ.get("CLAWBENCH_OPENROUTER_TIMEOUT_SECONDS") or "900")
+    set_nested(
+        data,
+        "agents.defaults.thinkingDefault",
+        os.environ.get("CLAWBENCH_OPENROUTER_THINKING_DEFAULT", "low").strip() or "low",
+    )
+    set_nested(
+        data,
+        "agents.defaults.timeoutSeconds",
+        int(os.environ.get("CLAWBENCH_OPENROUTER_AGENT_TIMEOUT_SECONDS") or "1200"),
+    )
+    agents_cfg = data.setdefault("agents", {})
+    if isinstance(agents_cfg, dict):
+        defaults_cfg = agents_cfg.setdefault("defaults", {})
+        if isinstance(defaults_cfg, dict):
+            model_defaults = defaults_cfg.setdefault("models", {})
+            if isinstance(model_defaults, dict):
+                model_cfg = model_defaults.setdefault(model_ref, {})
+                if not isinstance(model_cfg, dict):
+                    model_cfg = {}
+                    model_defaults[model_ref] = model_cfg
+                params_cfg = model_cfg.setdefault("params", {})
+                if not isinstance(params_cfg, dict):
+                    params_cfg = {}
+                    model_cfg["params"] = params_cfg
+                extra_body = params_cfg.setdefault("extra_body", {})
+                if not isinstance(extra_body, dict):
+                    extra_body = {}
+                    params_cfg["extra_body"] = extra_body
+                extra_body["include_reasoning"] = False
+                extra_body["reasoning"] = {"exclude": True}
+    models_cfg = data.setdefault("models", {})
+    if isinstance(models_cfg, dict):
+        providers = models_cfg.setdefault("providers", {})
+        if isinstance(providers, dict):
+            provider_cfg = providers.get("openrouter")
+            if not isinstance(provider_cfg, dict):
+                provider_cfg = {}
+                providers["openrouter"] = provider_cfg
+            provider_cfg.setdefault("baseUrl", "https://openrouter.ai/api/v1")
+            provider_cfg["api"] = "openai-completions"
+            provider_cfg.setdefault("apiKey", "OPENROUTER_API_KEY")
+            provider_cfg["timeoutSeconds"] = openrouter_timeout_seconds
+            model_entries = provider_cfg.get("models")
+            if not isinstance(model_entries, list):
+                model_entries = []
+                provider_cfg["models"] = model_entries
+            desired_model = {
+                "id": model_id,
+                "name": model_id,
+                "contextWindow": 131072,
+                "maxTokens": 8192,
+            }
+            for item in model_entries:
+                if isinstance(item, dict) and item.get("id") == model_id:
+                    item.update(desired_model)
+                    break
+            else:
+                model_entries.append(desired_model)
 
 cfg_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-
-approvals_path = cfg_path.with_name("exec-approvals.json")
-approvals = {
-    "version": 1,
-    "socket": {
-        "path": str(approvals_path.with_suffix(".sock")),
-        "token": "container-lane-eval-token",
-    },
-    "defaults": {"security": "full", "ask": "off", "askFallback": "full"},
-    "agents": {"*": {"security": "full", "ask": "off", "askFallback": "full"}},
-}
-approvals_path.write_text(json.dumps(approvals, indent=2) + "\n", encoding="utf-8")
 PY
+write_eval_exec_approvals
+
+if [ "${CLAWBENCH_ENABLE_GBRAIN:-0}" = "1" ]; then
+  export CLAWBENCH_LANE_PREPARE_CMD="${CLAWBENCH_LANE_PREPARE_CMD:-/home/node/app/scripts/setup_gbrain_runtime.sh}"
+  "$CLAWBENCH_LANE_PREPARE_CMD"
+fi
 
 echo "===== CONTAINER LANE EVAL START $(date '+%Y-%m-%d %H:%M:%S') ====="
 echo "label:    $SWEEP_LABEL"
 echo "model:    $SWEEP_MODEL"
+echo "runtime:  ${SWEEP_AGENT_RUNTIME:-default}"
+echo "codex dynamic tools: ${CLAWBENCH_CODEX_DYNAMIC_TOOLS_LOADING:-default}"
+echo "pi tool search: ${CLAWBENCH_OPENCLAW_TOOL_SEARCH:-default}"
 echo "runs:     $SWEEP_RUNS"
 echo "lanes:    $SWEEP_LANES"
 echo "tasks:    ${SWEEP_TASKS:-${CHERRY_TASKS:-all}}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 
 import pytest
 from websockets.datastructures import Headers
@@ -9,7 +10,7 @@ from websockets.exceptions import InvalidMessage, InvalidStatus
 from websockets.http11 import Response
 
 from clawbench.client import GatewayClient, GatewayConfig, _correlate_transcript, _parse_single_message
-from clawbench.schemas import Transcript
+from clawbench.schemas import EfficiencyResult, TokenUsage, Transcript
 
 
 def test_gateway_config_defaults():
@@ -19,6 +20,30 @@ def test_gateway_config_defaults():
     # spurious empty_response failures.
     assert cfg.connect_timeout == 30.0
     assert cfg.request_timeout == 60.0
+
+
+def test_set_session_auth_profile_override_patches_local_store(tmp_path: Path, monkeypatch):
+    state_dir = tmp_path / "state"
+    store_dir = state_dir / "agents" / "agent-stub" / "sessions"
+    store_dir.mkdir(parents=True)
+    store_path = store_dir / "sessions.json"
+    store_path.write_text(
+        json.dumps({"session-1": {"sessionId": "session-1"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+
+    ok = GatewayClient().set_session_auth_profile_override(
+        "session-1",
+        agent_id="agent-stub",
+        auth_profile_id="openai-codex:clawbench-env",
+    )
+
+    assert ok is True
+    entry = json.loads(store_path.read_text(encoding="utf-8"))["session-1"]
+    assert entry["authProfileOverride"] == "openai-codex:clawbench-env"
+    assert entry["authProfileOverrideSource"] == "user"
+    assert "authProfileOverrideCompactionCount" not in entry
 
 
 def test_gateway_config_env_overrides(monkeypatch):
@@ -36,6 +61,46 @@ def test_gateway_config_invalid_env_falls_back_to_default(monkeypatch, caplog, r
         cfg = GatewayConfig()
     assert cfg.connect_timeout == 30.0
     assert any("CLAWBENCH_CONNECT_TIMEOUT" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_gateway_client_disables_websocket_keepalive_for_long_rpc(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    connect_kwargs: dict[str, object] = {}
+    connect_params: dict[str, object] = {}
+
+    class FakeWebSocket:
+        async def close(self) -> None:
+            return None
+
+    async def fake_connect(*args, **kwargs):
+        connect_kwargs.update(kwargs)
+        return FakeWebSocket()
+
+    async def fake_wait_event(self, event_name: str, *, timeout: float):
+        return {"payload": {"nonce": ""}}
+
+    async def fake_rpc(self, method: str, params=None, **kwargs):
+        connect_params.update(params or {})
+        return {"payload": {"type": "hello-ok", "protocol": 3}}
+
+    async def fake_listener(self):
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr("clawbench.client.websockets.connect", fake_connect)
+    monkeypatch.setattr(GatewayClient, "_wait_event", fake_wait_event)
+    monkeypatch.setattr(GatewayClient, "_rpc", fake_rpc)
+    monkeypatch.setattr(GatewayClient, "_listener", fake_listener)
+
+    client = GatewayClient(GatewayConfig(connect_timeout=2))
+    await client.connect()
+    await client.close()
+
+    assert connect_kwargs["ping_interval"] is None
+    assert connect_kwargs["ping_timeout"] is None
+    assert connect_params["minProtocol"] == 3
+    assert connect_params["maxProtocol"] == 4
 
 
 def test_tool_results_are_correlated_back_to_tool_calls():
@@ -64,6 +129,74 @@ def test_tool_results_are_correlated_back_to_tool_calls():
     assert call.error == "ERROR failed test"
 
 
+def test_parser_accepts_codex_tool_search_output_shape():
+    tool_message = _parse_single_message(
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_search_call",
+                    "call_id": "search-1",
+                    "name": "tool_search",
+                    "arguments": {"query": "message"},
+                },
+                {
+                    "type": "functionCall",
+                    "callId": "call-1",
+                    "name": "message",
+                    "arguments": '{"text":"hello"}',
+                },
+            ],
+        }
+    )
+    result_message = _parse_single_message(
+        {
+            "role": "toolResult",
+            "toolCallId": "call-1",
+            "content": [
+                {
+                    "type": "toolSearchOutput",
+                    "callId": "search-1",
+                    "output": [{"text": "message: send a message"}],
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "sent",
+                },
+            ],
+        }
+    )
+
+    transcript = _correlate_transcript(Transcript(messages=[tool_message, result_message]))  # type: ignore[arg-type]
+
+    assert [call.name for call in transcript.tool_call_sequence] == ["tool_search", "message"]
+    assert transcript.tool_call_sequence[0].output == "message: send a message"
+    assert transcript.tool_call_sequence[1].output == "sent"
+    assert transcript.tool_call_sequence[1].success is True
+
+
+def test_parser_correlates_plain_top_level_tool_result_message():
+    tool_message = _parse_single_message(
+        {
+            "role": "assistant",
+            "content": [{"type": "toolUse", "id": "call-1", "name": "read", "input": {}}],
+        }
+    )
+    result_message = _parse_single_message(
+        {
+            "role": "toolResult",
+            "toolUseId": "call-1",
+            "content": "file contents",
+        }
+    )
+
+    transcript = _correlate_transcript(Transcript(messages=[tool_message, result_message]))  # type: ignore[arg-type]
+
+    assert transcript.tool_call_sequence[0].output == "file contents"
+    assert transcript.tool_call_sequence[0].success is True
+
+
 def test_message_usage_is_parsed_into_transcript_usage():
     message = _parse_single_message(
         {
@@ -87,6 +220,15 @@ def test_message_usage_is_parsed_into_transcript_usage():
     assert message.usage.reasoning_tokens == 5
     assert message.usage.total_tokens == 40
     assert message.usage.total_cost_usd == 0.0125
+
+
+def test_efficiency_component_tokens_stay_separate_from_total_snapshot():
+    usage = TokenUsage(input_tokens=10, output_tokens=5, cache_read_tokens=3, total_tokens=10_000)
+
+    result = EfficiencyResult.from_usage(duration_ms=123, usage=usage)
+
+    assert result.component_tokens == 18
+    assert result.total_tokens == 10_000
 
 
 @pytest.mark.asyncio
@@ -193,39 +335,6 @@ async def test_send_and_wait_collects_messages_that_arrive_after_final_state():
     transcript = await client.send_and_wait(session_key, "hello", timeout=1.0)
 
     assert [message.text for message in transcript.assistant_messages] == ["Late but valid."]
-
-
-@pytest.mark.asyncio
-async def test_rpc_send_failure_cleans_pending_request():
-    class FailingWebSocket:
-        async def send(self, payload: str) -> None:  # noqa: ARG002
-            raise ConnectionError("socket closed")
-
-    client = GatewayClient(GatewayConfig(request_timeout=0.01))
-    client._ws = FailingWebSocket()  # type: ignore[assignment]
-
-    with pytest.raises(ConnectionError, match="socket closed"):
-        await client._rpc("sessions.create", {"model": "test-model"})
-
-    assert client._pending == {}
-
-
-@pytest.mark.asyncio
-async def test_rpc_timeout_cleans_pending_request():
-    sent_frames: list[dict[str, object]] = []
-
-    class SilentWebSocket:
-        async def send(self, payload: str) -> None:
-            sent_frames.append(json.loads(payload))
-
-    client = GatewayClient(GatewayConfig(request_timeout=0.01))
-    client._ws = SilentWebSocket()  # type: ignore[assignment]
-
-    with pytest.raises(TimeoutError, match="RPC sessions.create timed out"):
-        await client._rpc("sessions.create", {"model": "test-model"})
-
-    assert sent_frames[0]["method"] == "sessions.create"
-    assert client._pending == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_dockerfiles.py
+++ b/tests/test_dockerfiles.py
@@ -17,3 +17,16 @@ def test_public_dockerfiles_copy_public_task_sets():
         assert "COPY --chown=node:node baselines/ baselines/" in contents
         assert "COPY --chown=node:node tasks-domain/ tasks-domain/" in contents
         assert "COPY --chown=node:node tasks/ tasks/" not in contents
+
+
+def test_container_eval_scripts_do_not_write_codex_plugin_config():
+    repo_root = Path(__file__).resolve().parent.parent
+
+    for script_name in ("scripts/container_adapter_eval.sh", "scripts/container_lane_eval.sh"):
+        contents = (repo_root / script_name).read_text(encoding="utf-8")
+
+        assert "codex.setdefault(\"config\"" not in contents
+        assert "config[\"codexDynamicToolsLoading\"]" not in contents
+        assert "model_cfg[\"agentRuntime\"]" not in contents
+        assert "openai-codex:clawbench-env" in contents
+        assert "PI_CODING_AGENT_DIR" in contents

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -9,6 +9,7 @@ the adapter's branches are covered end-to-end without a real gateway.
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -69,11 +70,35 @@ class _StubGateway:
         self.calls.append(("create_agent", {"name": name, "workspace": workspace}))
         return "agent-stub"
 
+    async def reconnect(self) -> None:
+        self.calls.append(("reconnect", {}))
+
     async def create_session(self, *, model: str, agent_id: str, label: str) -> str:
         self.calls.append(
             ("create_session", {"model": model, "agent_id": agent_id, "label": label})
         )
         return f"session-{label}"
+
+    def set_session_auth_profile_override(
+        self,
+        session_key: str,
+        *,
+        agent_id: str,
+        auth_profile_id: str,
+        source: str = "user",
+    ) -> bool:
+        self.calls.append(
+            (
+                "set_session_auth_profile_override",
+                {
+                    "session_key": session_key,
+                    "agent_id": agent_id,
+                    "auth_profile_id": auth_profile_id,
+                    "source": source,
+                },
+            )
+        )
+        return True
 
     async def subscribe(self, session_key: str) -> None:
         self.calls.append(("subscribe", {"session_key": session_key}))
@@ -268,6 +293,41 @@ def test_run_phase_creates_session_subscribes_and_drives_simulator(tmp_path: Pat
     # The send_and_wait call should use the rendered user turn text.
     send_args = next(args for name, args in gateway.calls if name == "send_and_wait")
     assert send_args["message"] == "Do the task."
+
+
+def test_run_phase_routes_openai_codex_runtime_to_codex_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _coding_task()
+    adapter, gateway = _make_adapter_and_gateway()
+    monkeypatch.setenv("CLAWBENCH_OPENCLAW_AGENT_RUNTIME", "codex")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(tmp_path / "state"))
+
+    async def _go() -> None:
+        async with adapter:
+            ctx = _make_ctx(task, tmp_path)
+            ctx.model = "openai/gpt-5.5"
+            await adapter.setup(ctx)
+            result = await adapter.run_phase(task.phases[0], ctx)
+            assert result.error is None
+
+    asyncio.run(_go())
+
+    create_args = next(args for name, args in gateway.calls if name == "create_session")
+    assert create_args["model"] == "openai-codex/gpt-5.5"
+    auth_args = next(
+        args for name, args in gateway.calls if name == "set_session_auth_profile_override"
+    )
+    assert auth_args["auth_profile_id"] == "openai-codex:clawbench-env"
+    auth_store = json.loads(
+        (tmp_path / "state" / "agents" / "agent-stub" / "agent" / "auth-profiles.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert auth_store["profiles"]["openai-codex:clawbench-env"]["keyRef"]["id"] == "OPENAI_API_KEY"
+    assert auth_store["profiles"]["openai-codex:clawbench-env"]["key"] == "test-key"
 
 
 def test_run_phase_fails_fast_without_setup(tmp_path: Path) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,15 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from clawbench.queue import Job, JobQueue, JobStatus, SubmissionRequest
-from clawbench.worker import (
-    GATEWAY_PORT,
-    GATEWAY_PORT_SPACING,
-    OPENCLAW_EVAL_SYSTEM_PROMPT,
-    EvalWorker,
-    JobProgressTracker,
-    ParallelLane,
-)
+from clawbench.queue import JobQueue
+from clawbench.worker import GATEWAY_PORT, GATEWAY_PORT_SPACING, EvalWorker, JobProgressTracker, ParallelLane
 
 
 class DummyTask:
@@ -33,52 +26,6 @@ class DummyTask:
 
     def normalized_phases(self):
         return [object()] * self._phases
-
-
-class FakeQueue:
-    def __init__(self) -> None:
-        self.evaluating: list[str] = []
-        self.finished: list[tuple[str, str]] = []
-        self.failed: list[tuple[str, str]] = []
-        self.progress: list[tuple[str, dict[str, object]]] = []
-
-    async def mark_evaluating(self, job_id: str) -> None:
-        self.evaluating.append(job_id)
-
-    async def mark_finished(self, job_id: str, result_id: str) -> None:
-        self.finished.append((job_id, result_id))
-
-    async def mark_failed(self, job_id: str, error: str) -> None:
-        self.failed.append((job_id, error))
-
-    async def update_progress(self, job_id: str, **kwargs) -> None:
-        self.progress.append((job_id, kwargs))
-
-
-class FakeBenchmarkResult:
-    submission_id = "submission-1"
-    overall_score = 0.82
-    overall_pass_hat_k = 1.0
-
-    def model_dump(self):
-        return {
-            "submission_id": self.submission_id,
-            "overall_score": self.overall_score,
-            "overall_pass_hat_k": self.overall_pass_hat_k,
-        }
-
-
-def make_job(*, status: JobStatus = JobStatus.PENDING, lanes: int = 1) -> Job:
-    return Job(
-        job_id="job-1",
-        status=status,
-        request=SubmissionRequest(
-            model="anthropic/claude-sonnet-4-6",
-            provider="anthropic",
-            runs_per_task=1,
-            max_parallel_lanes=lanes,
-        ),
-    )
 
 
 def test_configure_browser_runtime_sets_benchmark_safe_openclaw_config(monkeypatch):
@@ -102,8 +49,23 @@ def test_configure_browser_runtime_sets_benchmark_safe_openclaw_config(monkeypat
         "approvals": {"exec": {"enabled": False}},
     }
     approvals = json.loads((state_dir / "exec-approvals.json").read_text(encoding="utf-8"))
+    assert approvals["socket"]["path"] == str(state_dir / "exec-approvals.sock")
     assert approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
     assert approvals["agents"]["*"] == {"security": "full", "ask": "off", "askFallback": "full"}
+
+
+def test_write_eval_exec_approvals_replaces_gateway_defaults(tmp_path: Path):
+    approvals_path = tmp_path / "exec-approvals.json"
+    approvals_path.write_text(
+        json.dumps({"socket": {"path": "/home/node/.openclaw/exec-approvals.sock"}}),
+        encoding="utf-8",
+    )
+
+    EvalWorker._write_eval_exec_approvals(tmp_path)
+
+    approvals = json.loads(approvals_path.read_text(encoding="utf-8"))
+    assert approvals["socket"]["path"] == str(tmp_path / "exec-approvals.sock")
+    assert approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
 
 
 def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
@@ -121,62 +83,211 @@ def test_configure_browser_runtime_pins_subagents_to_active_model(monkeypatch):
 
     worker._configure_browser_runtime(["node", "/openclaw/dist/cli.js"], {"HOME": "/tmp/home"})
 
-    assert json.loads(config_path.read_text(encoding="utf-8")) == {
-        "agents": {
-            "defaults": {
-                "skipBootstrap": True,
-                "model": {"primary": "openai-codex/gpt-5.4"},
-                "models": {"openai-codex/gpt-5.4": {"params": {"fastMode": True}}},
-                "systemPromptOverride": OPENCLAW_EVAL_SYSTEM_PROMPT,
-                "subagents": {"model": {"primary": "openai-codex/gpt-5.4"}},
-            }
-        },
-        "browser": {"headless": True, "noSandbox": True},
-        "tools": {"exec": {"host": "gateway", "security": "full", "ask": "off"}},
-        "approvals": {"exec": {"enabled": False}},
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["agents"]["defaults"] == {
+        "skipBootstrap": True,
+        "model": {"primary": "openai-codex/gpt-5.4"},
+        "subagents": {"model": {"primary": "openai-codex/gpt-5.4"}},
     }
+    assert data["browser"] == {"headless": True, "noSandbox": True}
+    assert data["tools"] == {"exec": {"host": "gateway", "security": "full", "ask": "off"}}
+    assert data["approvals"] == {"exec": {"enabled": False}}
+    assert data["models"]["providers"]["openai-codex"]["auth"] == "api-key"
 
 
-def test_configure_browser_runtime_uses_gateway_env_config_path(tmp_path: Path, monkeypatch):
+def test_configure_browser_runtime_sets_requested_agent_runtime(monkeypatch):
     worker = EvalWorker(JobQueue())
-    worker.set_active_model("openai-codex/gpt-5.4")
-    parent_state = tmp_path / "parent"
-    lane_state = tmp_path / "lane"
-    parent_state.mkdir()
-    lane_state.mkdir()
-    parent_config = parent_state / "openclaw.json"
-    lane_config = lane_state / "openclaw.json"
-    parent_config.write_text("{}", encoding="utf-8")
-    lane_config.write_text("{}", encoding="utf-8")
-    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(parent_state))
+    worker.set_active_model("openai/gpt-5.5")
+    state_dir = Path("/tmp/test-openclaw-config-runtime")
+    if state_dir.exists():
+        import shutil
 
-    worker._configure_browser_runtime(
-        ["node", "/openclaw/dist/cli.js"],
-        {
-            "OPENCLAW_STATE_DIR": str(lane_state),
-            "OPENCLAW_CONFIG_PATH": str(lane_config),
-        },
+        shutil.rmtree(state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    config_path = state_dir / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "defaults": {
+                        "models": {
+                            "openai/gpt-5.5": {"agentRuntime": {"id": "codex"}}
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("CLAWBENCH_OPENCLAW_AGENT_RUNTIME", "codex")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+
+    worker._configure_browser_runtime(["node", "/openclaw/dist/cli.js"], {"HOME": "/tmp/home"})
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["agents"]["defaults"]["agentRuntime"]["id"] == "codex"
+    models = data["agents"]["defaults"].get("models", {})
+    assert "agentRuntime" not in models.get("openai/gpt-5.5", {})
+    provider = data["models"]["providers"]["openai"]
+    assert provider["apiKey"] == "OPENAI_API_KEY"
+    assert provider["api"] == "openai-responses"
+    assert provider["auth"] == "api-key"
+    assert any(item.get("id") == "gpt-5.5" for item in provider["models"])
+    codex_provider = data["models"]["providers"]["openai-codex"]
+    assert codex_provider["apiKey"] == "OPENAI_API_KEY"
+    assert codex_provider["auth"] == "api-key"
+    assert any(item.get("id") == "gpt-5.5" for item in codex_provider["models"])
+    auth_profile = data["auth"]["profiles"]["openai-codex:clawbench-env"]
+    assert auth_profile["provider"] == "openai-codex"
+    assert auth_profile["mode"] == "api_key"
+    assert data["auth"]["order"]["openai-codex"][0] == "openai-codex:clawbench-env"
+    for agent_name in ("main", "dev"):
+        store = json.loads(
+            (state_dir / "agents" / agent_name / "agent" / "auth-profiles.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        credential = store["profiles"]["openai-codex:clawbench-env"]
+        assert credential == {
+            "type": "api_key",
+            "provider": "openai-codex",
+            "keyRef": {"source": "env", "provider": "default", "id": "OPENAI_API_KEY"},
+            "key": "test-openai-key",
+        }
+
+
+def test_configure_browser_runtime_strips_source_agent_runtime_when_unset(monkeypatch):
+    worker = EvalWorker(JobQueue())
+    worker.set_active_model("anthropic/claude-sonnet-4-6")
+    state_dir = Path("/tmp/test-openclaw-config-runtime-strip")
+    if state_dir.exists():
+        import shutil
+
+        shutil.rmtree(state_dir)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    config_path = state_dir / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "defaults": {
+                        "agentRuntime": {"id": "codex"},
+                        "models": {
+                            "openai/gpt-5.5": {"agentRuntime": {"id": "codex"}},
+                            "anthropic/claude-sonnet-4-6": {
+                                "agentRuntime": {"id": "codex"}
+                            },
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENCLAW_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("CLAWBENCH_OPENCLAW_AGENT_RUNTIME", raising=False)
+    monkeypatch.delenv("OPENCLAW_AGENT_RUNTIME", raising=False)
+
+    worker._configure_browser_runtime(["node", "/openclaw/dist/cli.js"], {"HOME": "/tmp/home"})
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    defaults = data["agents"]["defaults"]
+    assert "agentRuntime" not in defaults
+    assert "agentRuntime" not in defaults["models"]["openai/gpt-5.5"]
+    assert "agentRuntime" not in defaults["models"]["anthropic/claude-sonnet-4-6"]
+    assert defaults["model"]["primary"] == "anthropic/claude-sonnet-4-6"
+
+
+def test_sanitize_lane_state_removes_schema_incompatible_whatsapp_config(tmp_path):
+    worker = EvalWorker(JobQueue())
+    worker.set_active_model("openai-codex/gpt-5.5")
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "channels": {
+                    "telegram": {"enabled": True, "streaming": "partial"},
+                    "discord": {"enabled": True, "streaming": {"mode": "partial"}},
+                    "whatsapp": {
+                        "enabled": True,
+                        "accounts": {"default": {"name": "WhatsApp", "enabled": True}},
+                        "groupAllowFrom": ["*"],
+                    },
+                },
+                "plugins": {
+                    "allow": ["openai", "whatsapp", "marxbiotech-git-tools"],
+                    "entries": {
+                        "whatsapp": {"enabled": True},
+                        "marxbiotech-git-tools": {"enabled": True},
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
     )
 
-    assert json.loads(parent_config.read_text(encoding="utf-8")) == {}
-    lane_data = json.loads(lane_config.read_text(encoding="utf-8"))
-    assert lane_data["agents"]["defaults"]["model"]["primary"] == "openai-codex/gpt-5.4"
-    assert lane_data["tools"]["exec"] == {"host": "gateway", "security": "full", "ask": "off"}
-    assert (lane_state / "exec-approvals.json").exists()
-    assert not (parent_state / "exec-approvals.json").exists()
+    worker._sanitize_lane_state_dir(tmp_path)
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "whatsapp" not in data["channels"]
+    assert data["channels"]["telegram"]["enabled"] is False
+    assert data["channels"]["telegram"]["streaming"] == {"mode": "off"}
+    assert data["channels"]["discord"]["enabled"] is False
+    assert data["channels"]["discord"]["streaming"] == {"mode": "off"}
+    assert data["plugins"]["allow"] == ["openai"]
+    assert "whatsapp" not in data["plugins"]["entries"]
+    assert "marxbiotech-git-tools" not in data["plugins"]["entries"]
+    assert data["agents"]["defaults"]["model"]["primary"] == "openai-codex/gpt-5.5"
+    assert (tmp_path / "exec-approvals.json").exists()
 
 
-def test_eval_model_defaults_pin_openai_to_sse_transport() -> None:
-    data: dict[str, object] = {}
+def test_sanitize_lane_state_strips_codex_runtime_when_runtime_unset(tmp_path, monkeypatch):
+    worker = EvalWorker(JobQueue())
+    worker.set_active_model("anthropic/claude-opus-4-7")
+    monkeypatch.delenv("CLAWBENCH_OPENCLAW_AGENT_RUNTIME", raising=False)
+    monkeypatch.delenv("OPENCLAW_AGENT_RUNTIME", raising=False)
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "agents": {
+                    "defaults": {
+                        "agentRuntime": {"id": "codex"},
+                        "models": {
+                            "anthropic/claude-opus-4-7": {
+                                "agentRuntime": {"id": "codex"}
+                            }
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
-    changed = EvalWorker._apply_eval_model_defaults(data, "openai/gpt-5.5")
+    worker._sanitize_lane_state_dir(tmp_path)
 
-    assert changed is True
-    assert data["agents"]["defaults"]["models"]["openai/gpt-5.5"]["params"] == {
-        "fastMode": True,
-        "transport": "sse",
-        "openaiWsWarmup": False,
-    }
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    defaults = data["agents"]["defaults"]
+    assert "agentRuntime" not in defaults
+    assert "agentRuntime" not in defaults["models"]["anthropic/claude-opus-4-7"]
+    assert defaults["model"]["primary"] == "anthropic/claude-opus-4-7"
+
+
+def test_seed_lane_codex_home_copies_auth_and_config(tmp_path, monkeypatch):
+    worker = EvalWorker(JobQueue())
+    source = tmp_path / "codex-source"
+    source.mkdir()
+    (source / "auth.json").write_text('{"token":"test"}', encoding="utf-8")
+    (source / "config.toml").write_text("model = 'gpt-5.5'\n", encoding="utf-8")
+    lane_home = tmp_path / "lane-home"
+    monkeypatch.setenv("CODEX_CONFIG_SOURCE", str(source))
+
+    worker._seed_lane_codex_home(lane_home)
+
+    assert (lane_home / ".codex" / "auth.json").read_text(encoding="utf-8") == '{"token":"test"}'
+    assert (lane_home / ".codex" / "config.toml").read_text(encoding="utf-8") == "model = 'gpt-5.5'\n"
 
 
 @pytest.mark.asyncio
@@ -253,6 +364,22 @@ def test_plan_parallel_lanes_serializes_browser_tasks():
     )
 
 
+def test_plan_parallel_lanes_can_distribute_browser_tasks(monkeypatch):
+    monkeypatch.setenv("CLAWBENCH_SERIALIZE_BROWSER_LANES", "0")
+    worker = EvalWorker(JobQueue())
+    tasks = [
+        DummyTask("t1", "tier1", "coding"),
+        DummyTask("t2", "tier2", "browser"),
+        DummyTask("t3", "tier3", "browser"),
+    ]
+
+    lanes = worker._plan_parallel_lanes(tasks, requested_parallel_lanes=3)
+
+    assert len(lanes) == 3
+    assert all(len(lane.tasks) == 1 for lane in lanes)
+    assert sorted(task.id for lane in lanes for task in lane.tasks) == ["t1", "t2", "t3"]
+
+
 def test_materialize_lane_runtime_spaces_ports_and_copies_auth(tmp_path: Path, monkeypatch):
     source_state = tmp_path / "source-state"
     auth_path = source_state / "agents" / "main" / "agent"
@@ -277,178 +404,8 @@ def test_materialize_lane_runtime_spaces_ports_and_copies_auth(tmp_path: Path, m
     assert lane_cfg["tools"]["exec"] == {"host": "gateway", "security": "full", "ask": "off"}
     assert lane_cfg["approvals"]["exec"] == {"enabled": False}
     lane_approvals = json.loads((lane1.state_dir / "exec-approvals.json").read_text(encoding="utf-8"))
+    assert lane_approvals["socket"]["path"] == str(lane1.state_dir / "exec-approvals.sock")
     assert lane_approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
-
-
-@pytest.mark.asyncio
-async def test_process_job_finishes_when_optional_result_upload_fails(tmp_path: Path, monkeypatch):
-    queue = FakeQueue()
-    worker = EvalWorker(queue)  # type: ignore[arg-type]
-    cleanup_calls: list[str] = []
-
-    async def fake_run_serial_benchmark(job, tasks, progress):  # noqa: ANN001
-        progress.mark_serial(tasks[0].id, 0, stage="running")
-        return FakeBenchmarkResult()
-
-    async def fake_upload_result(result):  # noqa: ANN001
-        raise RuntimeError("hub upload unavailable")
-
-    monkeypatch.setattr("clawbench.worker.RESULTS_DIR", tmp_path)
-    monkeypatch.setattr(worker, "_load_job_tasks", lambda job: [DummyTask("t1", "tier1", "coding")])
-    monkeypatch.setattr(worker, "_run_serial_benchmark", fake_run_serial_benchmark)
-    monkeypatch.setattr(worker, "_stop_gateway", lambda: cleanup_calls.append("serial"))
-    monkeypatch.setattr(worker, "_stop_parallel_gateways", lambda: cleanup_calls.append("parallel"))
-    monkeypatch.setattr("clawbench.upload.upload_result", fake_upload_result)
-
-    await worker._process_job(make_job())
-
-    assert queue.evaluating == ["job-1"]
-    assert queue.finished == [("job-1", "submission-1")]
-    assert queue.failed == []
-    assert (tmp_path / "submission-1.json").exists()
-    assert cleanup_calls[-2:] == ["serial", "parallel"]
-    assert worker._active_model == ""
-    assert worker._serial_last_task_id is None
-
-
-@pytest.mark.asyncio
-async def test_process_job_marks_failure_and_cleans_up_after_benchmark_error(monkeypatch):
-    queue = FakeQueue()
-    worker = EvalWorker(queue)  # type: ignore[arg-type]
-    cleanup_calls: list[str] = []
-
-    async def fail_run_serial_benchmark(job, tasks, progress):  # noqa: ANN001
-        raise RuntimeError("gateway died")
-
-    monkeypatch.setattr(worker, "_load_job_tasks", lambda job: [DummyTask("t1", "tier1", "coding")])
-    monkeypatch.setattr(worker, "_run_serial_benchmark", fail_run_serial_benchmark)
-    monkeypatch.setattr(worker, "_stop_gateway", lambda: cleanup_calls.append("serial"))
-    monkeypatch.setattr(worker, "_stop_parallel_gateways", lambda: cleanup_calls.append("parallel"))
-
-    await worker._process_job(make_job())
-
-    assert queue.evaluating == ["job-1"]
-    assert queue.finished == []
-    assert queue.failed == [("job-1", "gateway died")]
-    assert cleanup_calls[-2:] == ["serial", "parallel"]
-    assert worker._active_model == ""
-    assert worker._serial_last_task_id is None
-
-
-@pytest.mark.asyncio
-async def test_process_job_does_not_reclaim_already_claimed_evaluating_job(tmp_path: Path, monkeypatch):
-    queue = FakeQueue()
-    worker = EvalWorker(queue)  # type: ignore[arg-type]
-
-    async def fake_run_serial_benchmark(job, tasks, progress):  # noqa: ANN001
-        return FakeBenchmarkResult()
-
-    async def fake_upload_result(result):  # noqa: ANN001
-        return None
-
-    monkeypatch.setattr("clawbench.worker.RESULTS_DIR", tmp_path)
-    monkeypatch.setattr(worker, "_load_job_tasks", lambda job: [DummyTask("t1", "tier1", "coding")])
-    monkeypatch.setattr(worker, "_run_serial_benchmark", fake_run_serial_benchmark)
-    monkeypatch.setattr(worker, "_stop_gateway", lambda: None)
-    monkeypatch.setattr(worker, "_stop_parallel_gateways", lambda: None)
-    monkeypatch.setattr("clawbench.upload.upload_result", fake_upload_result)
-
-    await worker._process_job(make_job(status=JobStatus.EVALUATING))
-
-    assert queue.evaluating == []
-    assert queue.finished == [("job-1", "submission-1")]
-
-
-@pytest.mark.asyncio
-async def test_run_serial_benchmark_forwards_judge_score_gate(monkeypatch):
-    queue = JobQueue()
-    worker = EvalWorker(queue)
-    captured: dict[str, object] = {}
-
-    async def fake_ensure_gateway() -> None:
-        return None
-
-    async def fake_preflight_browser_support_for_tasks(*args, **kwargs) -> None:
-        return None
-
-    class FakeHarness:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
-        async def run(self):
-            return SimpleNamespace(submission_id="submission-1")
-
-    monkeypatch.setattr(worker, "_stop_gateway", lambda: None)
-    monkeypatch.setattr(worker, "_ensure_gateway", fake_ensure_gateway)
-    monkeypatch.setattr(worker, "_preflight_browser_support_for_tasks", fake_preflight_browser_support_for_tasks)
-    monkeypatch.setattr("clawbench.worker.BenchmarkHarness", FakeHarness)
-
-    job = SimpleNamespace(
-        request=SimpleNamespace(
-            model="anthropic/claude-sonnet-4-6",
-            provider="anthropic",
-            judge_model="judge-model",
-            judge_affects_score=True,
-            runs_per_task=1,
-            tier="tier1",
-            scenario=None,
-            prompt_variant="clear",
-        )
-    )
-    progress = JobProgressTracker(total_tasks=1, runs_per_task=1, requested_parallel_lanes=1)
-
-    await worker._run_serial_benchmark(
-        job,
-        [DummyTask("t1-bugfix-discount", "tier1", "coding")],
-        progress,
-    )
-
-    assert captured["judge_model"] == "judge-model"
-    assert captured["judge_affects_score"] is True
-
-
-@pytest.mark.asyncio
-async def test_ensure_gateway_closes_parent_log_handle(monkeypatch):
-    worker = EvalWorker(JobQueue())
-    captured_handles = []
-
-    class FakeProcess:
-        returncode = None
-        pid = 123456
-
-        def poll(self):
-            return None
-
-    def fake_popen(*args, stdout=None, **kwargs):
-        captured_handles.append(stdout)
-        return FakeProcess()
-
-    class FakeResponse:
-        status_code = 200
-
-    class FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-        async def get(self, *args, **kwargs):
-            return FakeResponse()
-
-    async def fake_assert_gateway_control_plane(config):
-        return None
-
-    monkeypatch.setattr(worker, "_find_gateway_cmd", lambda: ["node", "/fake/openclaw.js"])
-    monkeypatch.setattr(worker, "_configure_browser_runtime", lambda gateway_cmd, gateway_env: None)
-    monkeypatch.setattr("clawbench.worker.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("httpx.AsyncClient", FakeAsyncClient)
-    monkeypatch.setattr(worker, "_assert_gateway_control_plane", fake_assert_gateway_control_plane)
-
-    await worker._ensure_gateway()
-
-    assert captured_handles
-    assert captured_handles[0].closed
 
 
 def test_job_progress_tracker_drops_finished_parallel_lane():


### PR DESCRIPTION
## Summary
- bind OpenClaw Codex sessions for `openai/*` models to the `openai-codex/*` runtime path
- seed eval-local OpenAI/OpenAI-Codex provider config and auth profiles for both 2026.4.x and newer OpenClaw auth profile formats
- isolate eval agent state dirs and add container adapter/lane live eval scripts
- backfill transcript tool result parsing and component token accounting needed by the adapter path

## Validation
- `.venv/bin/python -m pytest -q tests/test_client.py tests/test_openclaw_adapter.py tests/test_worker.py tests/test_dockerfiles.py` — 49 passed
- `.venv/bin/python -m pytest -q` — 305 passed, 1 skipped
- Blacksmith Testbox focused suite — 49 passed
- Blacksmith Testbox Docker build — passed (`clawbench-eval-auth-flow-v2:latest`)
- Live OpenAI/Codex adapter smoke on OpenClaw 2026.4.26 — exit 0; agent reached terminal `ok`; result JSON written
- Live OpenAI/Codex lane smoke on OpenClaw 2026.4.26 — exit 0; worker job finished; result JSON written

## Notes
This replaces the stale large branch diff with a clean branch from current `main`. It intentionally excludes local task/result artifacts and untracked governance docs.
