### PR TITLE
[codex] fix shell runtime value quoting

### DIFF
--- a/CLAWBENCH_V0_4_SPEC.md
+++ b/CLAWBENCH_V0_4_SPEC.md
@@ -167,6 +167,18 @@ Each task verifier should be classified as one of:
 
 `semantic` should be the exception, not the default.
 
+### Shell Command Placeholders
+
+Runtime placeholders in `shell: true` execution checks and background
+service commands are literal data by default. Values substituted with
+`{name}` are shell-escaped so whitespace, glob characters, redirects,
+pipes, and other metacharacters are not interpreted as shell syntax.
+
+Task authors who intentionally need a runtime value to expand as a
+shell fragment must opt in at that insertion point with `{name:raw}`.
+Use this only for benchmark-owned fragments, never for agent-produced
+or otherwise untrusted values.
+
 ## Browser Verification
 
 Browser tasks should move closer to WebArena-Verified style evaluation.

--- a/clawbench/environment.py
+++ b/clawbench/environment.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from clawbench.client import GatewayClient
 from clawbench.paths import resolve_workspace_path
-from clawbench.render import render_argv_template, render_template, render_value
+from clawbench.render import render_argv_template, render_shell_template, render_template, render_value
 from clawbench.schemas import (
     CompletionResult,
     CompletionSpec,
@@ -108,7 +108,11 @@ async def run_execution_check(
     workspace: Path,
     runtime_values: dict[str, Any],
 ) -> ExecutionCheckResult:
-    rendered_command = render_template(spec.command, runtime_values)
+    rendered_command = (
+        render_shell_template(spec.command, runtime_values)
+        if spec.shell
+        else render_template(spec.command, runtime_values)
+    )
     try:
         rendered_cwd = resolve_workspace_path(
             workspace,

--- a/clawbench/environment_files.py
+++ b/clawbench/environment_files.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from clawbench.paths import resolve_workspace_path
-from clawbench.render import render_argv_template, render_template, render_value
+from clawbench.render import render_argv_template, render_shell_template, render_template, render_value
 from clawbench.schemas import (
     ExecutionCheck,
     ExecutionCheckResult,
@@ -100,7 +100,11 @@ async def run_execution_check(
 ) -> ExecutionCheckResult:
     """Run a single `ExecutionCheck` subprocess and evaluate its output."""
 
-    rendered_command = render_template(spec.command, runtime_values)
+    rendered_command = (
+        render_shell_template(spec.command, runtime_values)
+        if spec.shell
+        else render_template(spec.command, runtime_values)
+    )
     try:
         rendered_cwd = resolve_workspace_path(
             workspace,

--- a/clawbench/render.py
+++ b/clawbench/render.py
@@ -11,6 +11,12 @@ from typing import Any, Mapping
 PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z0-9_]+)\}")
 
 
+def _stringify_template_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
+
+
 def render_template(text: str, values: Mapping[str, Any]) -> str:
     """Replace `{name}` placeholders while leaving unrelated braces alone."""
 
@@ -18,12 +24,74 @@ def render_template(text: str, values: Mapping[str, Any]) -> str:
         key = match.group(1)
         if key not in values:
             return match.group(0)
-        value = values[key]
-        if isinstance(value, (dict, list)):
-            return json.dumps(value)
-        return str(value)
+        return _stringify_template_value(values[key])
 
     return PLACEHOLDER_RE.sub(repl, text)
+
+
+def _shell_quote_context(text: str, end: int) -> str | None:
+    quote: str | None = None
+    escaped = False
+
+    for char in text[:end]:
+        if quote == "single":
+            if char == "'":
+                quote = None
+            continue
+
+        if escaped:
+            escaped = False
+            continue
+
+        if char == "\\":
+            escaped = True
+            continue
+
+        if char == "'" and quote is None:
+            quote = "single"
+        elif char == '"' and quote is None:
+            quote = "double"
+        elif char == '"' and quote == "double":
+            quote = None
+
+    return quote
+
+
+def _escape_shell_single_quoted(value: str) -> str:
+    return value.replace("'", "'\\''")
+
+
+def _escape_shell_double_quoted(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+
+
+def render_shell_template(text: str, values: Mapping[str, Any]) -> str:
+    """Render placeholders as literal shell data without breaking existing quotes."""
+
+    parts: list[str] = []
+    last = 0
+    for match in PLACEHOLDER_RE.finditer(text):
+        parts.append(text[last : match.start()])
+        key = match.group(1)
+        if key not in values:
+            parts.append(match.group(0))
+        else:
+            value = _stringify_template_value(values[key])
+            quote_context = _shell_quote_context(text, match.start())
+            if quote_context == "single":
+                parts.append(_escape_shell_single_quoted(value))
+            elif quote_context == "double":
+                parts.append(_escape_shell_double_quoted(value))
+            else:
+                parts.append(shlex.quote(value))
+        last = match.end()
+    parts.append(text[last:])
+    return "".join(parts)
 
 
 def render_argv_template(text: str, values: Mapping[str, Any]) -> list[str]:

--- a/clawbench/render.py
+++ b/clawbench/render.py
@@ -9,6 +9,7 @@ from typing import Any, Mapping
 
 
 PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z0-9_]+)\}")
+SHELL_PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z0-9_]+)(?::(raw))?\}")
 
 
 def _stringify_template_value(value: Any) -> str:
@@ -71,24 +72,27 @@ def _escape_shell_double_quoted(value: str) -> str:
 
 
 def render_shell_template(text: str, values: Mapping[str, Any]) -> str:
-    """Render placeholders as literal shell data without breaking existing quotes."""
+    """Render shell placeholders as literal data, with `{name:raw}` as an escape hatch."""
 
     parts: list[str] = []
     last = 0
-    for match in PLACEHOLDER_RE.finditer(text):
+    for match in SHELL_PLACEHOLDER_RE.finditer(text):
         parts.append(text[last : match.start()])
         key = match.group(1)
         if key not in values:
             parts.append(match.group(0))
         else:
             value = _stringify_template_value(values[key])
-            quote_context = _shell_quote_context(text, match.start())
-            if quote_context == "single":
-                parts.append(_escape_shell_single_quoted(value))
-            elif quote_context == "double":
-                parts.append(_escape_shell_double_quoted(value))
+            if match.group(2) == "raw":
+                parts.append(value)
             else:
-                parts.append(shlex.quote(value))
+                quote_context = _shell_quote_context(text, match.start())
+                if quote_context == "single":
+                    parts.append(_escape_shell_single_quoted(value))
+                elif quote_context == "double":
+                    parts.append(_escape_shell_double_quoted(value))
+                else:
+                    parts.append(shlex.quote(value))
         last = match.end()
     parts.append(text[last:])
     return "".join(parts)

--- a/clawbench/services.py
+++ b/clawbench/services.py
@@ -16,7 +16,7 @@ from typing import Any
 import httpx
 
 from clawbench.paths import resolve_workspace_path
-from clawbench.render import render_template, render_value
+from clawbench.render import render_shell_template, render_template, render_value
 from clawbench.schemas import BackgroundService
 
 
@@ -80,7 +80,7 @@ async def start_background_services(
             service_env[spec.port_env] = str(port)
         service_env.setdefault("PYTHONUNBUFFERED", "1")
 
-        command = render_template(spec.command, values)
+        command = render_shell_template(spec.command, values)
         cwd = resolve_workspace_path(
             workspace,
             render_template(spec.cwd, values),

--- a/tests/test_execution_shell_rendering.py
+++ b/tests/test_execution_shell_rendering.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -56,6 +57,36 @@ async def test_shell_execution_check_treats_metacharacters_as_data(
 
     assert result.passed is True
     assert marker.exists() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_execution_check", RUNNERS)
+async def test_shell_execution_check_raw_placeholder_allows_shell_fragments(
+    tmp_path: Path,
+    run_execution_check,
+):
+    script = tmp_path / "check_argv.py"
+    script.write_text(
+        "import json, sys\n"
+        "print(json.dumps(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+
+    result = await run_execution_check(
+        ExecutionCheck(
+            name="raw-shell-fragment-check",
+            command="{python_exe} {script} {extra_args:raw}",
+            expected_json=["one", "two"],
+        ),
+        workspace=tmp_path,
+        runtime_values={
+            "python_exe": sys.executable,
+            "script": str(script),
+            "extra_args": "one two",
+        },
+    )
+
+    assert result.passed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_shell_rendering.py
+++ b/tests/test_execution_shell_rendering.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+import pytest
+
+from clawbench.environment import run_execution_check as run_gateway_execution_check
+from clawbench.environment_files import run_execution_check as run_file_execution_check
+from clawbench.schemas import ExecutionCheck
+
+
+RUNNERS = [
+    pytest.param(run_gateway_execution_check, id="gateway"),
+    pytest.param(run_file_execution_check, id="files"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_execution_check", RUNNERS)
+async def test_shell_execution_check_quotes_unquoted_runtime_values(
+    tmp_path: Path,
+    run_execution_check,
+):
+    output = tmp_path / "report 2026.json"
+    output.write_text("success\n", encoding="utf-8")
+
+    result = await run_execution_check(
+        ExecutionCheck(
+            name="shell-path-check",
+            command="cat {output_path}",
+            stdout_contains=["success"],
+        ),
+        workspace=tmp_path,
+        runtime_values={"output_path": output.name},
+    )
+
+    assert result.passed is True
+    assert result.reason == "OK"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_execution_check", RUNNERS)
+async def test_shell_execution_check_treats_metacharacters_as_data(
+    tmp_path: Path,
+    run_execution_check,
+):
+    marker = tmp_path / "injected_marker"
+
+    result = await run_execution_check(
+        ExecutionCheck(
+            name="shell-metachar-check",
+            command="printf '%s' {title}",
+            expected_stdout="safe; touch injected_marker",
+        ),
+        workspace=tmp_path,
+        runtime_values={"title": "safe; touch injected_marker"},
+    )
+
+    assert result.passed is True
+    assert marker.exists() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_execution_check", RUNNERS)
+async def test_shell_execution_check_preserves_double_quoted_placeholders(
+    tmp_path: Path,
+    run_execution_check,
+):
+    output = tmp_path / "report $HOME.json"
+    output.write_text("success\n", encoding="utf-8")
+
+    result = await run_execution_check(
+        ExecutionCheck(
+            name="double-quoted-shell-path-check",
+            command='cat "{output_path}"',
+            stdout_contains=["success"],
+        ),
+        workspace=tmp_path,
+        runtime_values={"output_path": output.name},
+    )
+
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run_execution_check", RUNNERS)
+async def test_shell_execution_check_preserves_single_quoted_placeholders(
+    tmp_path: Path,
+    run_execution_check,
+):
+    output = tmp_path / "report '26.json"
+    output.write_text("success\n", encoding="utf-8")
+
+    result = await run_execution_check(
+        ExecutionCheck(
+            name="single-quoted-shell-path-check",
+            command="cat '{output_path}'",
+            stdout_contains=["success"],
+        ),
+        workspace=tmp_path,
+        runtime_values={"output_path": output.name},
+    )
+
+    assert result.passed is True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -37,6 +37,40 @@ async def test_background_service_waits_for_ready_file(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_background_service_quotes_runtime_values_in_shell_command(tmp_path: Path):
+    script = tmp_path / "service with space.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        "import time\n"
+        "Path('ready with space.txt').write_text('ok', encoding='utf-8')\n"
+        "time.sleep(30)\n",
+        encoding="utf-8",
+    )
+    runtime_values = build_runtime_values(
+        workspace=tmp_path,
+        repo_root=Path.cwd(),
+        extra={"script_path": script.name},
+    )
+    service = BackgroundService(
+        name="quoted_service",
+        command="{python_exe} {script_path}",
+        ready_file="ready with space.txt",
+        startup_timeout_seconds=5,
+    )
+
+    services, _ = await start_background_services(
+        [service],
+        workspace=tmp_path,
+        repo_root=Path.cwd(),
+        runtime_values=runtime_values,
+    )
+    try:
+        assert (tmp_path / "ready with space.txt").exists()
+    finally:
+        await stop_background_services(services)
+
+
+@pytest.mark.asyncio
 async def test_background_service_rejects_cwd_outside_workspace(tmp_path: Path):
     runtime_values = build_runtime_values(workspace=tmp_path, repo_root=Path.cwd())
     service = BackgroundService(


### PR DESCRIPTION
## Summary
- add quote-aware shell rendering for runtime placeholders
- use it for `shell=True` execution checks in both verifier implementations
- use the same renderer for background service commands
- add `{name:raw}` as an explicit escape hatch for benchmark-owned shell fragments
- document the shell placeholder contract in the v0.4 spec
- add regression coverage for whitespace paths, shell metacharacters, pre-quoted placeholders, raw shell fragments, and background services

## Root Cause
`ExecutionCheck.shell` defaults to `True`, but the shell path rendered placeholders with plain string substitution and then passed the command to `/bin/sh -c`. Runtime values containing whitespace were split by the shell, and metacharacters could be interpreted as shell syntax.

## Compatibility
The new renderer treats `{name}` as literal data and quotes or escapes it according to shell quote context. Templates that intentionally need a runtime value to expand as a shell fragment can opt in at that insertion point with `{name:raw}`. The spec documents that `{name:raw}` is only for benchmark-owned fragments and should not be used for agent-produced or otherwise untrusted values.

Fixes #29.

## Validation
- `/tmp/clawbench-shell-render-venv/bin/python -m pytest -q tests/test_execution_shell_rendering.py tests/test_environment_files.py tests/test_environment.py tests/test_services.py`
- `/tmp/clawbench-shell-render-venv/bin/python -m ruff check clawbench/render.py clawbench/environment.py clawbench/environment_files.py clawbench/services.py tests/test_execution_shell_rendering.py tests/test_services.py`
- `/tmp/clawbench-shell-render-venv/bin/python -m compileall clawbench/render.py clawbench/environment.py clawbench/environment_files.py clawbench/services.py`
- `git diff --check`
