### PR TITLE
fix(ci): serialize Clawbench test runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,7 @@
 
 self-hosted-runner:
   labels:
+    - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-8vcpu-ubuntu-2404
     - blacksmith-16vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ concurrency:
 jobs:
   test:
     name: Python ${{ matrix.python-version }} test suite
-    runs-on: ${{ github.repository_owner == 'openclaw' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         python-version: ["3.11", "3.12"]
 

--- a/tests/test_blacksmith_setup.py
+++ b/tests/test_blacksmith_setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 def test_ci_uses_blacksmith_for_openclaw_with_fork_fallback():
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
 
-    assert "blacksmith-8vcpu-ubuntu-2404" in workflow
+    assert "blacksmith-4vcpu-ubuntu-2404" in workflow
     assert "ubuntu-latest" in workflow
     assert "github.repository_owner == 'openclaw'" in workflow
 


### PR DESCRIPTION
## Summary
- right-size the Python CI matrix to Blacksmith 4-vCPU runners
- run the two Python versions one at a time to smooth runner registration bursts
- update actionlint allowlisting and the Blacksmith setup guard test

## Verification
- Python compile smoke passed
- Ruby YAML parse for workflow and actionlint config
- `git diff --check`
- branch autoreview clean

Full pytest was not available locally because this checkout lacks the pytest module; the workflow still runs the complete suite in CI.