### PR TITLE
ci: cancel superseded blacksmith testboxes

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clawbench-testbox-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: check


### PR DESCRIPTION
## What changed
- add workflow-level cancellation for superseded Blacksmith Testbox runs on the same ref

## Why
The org shares GitHub's runner-registration budget. ClawBench is currently green and low-volume, but the Testbox workflow should still avoid stacking stale Blacksmith runner registrations when repeated runs target the same ref.

## Evidence
- org workflow scan found the Blacksmith Testbox workflow missing concurrency
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/ci-check-testbox.yml`
- `git diff --check`
