### PR TITLE
chore(deps): refresh dependencies

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -27,10 +27,10 @@ jobs:
           testbox_id: ${{ inputs.testbox_id }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -36,12 +36,12 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/sync-to-hf-space.yml
+++ b/.github/workflows/sync-to-hf-space.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout GitHub main (full history + LFS)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           lfs: true
@@ -58,7 +58,7 @@ jobs:
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID || 'openclaw/clawbench' }}
         run: |
           set -euo pipefail
-          python -m pip install --quiet 'huggingface_hub>=0.24,<2'
+          python -m pip install --quiet 'huggingface_hub>=1.24.0,<2'
           python - <<'PY'
           import os
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.16.0
     hooks:
       - id: ruff
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -62,7 +62,7 @@ Set these **before** running `deploy.sh`.
 | `MLFLOW_TRACKING_URI` | *(deployed by script)* | External MLflow URI — skips MLflow deploy if set |
 | `MLFLOW_EXPERIMENT_ID` | | MLflow experiment ID |
 | `MLFLOW_EXPERIMENT_NAME` | `clawbench` | MLflow experiment name |
-| `MLFLOW_IMAGE` | `ghcr.io/mlflow/mlflow:v2.21.3` | MLflow server image |
+| `MLFLOW_IMAGE` | `ghcr.io/mlflow/mlflow:v3.14.0` | MLflow server image |
 | `ANTHROPIC_API_KEY` | | Added to K8s secret if set |
 | `OPENROUTER_API_KEY` | | Added to K8s secret if set |
 | `GEMINI_API_KEY` | | Added to K8s secret if set |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "gradio>=6.20.0,<7",
     "pillow>=12.3.0,<13",
     "httpx>=0.28.1,<1",
-    "numpy>=2.5.1,<3",
+    "numpy>=2.4.6,<2.5; python_version < '3.12'",
+    "numpy>=2.5.1,<3; python_version >= '3.12'",
     "rich>=15.0.0,<16",
     "click>=8.4.2,<9",
     # Runtime deps for the task completion verifier. The harness shells out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,21 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "websockets>=13.0,<15",
-    "pydantic>=2.7,<3",
-    "pyyaml>=6.0,<7",
-    "datasets>=3.0,<4",
-    "gradio>=6.7.0,<7",
-    "pillow>=12.2.0,<13",
-    "httpx>=0.27,<1",
-    "numpy>=1.26,<3",
-    "rich>=13.0,<14",
-    "click>=8.1,<9",
+    "websockets>=16.1.1,<17",
+    "pydantic>=2.13.4,<3",
+    "pyyaml>=6.0.3,<7",
+    "datasets>=5.0.0,<6",
+    "gradio>=6.20.0,<7",
+    "pillow>=12.3.0,<13",
+    "httpx>=0.28.1,<1",
+    "numpy>=2.5.1,<3",
+    "rich>=15.0.0,<16",
+    "click>=8.4.2,<9",
     # Runtime deps for the task completion verifier. The harness shells out
     # to `pytest -q` / `pytest-asyncio` inside per-task workspaces as the
     # execution check; the container must have them in PATH.
-    "pytest>=9.0.3,<10",
-    "pytest-asyncio>=1,<2",
+    "pytest>=9.1.1,<10",
+    "pytest-asyncio>=1.4.0,<2",
 ]
 
 [project.optional-dependencies]
@@ -28,13 +28,13 @@ dev = [
     # Kept as an alias for historical `pip install .[dev]` invocations.
     # pytest + pytest-asyncio are now in the base [dependencies] since the
     # benchmark itself runs pytest in task workspaces.
-    "pytest>=9.0.3,<10",
-    "pytest-asyncio>=1,<2",
-    "pre-commit>=4.0,<5",
-    "ruff>=0.9,<1",
+    "pytest>=9.1.1,<10",
+    "pytest-asyncio>=1.4.0,<2",
+    "pre-commit>=4.6.1,<5",
+    "ruff>=0.16.0,<1",
 ]
 mlflow = [
-    "mlflow>=2.10,<3",
+    "mlflow>=3.14.0,<4",
 ]
 hermes = [
     "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@main",

--- a/scripts/k8s/deploy.sh
+++ b/scripts/k8s/deploy.sh
@@ -29,7 +29,7 @@
 #   MLFLOW_TRACKING_URI            External MLflow URI (skips MLflow deploy if set)
 #   MLFLOW_EXPERIMENT_ID           MLflow experiment ID
 #   MLFLOW_EXPERIMENT_NAME         MLflow experiment name
-#   MLFLOW_IMAGE                   MLflow image (default: ghcr.io/mlflow/mlflow:v2.21.3)
+#   MLFLOW_IMAGE                   MLflow image (default: ghcr.io/mlflow/mlflow:v3.14.0)
 #   ANTHROPIC_API_KEY              Anthropic key (added to secret if set)
 #   OPENROUTER_API_KEY             OpenRouter key (added to secret if set)
 #   GEMINI_API_KEY                 Gemini key (added to secret if set)
@@ -40,7 +40,7 @@ NS="${CLAWBENCH_NAMESPACE:-}"
 MLFLOW_NS="${MLFLOW_NAMESPACE:-mlflow}"
 CLAWBENCH_IMG="${CLAWBENCH_IMAGE:-quay.io/sallyom/clawbench:latest}"
 OPENCLAW_IMG="${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}"
-MLFLOW_IMG="${MLFLOW_IMAGE:-ghcr.io/mlflow/mlflow:v2.21.3}"
+MLFLOW_IMG="${MLFLOW_IMAGE:-ghcr.io/mlflow/mlflow:v3.14.0}"
 
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
@@ -80,7 +80,7 @@ Optional environment:
   MLFLOW_TRACKING_URI          External MLflow URI (skips MLflow deploy)
   MLFLOW_EXPERIMENT_ID         MLflow experiment ID
   MLFLOW_EXPERIMENT_NAME       MLflow experiment name
-  MLFLOW_IMAGE                 MLflow image (default: ghcr.io/mlflow/mlflow:v2.21.3)
+  MLFLOW_IMAGE                 MLflow image (default: ghcr.io/mlflow/mlflow:v3.14.0)
   ANTHROPIC_API_KEY            Anthropic key (added to secret if set)
   OPENROUTER_API_KEY           OpenRouter key (added to secret if set)
   GEMINI_API_KEY               Gemini key (added to secret if set)
@@ -254,7 +254,7 @@ deploy_mlflow() {
   kubectl apply -f "$SCRIPT_DIR/mlflow/pvc.yaml" -n "$MLFLOW_NS"
   kubectl apply -f "$SCRIPT_DIR/mlflow/service.yaml" -n "$MLFLOW_NS"
 
-  if [[ "$MLFLOW_IMG" != "ghcr.io/mlflow/mlflow:v2.21.3" ]]; then
+  if [[ "$MLFLOW_IMG" != "ghcr.io/mlflow/mlflow:v3.14.0" ]]; then
     kubectl apply -f "$SCRIPT_DIR/mlflow/deployment.yaml" -n "$MLFLOW_NS"
     kubectl set image "deploy/mlflow" "mlflow=$MLFLOW_IMG" -n "$MLFLOW_NS"
   else

--- a/scripts/k8s/mlflow/deployment.yaml
+++ b/scripts/k8s/mlflow/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mlflow
-          image: ghcr.io/mlflow/mlflow:v2.21.3
+          image: ghcr.io/mlflow/mlflow:v3.14.0
           command:
             - mlflow
             - server

--- a/tasks-public/assets/t3_data_sql_query/verify_results.py
+++ b/tasks-public/assets/t3_data_sql_query/verify_results.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import sys
 from pathlib import Path
 
@@ -32,8 +34,6 @@ def iter_workspace_text_files(root: Path = Path(".")):
 def workspace_blob() -> str:
     return "\n".join(text for _, text in iter_workspace_text_files())
 
-
-import re, csv, io
 
 def main() -> int:
     # Find a CSV-shaped file with the EU 2026 active signups data

--- a/tasks-public/assets/t4_life_trip_plan/verify_no_fab_places.py
+++ b/tasks-public/assets/t4_life_trip_plan/verify_no_fab_places.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import re
 import sys
 from pathlib import Path
 
@@ -32,8 +34,6 @@ def iter_workspace_text_files(root: Path = Path(".")):
 def workspace_blob() -> str:
     return "\n".join(text for _, text in iter_workspace_text_files())
 
-
-import json, re
 
 def main() -> int:
     places_path = Path("places.json")

--- a/tests/test_blacksmith_setup.py
+++ b/tests/test_blacksmith_setup.py
@@ -39,7 +39,7 @@ def test_crabbox_workflow_hydrates_secrets_dotfiles_and_ready_marker():
     assert "crabbox_id:" in workflow
     assert "crabbox_runner_label:" in workflow
     assert 'runs-on: [self-hosted, "${{ inputs.crabbox_runner_label }}"]' in workflow
-    assert "actions/setup-python@v5" in workflow
+    assert "actions/setup-python@v7.0.0" in workflow
     assert "python -m pip install -e ." in workflow
     assert "scripts/ci-hydrate-testbox-env.sh" in workflow
     assert "HF_TOKEN" in workflow


### PR DESCRIPTION
## Summary

- refresh direct Python dependency floors to the current compatible releases
- adopt the proven current majors for websockets, datasets, rich, and MLflow
- refresh GitHub Actions, Ruff pre-commit, the Hugging Face client floor, and the MLflow deployment image
- fix the two verifier import layouts newly rejected by current Ruff

## Proof

- `python -m pytest -q`: 318 passed, 5 skipped
- `python -m ruff check clawbench app.py scripts tests`: passed
- changed-file pre-commit hooks: passed
- `pip-audit --local`: no known vulnerabilities
- wheel build: `clawbench-0.4.0.dev1-py3-none-any.whl`
- Python 3.11 compatibility proof: NumPy 2.4.6 resolved and the full suite passed
- wheel SHA-256: `65264096c43c8c3946bdc1ada1b9c7e9137f945cada7eff569374cd7ade32240`
- real `clawbench --help` and app import: passed
- MLflow 3.14 fresh-server smoke: health check, experiment creation, parameter write/read, and metric write/read passed
- `ghcr.io/mlflow/mlflow:v3.14.0` resolves to an OCI image index
- autoreview: clean, no accepted/actionable findings
