### PR TITLE
feat(eval): add auditable native matrix runner

### DIFF
--- a/scripts/native_eval/__init__.py
+++ b/scripts/native_eval/__init__.py
@@ -1,0 +1,2 @@
+"""Native ShellBench matrix runner."""
+

--- a/scripts/native_eval/__init__.py
+++ b/scripts/native_eval/__init__.py
@@ -1,2 +1,1 @@
 """Native ShellBench matrix runner."""
-

--- a/scripts/native_eval/aggregate.py
+++ b/scripts/native_eval/aggregate.py
@@ -107,6 +107,10 @@ PER_TASK_FIELDS = (
     "n_cache_tokens",
     "n_output_tokens",
     "cost_usd",
+    "source",
+    "trajectory_status",
+    "runtime_model_name",
+    "canonical_model_identity",
 )
 
 RUN_FIELDS = (
@@ -131,6 +135,9 @@ RUN_FIELDS = (
     "infra_dominated",
     "harness_wide_failure",
     "harness_wide_failure_signature",
+    "canonical_model_identity",
+    "trajectory_complete",
+    "parity_validated",
     "eligible",
     "exclusion_reason",
     "n_input_tokens",
@@ -444,6 +451,10 @@ def _normalize_result(
             "estimated_cost_usd",
             "total_cost_usd",
         ),
+        "source": str(result.get("source") or ""),
+        "trajectory_status": str(agent_result.get("trajectory_status") or ""),
+        "runtime_model_name": str(agent_result.get("runtime_model_name") or ""),
+        "canonical_model_identity": agent_result.get("canonical_model_identity"),
         "_has_result_file": True,
         "_valid_result": True,
         "_completed_result": bool(result.get("finished_at")),
@@ -620,6 +631,7 @@ def _load_run(run_dir: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         repetition=repetition,
         expected_count=expected_count,
         rows=rows,
+        manifest=manifest,
     )
     return summary, rows
 
@@ -664,6 +676,7 @@ def _summarize_run(
     repetition: int | None,
     expected_count: int,
     rows: Sequence[dict[str, Any]],
+    manifest: dict[str, Any],
 ) -> dict[str, Any]:
     classifications = [str(row["classification"]) for row in rows]
     rewards = [_number(row.get("reward")) for row in rows]
@@ -700,13 +713,47 @@ def _summarize_run(
         rows,
         expected_count,
     )
-    eligible = not incomplete and not infra_dominated and not harness_wide_failure
+    native_run = (
+        manifest.get("runner") == "shellbench-native"
+        or any(row.get("source") == "shellbench-native" for row in rows)
+    )
+    canonical_model_identity = not native_run or (
+        manifest.get("canonical_model_identity") is True
+        and all(
+            row.get("canonical_model_identity") is True
+            for row in rows
+            if row.get("_valid_result")
+        )
+    )
+    trajectory_complete = not native_run or (
+        manifest.get("trajectory_mode") == "real_harness_events"
+        and all(
+            row.get("trajectory_status") == "real"
+            for row in rows
+            if row.get("_valid_result")
+        )
+    )
+    parity_validated = not native_run or manifest.get("parity_validated") is True
+    eligible = (
+        not incomplete
+        and not infra_dominated
+        and not harness_wide_failure
+        and canonical_model_identity
+        and trajectory_complete
+        and parity_validated
+    )
     if incomplete:
         exclusion_reason = "incomplete"
     elif infra_dominated:
         exclusion_reason = "infra_dominated"
     elif harness_wide_failure:
         exclusion_reason = "harness_wide_failure"
+    elif not canonical_model_identity:
+        exclusion_reason = "canonical_model_identity_not_preserved"
+    elif not trajectory_complete:
+        exclusion_reason = "trajectory_unavailable"
+    elif not parity_validated:
+        exclusion_reason = "parity_not_validated"
     else:
         exclusion_reason = ""
 
@@ -732,6 +779,9 @@ def _summarize_run(
         "infra_dominated": infra_dominated,
         "harness_wide_failure": harness_wide_failure,
         "harness_wide_failure_signature": harness_wide_failure_signature,
+        "canonical_model_identity": canonical_model_identity,
+        "trajectory_complete": trajectory_complete,
+        "parity_validated": parity_validated,
         "eligible": eligible,
         "exclusion_reason": exclusion_reason,
         "n_input_tokens": _sum_present(rows, "n_input_tokens"),

--- a/scripts/native_eval/aggregate.py
+++ b/scripts/native_eval/aggregate.py
@@ -458,6 +458,7 @@ def _normalize_result(
         "_has_result_file": True,
         "_valid_result": True,
         "_completed_result": bool(result.get("finished_at")),
+        "_scorable": True,
     }
     for field in TIMING_FIELDS:
         timing = result.get(field)
@@ -482,6 +483,7 @@ def _infra_row(
     exception_type: str,
     exception_message: str,
     has_result_file: bool,
+    scorable: bool = True,
 ) -> dict[str, Any]:
     row = {field: "" for field in PER_TASK_FIELDS}
     row.update(
@@ -500,9 +502,27 @@ def _infra_row(
             "_has_result_file": has_result_file,
             "_valid_result": False,
             "_completed_result": False,
+            "_scorable": scorable,
         }
     )
     return row
+
+
+def _exclude_row(
+    row: dict[str, Any],
+    *,
+    exception_type: str,
+    exception_message: str,
+) -> None:
+    row.update(
+        {
+            "classification": "infra",
+            "reward": None,
+            "exception_type": exception_type,
+            "exception_message": exception_message,
+            "_scorable": False,
+        }
+    )
 
 
 def _matches_expected(row: dict[str, Any], task_name: str, task_path: str) -> bool:
@@ -571,28 +591,53 @@ def _load_run(run_dir: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         )
 
     expected_tasks = _expected_tasks(manifest)
-    for task_name, task_path in expected_tasks:
-        if any(_matches_expected(row, task_name, task_path) for row in rows):
-            continue
-        trial_name = task_name or Path(task_path).name
-        rows.append(
-            _infra_row(
-                run_label=run_label,
-                pair_label=pair_label,
-                repetition=repetition,
-                task_name=task_name or trial_name,
-                task_path=task_path,
-                trial_name=trial_name,
-                result_path=run_dir / trial_name / "result.json",
-                exception_type="MissingResultError",
-                exception_message="expected task produced no result.json",
-                has_result_file=False,
+    if expected_tasks:
+        available = set(range(len(rows)))
+        for task_name, task_path in expected_tasks:
+            matches = [
+                index
+                for index in sorted(available)
+                if _matches_expected(rows[index], task_name, task_path)
+            ]
+            if not matches:
+                trial_name = task_name or Path(task_path).name
+                rows.append(
+                    _infra_row(
+                        run_label=run_label,
+                        pair_label=pair_label,
+                        repetition=repetition,
+                        task_name=task_name or trial_name,
+                        task_path=task_path,
+                        trial_name=trial_name,
+                        result_path=run_dir / trial_name / "result.json",
+                        exception_type="MissingResultError",
+                        exception_message="expected task produced no result.json",
+                        has_result_file=False,
+                    )
+                )
+                continue
+            selected = matches[0]
+            available.remove(selected)
+            rows[selected]["_scorable"] = True
+            for duplicate in matches[1:]:
+                available.remove(duplicate)
+                _exclude_row(
+                    rows[duplicate],
+                    exception_type="DuplicateTaskResultError",
+                    exception_message=(
+                        f"multiple result.json files matched expected task {task_name}"
+                    ),
+                )
+        for index in sorted(available):
+            _exclude_row(
+                rows[index],
+                exception_type="UnexpectedTaskResultError",
+                exception_message="result.json does not match any expected task",
             )
-        )
 
     expected_count = _expected_task_count(manifest, expected_tasks, len(rows))
-    while len(rows) < expected_count:
-        missing_index = len(rows) + 1
+    while sum(bool(row.get("_scorable")) for row in rows) < expected_count:
+        missing_index = sum(bool(row.get("_scorable")) for row in rows) + 1
         rows.append(
             _infra_row(
                 run_label=run_label,
@@ -621,6 +666,7 @@ def _load_run(run_dir: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
                 exception_type="InvalidManifestError",
                 exception_message=manifest_error,
                 has_result_file=False,
+                scorable=False,
             )
         )
 
@@ -678,8 +724,10 @@ def _summarize_run(
     rows: Sequence[dict[str, Any]],
     manifest: dict[str, Any],
 ) -> dict[str, Any]:
-    classifications = [str(row["classification"]) for row in rows]
-    rewards = [_number(row.get("reward")) for row in rows]
+    scored_rows = [row for row in rows if row.get("_scorable")]
+    classifications = [str(row["classification"]) for row in scored_rows]
+    rewards = [_number(row.get("reward")) for row in scored_rows]
+    all_classifications = [str(row["classification"]) for row in rows]
     result_file_count = sum(bool(row.get("_has_result_file")) for row in rows)
     valid_result_count = sum(bool(row.get("_valid_result")) for row in rows)
     completed_result_count = sum(bool(row.get("_completed_result")) for row in rows)
@@ -688,7 +736,7 @@ def _summarize_run(
         for classification, reward in zip(classifications, rewards)
     )
     partials = classifications.count("partial")
-    infra = classifications.count("infra")
+    infra = all_classifications.count("infra")
     agent_exits = classifications.count("agent_exit")
     missing_reward = classifications.count("verifier_missing_reward")
     clean_completed = sum(
@@ -704,9 +752,10 @@ def _summarize_run(
     clean_coverage = clean_completed / expected_count if expected_count else 0.0
     incomplete = (
         expected_count <= 0
-        or result_file_count < expected_count
-        or valid_result_count < expected_count
-        or completed_result_count < expected_count
+        or len(scored_rows) != expected_count
+        or result_file_count != expected_count
+        or valid_result_count != expected_count
+        or completed_result_count != expected_count
     )
     infra_dominated = expected_count > 0 and infra > expected_count / 2
     harness_wide_failure, harness_wide_failure_signature = _harness_wide_failure(
@@ -721,7 +770,7 @@ def _summarize_run(
         manifest.get("canonical_model_identity") is True
         and all(
             row.get("canonical_model_identity") is True
-            for row in rows
+            for row in scored_rows
             if row.get("_valid_result")
         )
     )
@@ -729,7 +778,7 @@ def _summarize_run(
         manifest.get("trajectory_mode") == "real_harness_events"
         and all(
             row.get("trajectory_status") == "real"
-            for row in rows
+            for row in scored_rows
             if row.get("_valid_result")
         )
     )
@@ -784,10 +833,10 @@ def _summarize_run(
         "parity_validated": parity_validated,
         "eligible": eligible,
         "exclusion_reason": exclusion_reason,
-        "n_input_tokens": _sum_present(rows, "n_input_tokens"),
-        "n_cache_tokens": _sum_present(rows, "n_cache_tokens"),
-        "n_output_tokens": _sum_present(rows, "n_output_tokens"),
-        "cost_usd": _sum_present(rows, "cost_usd"),
+        "n_input_tokens": _sum_present(scored_rows, "n_input_tokens"),
+        "n_cache_tokens": _sum_present(scored_rows, "n_cache_tokens"),
+        "n_output_tokens": _sum_present(scored_rows, "n_output_tokens"),
+        "cost_usd": _sum_present(scored_rows, "cost_usd"),
     }
 
 

--- a/scripts/native_eval/aggregate.py
+++ b/scripts/native_eval/aggregate.py
@@ -42,6 +42,7 @@ INFRA_EXCEPTION_TYPES = {
     "InvalidManifestError",
     "InvalidResultError",
     "MissingResultError",
+    "VerifierJudgeInfraError",
     "VerifierTimeoutError",
 }
 
@@ -261,6 +262,28 @@ def _classify(result: dict[str, Any], reward: int | float | None) -> str:
     return "pass"
 
 
+def _scorecard_infra_error(trial_dir: Path) -> tuple[str, str] | None:
+    scorecard_path = trial_dir / "verifier" / "scorecard.json"
+    if not scorecard_path.is_file():
+        return None
+    scorecard, error = _read_json(scorecard_path)
+    if scorecard is None or scorecard.get("status") != "infra_error":
+        return None
+
+    reasons = scorecard.get("judge_reasons")
+    if isinstance(reasons, list):
+        message = "; ".join(str(reason) for reason in reasons if reason)
+    else:
+        message = ""
+    if not message:
+        message = str(
+            scorecard.get("reason")
+            or error
+            or "verifier scorecard reported infrastructure failure"
+        )
+    return "VerifierJudgeInfraError", message[:2000]
+
+
 def _manifest_value(manifest: dict[str, Any], *keys: str) -> Any:
     for key in keys:
         value = manifest.get(key)
@@ -389,6 +412,9 @@ def _normalize_result(
     task_name, task_path, trial_name = _task_identity(result, result_path.parent)
     reward = _reward(result)
     exception_type, exception_message, exception_occurred_at = _exception_fields(result)
+    scorecard_infra = _scorecard_infra_error(result_path.parent)
+    if scorecard_infra is not None:
+        exception_type, exception_message = scorecard_infra
     agent_result = result.get("agent_result")
     agent_result = agent_result if isinstance(agent_result, dict) else {}
     row: dict[str, Any] = {
@@ -399,7 +425,9 @@ def _normalize_result(
         "task_path": task_path,
         "trial_name": trial_name,
         "result_path": str(result_path),
-        "classification": _classify(result, reward),
+        "classification": (
+            "infra" if scorecard_infra is not None else _classify(result, reward)
+        ),
         "reward": reward,
         "exception_type": exception_type,
         "exception_message": exception_message,

--- a/scripts/native_eval/aggregate.py
+++ b/scripts/native_eval/aggregate.py
@@ -761,10 +761,7 @@ def _pair_summaries(runs: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
                 "pass_rate": (
                     sum(exact_passes) / total_expected if total_expected else None
                 ),
-                "clean_complete_repetitions": sum(
-                    run["clean_completed"] == run["expected_task_count"]
-                    for run in eligible
-                ),
+                "clean_complete_repetitions": len(eligible),
                 "mean_coverage": _mean([float(run["coverage"]) for run in eligible]),
                 "mean_clean_completed": _mean(
                     [int(run["clean_completed"]) for run in eligible]

--- a/scripts/native_eval/aggregate.py
+++ b/scripts/native_eval/aggregate.py
@@ -1,0 +1,930 @@
+"""Aggregate native ShellBench Harbor job directories.
+
+The postprocessor intentionally uses only the Python standard library so it can
+run directly on a copied Harbor job directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import statistics
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+CLASSIFICATIONS = (
+    "infra",
+    "agent_exit",
+    "verifier_missing_reward",
+    "clean_fail",
+    "partial",
+    "pass",
+)
+
+AGENT_EXIT_EXCEPTION_TYPES = {
+    "AgentSafetyRefusalError",
+    "AgentTimeoutError",
+    "NonZeroAgentExitCodeError",
+}
+
+INFRA_EXCEPTION_TYPES = {
+    "AgentSetupTimeoutError",
+    "DockerStartupError",
+    "EnvironmentStartTimeoutError",
+    "GatewaySetupError",
+    "GatewayTimeoutError",
+    "InvalidManifestError",
+    "InvalidResultError",
+    "MissingResultError",
+    "VerifierTimeoutError",
+}
+
+INFRA_MESSAGE_PATTERNS = (
+    "connection refused",
+    "connection reset",
+    "docker daemon",
+    "docker startup",
+    "failed to connect",
+    "gateway",
+    "host.docker.internal",
+    "litellm",
+    "model not found",
+    "no healthy upstream",
+    "proxy",
+    "service unavailable",
+    "timed out waiting for container",
+    "upstream connect",
+)
+
+MISSING_REWARD_EXCEPTION_TYPES = {
+    "RewardFileEmptyError",
+    "RewardFileNotFoundError",
+}
+
+TIMING_FIELDS = (
+    "environment_setup",
+    "agent_setup",
+    "agent_execution",
+    "verifier",
+)
+
+PER_TASK_FIELDS = (
+    "run_label",
+    "pair_label",
+    "repetition",
+    "task_name",
+    "task_path",
+    "trial_name",
+    "result_path",
+    "classification",
+    "reward",
+    "exception_type",
+    "exception_message",
+    "exception_occurred_at",
+    "started_at",
+    "finished_at",
+    "duration_sec",
+    "environment_setup_started_at",
+    "environment_setup_finished_at",
+    "environment_setup_sec",
+    "agent_setup_started_at",
+    "agent_setup_finished_at",
+    "agent_setup_sec",
+    "agent_execution_started_at",
+    "agent_execution_finished_at",
+    "agent_execution_sec",
+    "verifier_started_at",
+    "verifier_finished_at",
+    "verifier_sec",
+    "n_input_tokens",
+    "n_cache_tokens",
+    "n_output_tokens",
+    "cost_usd",
+)
+
+RUN_FIELDS = (
+    "run_label",
+    "pair_label",
+    "repetition",
+    "expected_task_count",
+    "result_file_count",
+    "valid_result_count",
+    "completed_result_count",
+    "coverage",
+    "score",
+    "exact_passes",
+    "partials",
+    "nonzero",
+    "infra",
+    "agent_exits",
+    "clean_completed",
+    "missing_reward",
+    "clean_coverage",
+    "incomplete",
+    "infra_dominated",
+    "harness_wide_failure",
+    "harness_wide_failure_signature",
+    "eligible",
+    "exclusion_reason",
+    "n_input_tokens",
+    "n_cache_tokens",
+    "n_output_tokens",
+    "cost_usd",
+)
+
+INFRA_FIELDS = (
+    "run_label",
+    "pair_label",
+    "repetition",
+    "task_name",
+    "task_path",
+    "trial_name",
+    "result_path",
+    "exception_type",
+    "exception_message",
+    "exception_occurred_at",
+)
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(value, dict):
+        return None, f"expected a JSON object, found {type(value).__name__}"
+    return value, None
+
+
+def _number(value: Any) -> int | float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = value
+    elif isinstance(value, str):
+        try:
+            number = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not math.isfinite(float(number)):
+        return None
+    return number
+
+
+def _integer(value: Any) -> int | None:
+    number = _number(value)
+    if number is None or int(number) != number:
+        return None
+    return int(number)
+
+
+def _nested(mapping: dict[str, Any], *keys: str) -> Any:
+    value: Any = mapping
+    for key in keys:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _duration_seconds(started_at: Any, finished_at: Any) -> float | None:
+    started = _parse_datetime(started_at)
+    finished = _parse_datetime(finished_at)
+    if started is None or finished is None:
+        return None
+    try:
+        return round((finished - started).total_seconds(), 6)
+    except TypeError:
+        return None
+
+
+def _exception_fields(result: dict[str, Any]) -> tuple[str, str, str]:
+    exception = result.get("exception_info")
+    if not isinstance(exception, dict):
+        return "", "", ""
+    return (
+        str(exception.get("exception_type") or ""),
+        str(exception.get("exception_message") or ""),
+        str(exception.get("occurred_at") or ""),
+    )
+
+
+def _reward(result: dict[str, Any]) -> int | float | None:
+    return _number(_nested(result, "verifier_result", "rewards", "reward"))
+
+
+def _is_agent_exit(exception_type: str) -> bool:
+    return exception_type in AGENT_EXIT_EXCEPTION_TYPES or (
+        exception_type.endswith("AgentExitCodeError")
+    )
+
+
+def _is_infra(exception_type: str, exception_message: str) -> bool:
+    if exception_type in INFRA_EXCEPTION_TYPES:
+        return True
+    combined = f"{exception_type} {exception_message}".lower()
+    return any(pattern in combined for pattern in INFRA_MESSAGE_PATTERNS)
+
+
+def _classify(result: dict[str, Any], reward: int | float | None) -> str:
+    exception_type, exception_message, _ = _exception_fields(result)
+    if exception_type in MISSING_REWARD_EXCEPTION_TYPES:
+        return "verifier_missing_reward"
+    if exception_type:
+        if _is_infra(exception_type, exception_message):
+            return "infra"
+        return "agent_exit"
+    if reward is None:
+        return "verifier_missing_reward"
+    if reward <= 0:
+        return "clean_fail"
+    if reward < 1:
+        return "partial"
+    return "pass"
+
+
+def _manifest_value(manifest: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = manifest.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _derive_repetition(run_label: str) -> int | None:
+    match = re.search(r"(?:^|[-_])(?:rep(?:etition)?|repeat|r)[-_]?(\d+)$", run_label, re.I)
+    return int(match.group(1)) if match else None
+
+
+def _derive_pair_label(run_label: str) -> str:
+    return re.sub(
+        r"(?:[-_])(?:rep(?:etition)?|repeat|r)[-_]?\d+$",
+        "",
+        run_label,
+        flags=re.I,
+    )
+
+
+def _pair_label(manifest: dict[str, Any], run_label: str) -> str:
+    value = _manifest_value(
+        manifest,
+        "pair_label",
+        "pair_name",
+        "comparison_pair",
+        "base_label",
+        "pair",
+    )
+    if isinstance(value, dict):
+        value = _manifest_value(value, "label", "name", "id")
+    if value is not None:
+        return str(value)
+    harness = manifest.get("harness")
+    model_slug = manifest.get("model_slug")
+    if harness and model_slug:
+        return f"{harness}-{model_slug}"
+    return _derive_pair_label(run_label)
+
+
+def _repetition(manifest: dict[str, Any], run_label: str) -> int | None:
+    value = _manifest_value(
+        manifest,
+        "repetition",
+        "repetition_index",
+        "repeat",
+        "repeat_index",
+    )
+    return _integer(value) if value is not None else _derive_repetition(run_label)
+
+
+def _task_reference(item: Any) -> tuple[str, str] | None:
+    if isinstance(item, str):
+        path = item
+        return Path(path).name or path, path
+    if not isinstance(item, dict):
+        return None
+    path_value = _manifest_value(item, "path", "task_path")
+    name_value = _manifest_value(item, "task_name", "name", "id")
+    if isinstance(path_value, dict):
+        path_value = path_value.get("path")
+    path = str(path_value or "")
+    name = str(name_value or (Path(path).name if path else ""))
+    return (name, path) if name or path else None
+
+
+def _expected_tasks(manifest: dict[str, Any]) -> list[tuple[str, str]]:
+    for key in ("tasks", "expected_tasks", "task_paths"):
+        value = manifest.get(key)
+        if not isinstance(value, list):
+            continue
+        tasks = [task for item in value if (task := _task_reference(item)) is not None]
+        if tasks:
+            return tasks
+    return []
+
+
+def _expected_task_count(
+    manifest: dict[str, Any],
+    expected_tasks: Sequence[tuple[str, str]],
+    discovered_count: int,
+) -> int:
+    value = _manifest_value(
+        manifest,
+        "expected_task_count",
+        "task_count",
+        "expected_trials",
+        "n_tasks",
+    )
+    explicit = _integer(value)
+    if explicit is not None and explicit >= 0:
+        return explicit
+    if expected_tasks:
+        return len(expected_tasks)
+    return discovered_count
+
+
+def _task_identity(result: dict[str, Any], trial_dir: Path) -> tuple[str, str, str]:
+    task_path = _nested(result, "task_id", "path")
+    task_path = str(task_path or "")
+    task_name = str(result.get("task_name") or "")
+    if not task_name and task_path:
+        task_name = Path(task_path).name
+    trial_name = str(result.get("trial_name") or trial_dir.name)
+    return task_name or trial_name, task_path, trial_name
+
+
+def _usage_value(agent_result: dict[str, Any], *keys: str) -> int | float | None:
+    for key in keys:
+        value = _number(agent_result.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _normalize_result(
+    *,
+    result: dict[str, Any],
+    result_path: Path,
+    run_label: str,
+    pair_label: str,
+    repetition: int | None,
+) -> dict[str, Any]:
+    task_name, task_path, trial_name = _task_identity(result, result_path.parent)
+    reward = _reward(result)
+    exception_type, exception_message, exception_occurred_at = _exception_fields(result)
+    agent_result = result.get("agent_result")
+    agent_result = agent_result if isinstance(agent_result, dict) else {}
+    row: dict[str, Any] = {
+        "run_label": run_label,
+        "pair_label": pair_label,
+        "repetition": repetition,
+        "task_name": task_name,
+        "task_path": task_path,
+        "trial_name": trial_name,
+        "result_path": str(result_path),
+        "classification": _classify(result, reward),
+        "reward": reward,
+        "exception_type": exception_type,
+        "exception_message": exception_message,
+        "exception_occurred_at": exception_occurred_at,
+        "started_at": result.get("started_at") or "",
+        "finished_at": result.get("finished_at") or "",
+        "duration_sec": _duration_seconds(result.get("started_at"), result.get("finished_at")),
+        "n_input_tokens": _usage_value(agent_result, "n_input_tokens", "input_tokens"),
+        "n_cache_tokens": _usage_value(agent_result, "n_cache_tokens", "cache_tokens"),
+        "n_output_tokens": _usage_value(agent_result, "n_output_tokens", "output_tokens"),
+        "cost_usd": _usage_value(
+            agent_result,
+            "cost_usd",
+            "estimated_cost_usd",
+            "total_cost_usd",
+        ),
+        "_has_result_file": True,
+        "_valid_result": True,
+        "_completed_result": bool(result.get("finished_at")),
+    }
+    for field in TIMING_FIELDS:
+        timing = result.get(field)
+        timing = timing if isinstance(timing, dict) else {}
+        started_at = timing.get("started_at") or ""
+        finished_at = timing.get("finished_at") or ""
+        row[f"{field}_started_at"] = started_at
+        row[f"{field}_finished_at"] = finished_at
+        row[f"{field}_sec"] = _duration_seconds(started_at, finished_at)
+    return row
+
+
+def _infra_row(
+    *,
+    run_label: str,
+    pair_label: str,
+    repetition: int | None,
+    task_name: str,
+    task_path: str,
+    trial_name: str,
+    result_path: Path,
+    exception_type: str,
+    exception_message: str,
+    has_result_file: bool,
+) -> dict[str, Any]:
+    row = {field: "" for field in PER_TASK_FIELDS}
+    row.update(
+        {
+            "run_label": run_label,
+            "pair_label": pair_label,
+            "repetition": repetition,
+            "task_name": task_name,
+            "task_path": task_path,
+            "trial_name": trial_name,
+            "result_path": str(result_path),
+            "classification": "infra",
+            "reward": None,
+            "exception_type": exception_type,
+            "exception_message": exception_message,
+            "_has_result_file": has_result_file,
+            "_valid_result": False,
+            "_completed_result": False,
+        }
+    )
+    return row
+
+
+def _matches_expected(row: dict[str, Any], task_name: str, task_path: str) -> bool:
+    candidates = {
+        str(row.get("task_name") or ""),
+        str(row.get("task_path") or ""),
+        Path(str(row.get("task_path") or "")).name,
+    }
+    return bool({task_name, task_path, Path(task_path).name if task_path else ""} & candidates)
+
+
+def _load_run(run_dir: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    run_label = run_dir.name
+    manifest_path = run_dir / "run_manifest.json"
+    manifest, manifest_error = _read_json(manifest_path)
+    manifest = manifest or {}
+    run_label = str(manifest.get("run_label") or run_label)
+    pair_label = _pair_label(manifest, run_label)
+    repetition = _repetition(manifest, run_label)
+
+    rows: list[dict[str, Any]] = []
+    trial_dirs = sorted(path for path in run_dir.iterdir() if path.is_dir())
+    for trial_dir in trial_dirs:
+        result_path = trial_dir / "result.json"
+        if not result_path.is_file():
+            rows.append(
+                _infra_row(
+                    run_label=run_label,
+                    pair_label=pair_label,
+                    repetition=repetition,
+                    task_name=trial_dir.name,
+                    task_path="",
+                    trial_name=trial_dir.name,
+                    result_path=result_path,
+                    exception_type="MissingResultError",
+                    exception_message="trial directory has no result.json",
+                    has_result_file=False,
+                )
+            )
+            continue
+        result, error = _read_json(result_path)
+        if result is None:
+            rows.append(
+                _infra_row(
+                    run_label=run_label,
+                    pair_label=pair_label,
+                    repetition=repetition,
+                    task_name=trial_dir.name,
+                    task_path="",
+                    trial_name=trial_dir.name,
+                    result_path=result_path,
+                    exception_type="InvalidResultError",
+                    exception_message=error or "invalid result.json",
+                    has_result_file=True,
+                )
+            )
+            continue
+        rows.append(
+            _normalize_result(
+                result=result,
+                result_path=result_path,
+                run_label=run_label,
+                pair_label=pair_label,
+                repetition=repetition,
+            )
+        )
+
+    expected_tasks = _expected_tasks(manifest)
+    for task_name, task_path in expected_tasks:
+        if any(_matches_expected(row, task_name, task_path) for row in rows):
+            continue
+        trial_name = task_name or Path(task_path).name
+        rows.append(
+            _infra_row(
+                run_label=run_label,
+                pair_label=pair_label,
+                repetition=repetition,
+                task_name=task_name or trial_name,
+                task_path=task_path,
+                trial_name=trial_name,
+                result_path=run_dir / trial_name / "result.json",
+                exception_type="MissingResultError",
+                exception_message="expected task produced no result.json",
+                has_result_file=False,
+            )
+        )
+
+    expected_count = _expected_task_count(manifest, expected_tasks, len(rows))
+    while len(rows) < expected_count:
+        missing_index = len(rows) + 1
+        rows.append(
+            _infra_row(
+                run_label=run_label,
+                pair_label=pair_label,
+                repetition=repetition,
+                task_name=f"<missing-{missing_index}>",
+                task_path="",
+                trial_name=f"<missing-{missing_index}>",
+                result_path=run_dir / f"<missing-{missing_index}>" / "result.json",
+                exception_type="MissingResultError",
+                exception_message="expected task produced no trial directory",
+                has_result_file=False,
+            )
+        )
+
+    if manifest_error:
+        rows.append(
+            _infra_row(
+                run_label=run_label,
+                pair_label=pair_label,
+                repetition=repetition,
+                task_name="<run-manifest>",
+                task_path="",
+                trial_name="<run-manifest>",
+                result_path=manifest_path,
+                exception_type="InvalidManifestError",
+                exception_message=manifest_error,
+                has_result_file=False,
+            )
+        )
+
+    rows.sort(key=lambda row: (str(row["task_name"]), str(row["trial_name"])))
+    summary = _summarize_run(
+        run_label=run_label,
+        pair_label=pair_label,
+        repetition=repetition,
+        expected_count=expected_count,
+        rows=rows,
+    )
+    return summary, rows
+
+
+def _sum_present(rows: Iterable[dict[str, Any]], key: str) -> int | float | None:
+    values = [_number(row.get(key)) for row in rows]
+    present = [value for value in values if value is not None]
+    return sum(present) if present else None
+
+
+def _failure_signature(row: dict[str, Any]) -> str:
+    exception_type = str(row.get("exception_type") or "")
+    message = str(row.get("exception_message") or "").lower()
+    normalized = re.sub(r"\b[0-9a-f]{8,}\b", "<id>", message)
+    normalized = re.sub(r"\b\d+\b", "<n>", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return f"{exception_type}: {normalized[:240]}"
+
+
+def _harness_wide_failure(
+    rows: Sequence[dict[str, Any]],
+    expected_count: int,
+) -> tuple[bool, str]:
+    signatures: dict[str, int] = defaultdict(int)
+    for row in rows:
+        if row.get("classification") != "infra":
+            continue
+        signature = _failure_signature(row)
+        if signature:
+            signatures[signature] += 1
+    if not signatures:
+        return False, ""
+    signature, count = max(signatures.items(), key=lambda item: item[1])
+    threshold = max(3, math.ceil(expected_count * 0.25))
+    return count >= threshold, signature if count >= threshold else ""
+
+
+def _summarize_run(
+    *,
+    run_label: str,
+    pair_label: str,
+    repetition: int | None,
+    expected_count: int,
+    rows: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    classifications = [str(row["classification"]) for row in rows]
+    rewards = [_number(row.get("reward")) for row in rows]
+    result_file_count = sum(bool(row.get("_has_result_file")) for row in rows)
+    valid_result_count = sum(bool(row.get("_valid_result")) for row in rows)
+    completed_result_count = sum(bool(row.get("_completed_result")) for row in rows)
+    exact_passes = sum(
+        classification == "pass" and reward is not None and reward >= 1
+        for classification, reward in zip(classifications, rewards)
+    )
+    partials = classifications.count("partial")
+    infra = classifications.count("infra")
+    agent_exits = classifications.count("agent_exit")
+    missing_reward = classifications.count("verifier_missing_reward")
+    clean_completed = sum(
+        classification in {"clean_fail", "partial", "pass"}
+        for classification in classifications
+    )
+    nonzero = sum(reward is not None and reward > 0 for reward in rewards)
+    reward_sum = sum(reward or 0 for reward in rewards)
+    score = reward_sum / expected_count if expected_count else 0.0
+    coverage = (
+        min(completed_result_count / expected_count, 1.0) if expected_count else 0.0
+    )
+    clean_coverage = clean_completed / expected_count if expected_count else 0.0
+    incomplete = (
+        expected_count <= 0
+        or result_file_count < expected_count
+        or valid_result_count < expected_count
+        or completed_result_count < expected_count
+    )
+    infra_dominated = expected_count > 0 and infra > expected_count / 2
+    harness_wide_failure, harness_wide_failure_signature = _harness_wide_failure(
+        rows,
+        expected_count,
+    )
+    eligible = not incomplete and not infra_dominated and not harness_wide_failure
+    if incomplete:
+        exclusion_reason = "incomplete"
+    elif infra_dominated:
+        exclusion_reason = "infra_dominated"
+    elif harness_wide_failure:
+        exclusion_reason = "harness_wide_failure"
+    else:
+        exclusion_reason = ""
+
+    return {
+        "run_label": run_label,
+        "pair_label": pair_label,
+        "repetition": repetition,
+        "expected_task_count": expected_count,
+        "result_file_count": result_file_count,
+        "valid_result_count": valid_result_count,
+        "completed_result_count": completed_result_count,
+        "coverage": coverage,
+        "score": score,
+        "exact_passes": exact_passes,
+        "partials": partials,
+        "nonzero": nonzero,
+        "infra": infra,
+        "agent_exits": agent_exits,
+        "clean_completed": clean_completed,
+        "missing_reward": missing_reward,
+        "clean_coverage": clean_coverage,
+        "incomplete": incomplete,
+        "infra_dominated": infra_dominated,
+        "harness_wide_failure": harness_wide_failure,
+        "harness_wide_failure_signature": harness_wide_failure_signature,
+        "eligible": eligible,
+        "exclusion_reason": exclusion_reason,
+        "n_input_tokens": _sum_present(rows, "n_input_tokens"),
+        "n_cache_tokens": _sum_present(rows, "n_cache_tokens"),
+        "n_output_tokens": _sum_present(rows, "n_output_tokens"),
+        "cost_usd": _sum_present(rows, "cost_usd"),
+    }
+
+
+def _mean(values: Sequence[int | float]) -> float | None:
+    return statistics.mean(values) if values else None
+
+
+def _pair_summaries(runs: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for run in runs:
+        grouped[str(run["pair_label"])].append(run)
+
+    summaries: list[dict[str, Any]] = []
+    for pair_label, pair_runs in sorted(grouped.items()):
+        ordered = sorted(
+            pair_runs,
+            key=lambda run: (
+                run["repetition"] is None,
+                run["repetition"] if run["repetition"] is not None else 0,
+                run["run_label"],
+            ),
+        )
+        eligible = [run for run in ordered if run["eligible"]]
+        scores = [float(run["score"]) for run in eligible]
+        exact_passes = [int(run["exact_passes"]) for run in eligible]
+        total_expected = sum(int(run["expected_task_count"]) for run in eligible)
+        mean_score = _mean(scores)
+        score_stdev = statistics.stdev(scores) if len(scores) > 1 else 0.0
+        min_score = min(scores) if scores else None
+        max_score = max(scores) if scores else None
+        summaries.append(
+            {
+                "pair_label": pair_label,
+                "total_repetitions": len(ordered),
+                "eligible_repetitions": len(eligible),
+                "excluded_repetitions": len(ordered) - len(eligible),
+                "excluded_run_labels": [
+                    str(run["run_label"]) for run in ordered if not run["eligible"]
+                ],
+                "mean_score": mean_score,
+                "score_stdev": score_stdev,
+                "min_score": min_score,
+                "max_score": max_score,
+                "mean": mean_score,
+                "stdev": score_stdev,
+                "min": min_score,
+                "max": max_score,
+                "mean_exact_passes": _mean(exact_passes),
+                "pass_rate": (
+                    sum(exact_passes) / total_expected if total_expected else None
+                ),
+                "clean_complete_repetitions": sum(
+                    run["clean_completed"] == run["expected_task_count"]
+                    for run in eligible
+                ),
+                "mean_coverage": _mean([float(run["coverage"]) for run in eligible]),
+                "mean_clean_completed": _mean(
+                    [int(run["clean_completed"]) for run in eligible]
+                ),
+            }
+        )
+    return summaries
+
+
+def _public_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in row.items() if not key.startswith("_")}
+        for row in rows
+    ]
+
+
+def _write_csv(path: Path, fieldnames: Sequence[str], rows: Iterable[dict[str, Any]]) -> None:
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _format_metric(value: Any, digits: int = 4) -> str:
+    return "-" if value is None else f"{float(value):.{digits}f}"
+
+
+def _markdown_label(value: Any) -> str:
+    return str(value).replace("|", r"\|").replace("\n", " ")
+
+
+def _write_leaderboard(path: Path, pairs: Sequence[dict[str, Any]]) -> None:
+    ranked = sorted(
+        (pair for pair in pairs if pair["eligible_repetitions"]),
+        key=lambda pair: (
+            -(float(pair["mean_score"]) if pair["mean_score"] is not None else -1.0),
+            str(pair["pair_label"]),
+        ),
+    )
+    lines = [
+        "# Cleaned Native ShellBench Leaderboard",
+        "",
+        "Incomplete, infra-dominated, and harness-wide failure repetitions are excluded.",
+        "",
+        "| Rank | Pair | Repetitions | Mean | Stdev | Min | Max | Mean exact passes | Pass rate | Clean complete |",
+        "| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for rank, pair in enumerate(ranked, start=1):
+        lines.append(
+            "| {rank} | {label} | {eligible}/{total} | {mean} | {stdev} | "
+            "{minimum} | {maximum} | {passes} | {pass_rate} | {clean} |".format(
+                rank=rank,
+                label=_markdown_label(pair["pair_label"]),
+                eligible=pair["eligible_repetitions"],
+                total=pair["total_repetitions"],
+                mean=_format_metric(pair["mean_score"]),
+                stdev=_format_metric(pair["score_stdev"]),
+                minimum=_format_metric(pair["min_score"]),
+                maximum=_format_metric(pair["max_score"]),
+                passes=_format_metric(pair["mean_exact_passes"], 2),
+                pass_rate=_format_metric(pair["pass_rate"]),
+                clean=pair["clean_complete_repetitions"],
+            )
+        )
+    if not ranked:
+        lines.append("| - | No eligible repetitions | 0/0 | - | - | - | - | - | - | 0 |")
+    path.write_text("\n".join(lines) + "\n")
+
+
+def aggregate(jobs_root: str | Path, summaries_dir: str | Path) -> dict[str, Any]:
+    """Aggregate ``jobs/<run_label>/<trial>/result.json`` directories.
+
+    Returns the same run and pair data written to ``aggregate_results.json``.
+    """
+
+    root = Path(jobs_root)
+    jobs_dir = root / "jobs" if (root / "jobs").is_dir() else root
+    output_dir = Path(summaries_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not jobs_dir.is_dir():
+        raise FileNotFoundError(f"jobs directory does not exist: {jobs_dir}")
+
+    run_summaries: list[dict[str, Any]] = []
+    task_rows: list[dict[str, Any]] = []
+    run_dirs = sorted(
+        path
+        for path in jobs_dir.iterdir()
+        if path.is_dir()
+        and path.resolve() != output_dir.resolve()
+        and (path / "run_manifest.json").is_file()
+    )
+    for run_dir in run_dirs:
+        summary, rows = _load_run(run_dir)
+        run_summaries.append(summary)
+        task_rows.extend(rows)
+
+    run_summaries.sort(key=lambda run: str(run["run_label"]))
+    task_rows.sort(
+        key=lambda row: (
+            str(row["run_label"]),
+            str(row["task_name"]),
+            str(row["trial_name"]),
+        )
+    )
+    pair_summaries = _pair_summaries(run_summaries)
+    public_task_rows = _public_rows(task_rows)
+    infra_rows = [row for row in public_task_rows if row["classification"] == "infra"]
+
+    report = {
+        "taxonomy": {
+            "infra": "environment, setup, gateway, Docker, malformed, or missing result",
+            "agent_exit": "agent timeout, refusal, nonzero exit, or other agent exception",
+            "verifier_missing_reward": (
+                "completed result with no reward, including missing reward files"
+            ),
+            "clean_fail": "clean completion with reward <= 0",
+            "partial": "clean completion with 0 < reward < 1",
+            "pass": "clean completion with reward >= 1",
+        },
+        "runs": run_summaries,
+        "pairs": pair_summaries,
+    }
+
+    _write_csv(output_dir / "aggregate_results.csv", RUN_FIELDS, run_summaries)
+    (output_dir / "aggregate_results.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    _write_csv(output_dir / "per_task_results.csv", PER_TASK_FIELDS, public_task_rows)
+    _write_csv(output_dir / "infra_failures.csv", INFRA_FIELDS, infra_rows)
+    _write_leaderboard(output_dir / "cleaned_leaderboard.md", pair_summaries)
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate native ShellBench Harbor job directories."
+    )
+    parser.add_argument("jobs_root", type=Path, help="Root containing jobs/<run_label>")
+    parser.add_argument(
+        "summaries_dir",
+        type=Path,
+        nargs="?",
+        help="Output directory (default: <jobs_root>/summaries)",
+    )
+    args = parser.parse_args(argv)
+    summaries_dir = args.summaries_dir or args.jobs_root / "summaries"
+    report = aggregate(args.jobs_root, summaries_dir)
+    print(
+        json.dumps(
+            {
+                "runs": len(report["runs"]),
+                "pairs": len(report["pairs"]),
+                "summaries_dir": str(summaries_dir),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_eval/audit.py
+++ b/scripts/native_eval/audit.py
@@ -1,0 +1,94 @@
+"""Generate non-destructive provenance supplements for native run archives."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+PROVENANCE_FIELDS = (
+    "execution_mode",
+    "harbor_reference_commit",
+    "judge_model_id",
+)
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return value
+
+
+def build_metadata_supplements(
+    run_index_path: Path,
+    extracted_root: Path,
+) -> dict[str, Any]:
+    run_index = _read_object(run_index_path)
+    fleet = run_index.get("fleet")
+    if not isinstance(fleet, dict):
+        raise ValueError("run index is missing fleet metadata")
+
+    provenance = {field: fleet.get(field) for field in PROVENANCE_FIELDS}
+    missing = [field for field, value in provenance.items() if value in (None, "")]
+    if missing:
+        raise ValueError(f"fleet metadata is missing: {', '.join(missing)}")
+
+    supplements = []
+    for manifest_path in sorted(extracted_root.glob("*/shellbench_meta-*/run_manifest.json")):
+        manifest = _read_object(manifest_path)
+        run_label = str(manifest.get("run_label") or "")
+        if not run_label:
+            raise ValueError(f"run manifest is missing run_label: {manifest_path}")
+
+        additions: dict[str, Any] = {}
+        for field, expected in provenance.items():
+            archived = manifest.get(field)
+            if archived in (None, ""):
+                additions[field] = expected
+            elif archived != expected:
+                raise ValueError(
+                    f"{run_label} has conflicting {field}: "
+                    f"archive={archived!r}, fleet={expected!r}"
+                )
+        if additions:
+            supplements.append(
+                {
+                    "run_label": run_label,
+                    "archived_manifest": str(manifest_path.relative_to(extracted_root)),
+                    "supplements": additions,
+                }
+            )
+
+    return {
+        "schema_version": 1,
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "source_run_index": str(run_index_path),
+        "extracted_root": str(extracted_root),
+        "raw_archives_mutated": False,
+        "provenance": provenance,
+        "runs": supplements,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_index", type=Path)
+    parser.add_argument("extracted_root", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args(argv)
+
+    report = build_metadata_supplements(
+        args.run_index.resolve(),
+        args.extracted_root.resolve(),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_eval/bootstrap_beast.sh
+++ b/scripts/native_eval/bootstrap_beast.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOOLCHAIN_ROOT="${TOOLCHAIN_ROOT:-/opt/shellbench-native}"
+NODE_VERSION="${NODE_VERSION:-22.23.1}"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.7.1-2}"
+CODEX_VERSION="${CODEX_VERSION:-0.145.0}"
+CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION:-2.1.220}"
+HERMES_COMMIT="${HERMES_COMMIT:-cb06017b1d6e1b9ae0cb35f99a48ffa6bcbaa828}"
+LITELLM_VERSION="${LITELLM_VERSION:-1.93.0}"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  exec sudo -E bash "$0" "$@"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+install -d -m 0755 "$TOOLCHAIN_ROOT"
+
+install_base_packages() {
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    ca-certificates curl git gnupg jq openssl ripgrep rsync tar xz-utils
+  rm -rf /var/lib/apt/lists/*
+}
+
+install_docker() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    return
+  fi
+
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  . /etc/os-release
+  printf '%s\n' \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${UBUNTU_CODENAME:-$VERSION_CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+  printf '#!/bin/sh\nexit 101\n' > /usr/sbin/policy-rc.d
+  chmod +x /usr/sbin/policy-rc.d
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    containerd.io docker-buildx-plugin docker-ce docker-ce-cli docker-compose-plugin
+  rm -f /usr/sbin/policy-rc.d
+  rm -rf /var/lib/apt/lists/*
+
+  cat > /etc/sysctl.d/99-shellbench-docker.conf <<'EOF'
+net.ipv4.ip_forward=1
+net.ipv6.conf.all.forwarding=1
+EOF
+  sysctl --system >/dev/null
+
+  install -d -m 0755 /etc/docker
+  if [[ -s /etc/docker/daemon.json ]]; then
+    jq '. + {"firewall-backend":"nftables"}' /etc/docker/daemon.json \
+      > /etc/docker/daemon.json.tmp
+    mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+  else
+    printf '%s\n' '{"firewall-backend":"nftables"}' > /etc/docker/daemon.json
+  fi
+
+  systemctl enable --now containerd docker
+  chmod 0666 /var/run/docker.sock
+  docker run --rm hello-world >/dev/null
+}
+
+install_node_tools() {
+  local node_root="$TOOLCHAIN_ROOT/node"
+  if [[ ! -x "$node_root/bin/node" ]] || \
+    [[ "$("$node_root/bin/node" --version)" != "v$NODE_VERSION" ]]; then
+    rm -rf "$node_root"
+    curl -fsSL \
+      "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+      -o /tmp/shellbench-node.tar.xz
+    tar -xJf /tmp/shellbench-node.tar.xz -C "$TOOLCHAIN_ROOT"
+    mv "$TOOLCHAIN_ROOT/node-v$NODE_VERSION-linux-x64" "$node_root"
+    rm -f /tmp/shellbench-node.tar.xz
+  fi
+
+  export PATH="$node_root/bin:$PATH"
+  rm -rf "$TOOLCHAIN_ROOT/npm-packages"
+  npm install --prefix "$TOOLCHAIN_ROOT/npm-packages" \
+    "openclaw@$OPENCLAW_VERSION" \
+    "@openai/codex@$CODEX_VERSION" \
+    "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION"
+}
+
+install_uv() {
+  install -d -m 0755 "$TOOLCHAIN_ROOT/bin"
+  if [[ ! -x "$TOOLCHAIN_ROOT/bin/uv" ]]; then
+    curl -LsSf https://astral.sh/uv/install.sh -o /tmp/install-uv.sh
+    UV_UNMANAGED_INSTALL="$TOOLCHAIN_ROOT/bin" sh /tmp/install-uv.sh
+    rm -f /tmp/install-uv.sh
+  fi
+}
+
+install_hermes() {
+  export HOME="$TOOLCHAIN_ROOT/home"
+  export HERMES_HOME="$TOOLCHAIN_ROOT/hermes-home"
+  export HERMES_INSTALL_DIR="$TOOLCHAIN_ROOT/hermes-agent"
+  export UV_PYTHON_INSTALL_DIR="$TOOLCHAIN_ROOT/uv-python"
+  export UV_CACHE_DIR="$TOOLCHAIN_ROOT/uv-cache"
+  export PATH="$TOOLCHAIN_ROOT/node/bin:$TOOLCHAIN_ROOT/bin:$PATH"
+  install -d -m 0755 "$HOME" "$HERMES_HOME"
+
+  curl -fsSL \
+    "https://raw.githubusercontent.com/NousResearch/hermes-agent/$HERMES_COMMIT/scripts/install.sh" \
+    -o /tmp/install-hermes.sh
+  bash /tmp/install-hermes.sh \
+    --skip-setup \
+    --skip-browser \
+    --commit "$HERMES_COMMIT" \
+    --dir "$HERMES_INSTALL_DIR" \
+    --hermes-home "$HERMES_HOME"
+  rm -f /tmp/install-hermes.sh
+}
+
+install_litellm() {
+  local venv="$TOOLCHAIN_ROOT/litellm-venv"
+  "$TOOLCHAIN_ROOT/bin/uv" venv --clear --python 3.12 "$venv"
+  "$TOOLCHAIN_ROOT/bin/uv" pip install \
+    --python "$venv/bin/python" \
+    "litellm[proxy]==$LITELLM_VERSION"
+}
+
+write_manifest() {
+  export PATH="$TOOLCHAIN_ROOT/node/bin:$TOOLCHAIN_ROOT/npm-packages/node_modules/.bin:$TOOLCHAIN_ROOT/home/.local/bin:$PATH"
+  jq -n \
+    --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg node "$(node --version)" \
+    --arg openclaw "$(openclaw --version | head -1)" \
+    --arg codex "$(codex --version | head -1)" \
+    --arg claude_code "$(claude --version | head -1)" \
+    --arg hermes "$(hermes version | head -1)" \
+    --arg litellm "$("$TOOLCHAIN_ROOT/litellm-venv/bin/python" -c 'from importlib.metadata import version; print(version("litellm"))')" \
+    --arg hermes_commit "$HERMES_COMMIT" \
+    '{
+      created_at_utc: $created_at,
+      node: $node,
+      openclaw: $openclaw,
+      codex: $codex,
+      claude_code: $claude_code,
+      hermes: $hermes,
+      hermes_commit: $hermes_commit,
+      litellm: $litellm
+    }' > "$TOOLCHAIN_ROOT/manifest.json"
+  chmod -R a+rX "$TOOLCHAIN_ROOT"
+}
+
+install_base_packages
+install_docker
+install_node_tools
+install_uv
+install_hermes
+install_litellm
+write_manifest
+
+docker version --format '{{.Server.Version}}'
+docker compose version
+jq . "$TOOLCHAIN_ROOT/manifest.json"

--- a/scripts/native_eval/checkpoint_loop.py
+++ b/scripts/native_eval/checkpoint_loop.py
@@ -37,6 +37,10 @@ def count_result_json(archive: Path) -> int:
         for member in handle.getmembers():
             if not member.isfile():
                 continue
+            extracted = handle.extractfile(member)
+            if extracted is not None:
+                while extracted.read(1024 * 1024):
+                    pass
             parts = PurePosixPath(member.name).parts
             for index, part in enumerate(parts):
                 if part != "jobs":
@@ -159,6 +163,29 @@ def append_checkpoint_log(
         )
 
 
+def partial_path(final_path: Path) -> Path:
+    return final_path.with_name(f"{final_path.name}.partial")
+
+
+def download_partial(
+    client: SSHClient,
+    remote_path: str,
+    final_path: Path,
+) -> Path:
+    if final_path.exists():
+        raise FileExistsError(f"refusing to overwrite local artifact: {final_path}")
+    staged_path = partial_path(final_path)
+    staged_path.unlink(missing_ok=True)
+    client.copy_from(remote_path, staged_path)
+    return staged_path
+
+
+def publish_partial(staged_path: Path, final_path: Path) -> None:
+    if final_path.exists():
+        raise FileExistsError(f"refusing to overwrite local artifact: {final_path}")
+    staged_path.replace(final_path)
+
+
 def pull_checkpoint(
     *,
     client: SSHClient,
@@ -179,8 +206,9 @@ def pull_checkpoint(
     local_path = raw_dir / archive_name
     if local_path.exists():
         raise FileExistsError(f"refusing to overwrite checkpoint: {local_path}")
-    client.copy_from(remote_path, local_path)
-    result_count = count_result_json(local_path)
+    staged_path = download_partial(client, remote_path, local_path)
+    result_count = count_result_json(staged_path)
+    publish_partial(staged_path, local_path)
     append_checkpoint_log(
         log_path,
         event="checkpoint",
@@ -200,25 +228,33 @@ def pull_final(
     log_path: Path,
 ) -> int:
     archive_name = f"{run_label}-final-artifacts.tar.gz"
-    local_path = raw_dir / archive_name
-    if local_path.exists():
-        raise FileExistsError(f"refusing to overwrite final archive: {local_path}")
-    client.copy_from(f"/tmp/{archive_name}", local_path)
-    result_count = count_result_json(local_path)
+    destinations = [
+        (f"/tmp/{archive_name}", raw_dir / archive_name),
+        *[
+            (
+                f"{remote_root}/run-logs/{run_label}.{suffix}.log",
+                logs_dir / f"{run_label}.{suffix}.log",
+            )
+            for suffix in ("stdout", "stderr")
+        ],
+    ]
+    for _, final_path in destinations:
+        if final_path.exists():
+            raise FileExistsError(f"refusing to overwrite local artifact: {final_path}")
+
+    staged = [
+        (download_partial(client, remote_path, final_path), final_path)
+        for remote_path, final_path in destinations
+    ]
+    result_count = count_result_json(staged[0][0])
+    for staged_path, final_path in staged:
+        publish_partial(staged_path, final_path)
     append_checkpoint_log(
         log_path,
         event="final",
         archive_name=archive_name,
         result_count=result_count,
     )
-    for suffix in ("stdout", "stderr"):
-        local_log = logs_dir / f"{run_label}.{suffix}.log"
-        if local_log.exists():
-            raise FileExistsError(f"refusing to overwrite run log: {local_log}")
-        client.copy_from(
-            f"{remote_root}/run-logs/{run_label}.{suffix}.log",
-            local_log,
-        )
     return result_count
 
 
@@ -305,23 +341,42 @@ def run_loop(args: argparse.Namespace) -> int:
                 state.result_file_count != last_archive_count
                 and state.result_file_count
             ):
-                last_archive_count = pull_checkpoint(
+                try:
+                    last_archive_count = pull_checkpoint(
+                        client=client,
+                        runner_root=args.runner_root,
+                        remote_root=args.remote_root,
+                        run_label=args.run_label,
+                        raw_dir=raw_dir,
+                        log_path=log_path,
+                        sequence=sequence,
+                    )
+                except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
+                    append_checkpoint_log(
+                        log_path,
+                        event="checkpoint_error",
+                        archive_name="",
+                        result_count=last_archive_count,
+                        detail=str(exc).replace("\n", " ")[:500],
+                    )
+            try:
+                final_count = pull_final(
                     client=client,
-                    runner_root=args.runner_root,
                     remote_root=args.remote_root,
                     run_label=args.run_label,
                     raw_dir=raw_dir,
+                    logs_dir=logs_dir,
                     log_path=log_path,
-                    sequence=sequence,
                 )
-            final_count = pull_final(
-                client=client,
-                remote_root=args.remote_root,
-                run_label=args.run_label,
-                raw_dir=raw_dir,
-                logs_dir=logs_dir,
-                log_path=log_path,
-            )
+            except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
+                append_checkpoint_log(
+                    log_path,
+                    event="final_error",
+                    archive_name="",
+                    result_count=last_archive_count,
+                    detail=str(exc).replace("\n", " ")[:500],
+                )
+                return 75
             return state.exit_status or (0 if final_count else 1)
 
         time.sleep(args.poll_seconds)

--- a/scripts/native_eval/checkpoint_loop.py
+++ b/scripts/native_eval/checkpoint_loop.py
@@ -13,7 +13,8 @@ from pathlib import PurePosixPath
 
 @dataclass(frozen=True)
 class RemoteState:
-    result_count: int
+    result_file_count: int
+    completed_count: int
     done: bool
     exit_status: int | None
 
@@ -111,14 +112,18 @@ set -eu
 job_dir=$1
 state_dir=$2
 count=0
+completed=0
 if [ -d "$job_dir" ]; then
   count=$(find "$job_dir" -mindepth 2 -maxdepth 2 -name result.json | wc -l | tr -d ' ')
+  completed=$(find "$job_dir" -mindepth 2 -maxdepth 2 -name result.json -exec \
+    jq -r 'select(.finished_at != null and .finished_at != "") | 1' {} \\; \
+    | wc -l | tr -d ' ')
 fi
 done_flag=0
 [ -f "$state_dir/done" ] && done_flag=1
 status=-
 [ -f "$state_dir/exit_status" ] && status=$(cat "$state_dir/exit_status")
-printf '%s\\t%s\\t%s\\n' "$count" "$done_flag" "$status"
+printf '%s\\t%s\\t%s\\t%s\\n' "$count" "$completed" "$done_flag" "$status"
 """
     output = client.run(
         [
@@ -130,9 +135,10 @@ printf '%s\\t%s\\t%s\\n' "$count" "$done_flag" "$status"
             f"/tmp/shellbench-runs/{run_label}",
         ]
     )
-    count, done, status = output.split("\t")
+    result_files, completed, done, status = output.split("\t")
     return RemoteState(
-        result_count=int(count),
+        result_file_count=int(result_files),
+        completed_count=int(completed),
         done=done == "1",
         exit_status=None if status == "-" else int(status),
     )
@@ -222,7 +228,8 @@ def run_loop(args: argparse.Namespace) -> int:
     )
 
     sequence = next_checkpoint_sequence(raw_dir, args.run_label)
-    last_count = 0
+    last_archive_count = 0
+    last_completed_count = 0
     last_checkpoint_at = 0.0
     failures = 0
 
@@ -236,7 +243,7 @@ def run_loop(args: argparse.Namespace) -> int:
                 log_path,
                 event="ssh_error",
                 archive_name="",
-                result_count=last_count,
+                result_count=last_archive_count,
                 detail=str(exc).replace("\n", " ")[:500],
             )
             if failures >= args.max_ssh_failures:
@@ -244,7 +251,7 @@ def run_loop(args: argparse.Namespace) -> int:
                     log_path,
                     event="lease_lost",
                     archive_name="",
-                    result_count=last_count,
+                    result_count=last_archive_count,
                 )
                 return 75
             time.sleep(args.poll_seconds)
@@ -252,16 +259,17 @@ def run_loop(args: argparse.Namespace) -> int:
 
         now = time.monotonic()
         checkpoint_due = (
-            state.result_count >= 1
+            state.completed_count >= 1
             and (
                 last_checkpoint_at == 0
-                or state.result_count - last_count >= args.trial_increment
+                or state.completed_count - last_completed_count
+                >= args.trial_increment
                 or now - last_checkpoint_at >= args.interval_seconds
             )
         )
         if checkpoint_due:
             try:
-                last_count = pull_checkpoint(
+                last_archive_count = pull_checkpoint(
                     client=client,
                     runner_root=args.runner_root,
                     remote_root=args.remote_root,
@@ -270,6 +278,7 @@ def run_loop(args: argparse.Namespace) -> int:
                     log_path=log_path,
                     sequence=sequence,
                 )
+                last_completed_count = state.completed_count
                 sequence += 1
                 last_checkpoint_at = time.monotonic()
             except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
@@ -277,13 +286,16 @@ def run_loop(args: argparse.Namespace) -> int:
                     log_path,
                     event="checkpoint_error",
                     archive_name="",
-                    result_count=last_count,
+                    result_count=last_archive_count,
                     detail=str(exc).replace("\n", " ")[:500],
                 )
 
         if state.done:
-            if state.result_count != last_count and state.result_count:
-                last_count = pull_checkpoint(
+            if (
+                state.result_file_count != last_archive_count
+                and state.result_file_count
+            ):
+                last_archive_count = pull_checkpoint(
                     client=client,
                     runner_root=args.runner_root,
                     remote_root=args.remote_root,

--- a/scripts/native_eval/checkpoint_loop.py
+++ b/scripts/native_eval/checkpoint_loop.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import subprocess
+import tarfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from pathlib import PurePosixPath
+
+
+@dataclass(frozen=True)
+class RemoteState:
+    result_count: int
+    done: bool
+    exit_status: int | None
+
+
+def next_checkpoint_sequence(raw_dir: Path, run_label: str) -> int:
+    pattern = re.compile(
+        rf"^{re.escape(run_label)}-checkpoint-(\d{{4}})-artifacts\.tar\.gz$"
+    )
+    sequences = [
+        int(match.group(1))
+        for path in raw_dir.glob(f"{run_label}-checkpoint-*-artifacts.tar.gz")
+        if (match := pattern.match(path.name))
+    ]
+    return max(sequences, default=0) + 1
+
+
+def count_result_json(archive: Path) -> int:
+    with tarfile.open(archive, "r:gz") as handle:
+        count = 0
+        for member in handle.getmembers():
+            if not member.isfile():
+                continue
+            parts = PurePosixPath(member.name).parts
+            for index, part in enumerate(parts):
+                if part != "jobs":
+                    continue
+                relative = parts[index:]
+                if len(relative) == 4 and relative[-1] == "result.json":
+                    count += 1
+                break
+        return count
+
+
+class SSHClient:
+    def __init__(
+        self,
+        *,
+        target: str,
+        port: int,
+        identity_file: Path,
+        control_path: Path,
+    ) -> None:
+        common_options = [
+            "-i",
+            str(identity_file),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=15",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPersist=12h",
+            "-o",
+            f"ControlPath={control_path}",
+        ]
+        self.ssh_options = ["-p", str(port), *common_options]
+        self.scp_options = ["-P", str(port), *common_options]
+        self.target = target
+
+    def run(self, command: list[str]) -> str:
+        result = subprocess.run(
+            ["ssh", *self.ssh_options, self.target, shlex.join(command)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def copy_from(self, remote_path: str, local_path: Path) -> None:
+        subprocess.run(
+            [
+                "scp",
+                *self.scp_options,
+                f"{self.target}:{remote_path}",
+                str(local_path),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+
+def read_remote_state(client: SSHClient, remote_root: str, run_label: str) -> RemoteState:
+    script = """
+set -eu
+job_dir=$1
+state_dir=$2
+count=0
+if [ -d "$job_dir" ]; then
+  count=$(find "$job_dir" -mindepth 2 -maxdepth 2 -name result.json | wc -l | tr -d ' ')
+fi
+done_flag=0
+[ -f "$state_dir/done" ] && done_flag=1
+status=-
+[ -f "$state_dir/exit_status" ] && status=$(cat "$state_dir/exit_status")
+printf '%s\\t%s\\t%s\\n' "$count" "$done_flag" "$status"
+"""
+    output = client.run(
+        [
+            "bash",
+            "-c",
+            script,
+            "checkpoint-state",
+            f"{remote_root}/results/jobs/{run_label}",
+            f"/tmp/shellbench-runs/{run_label}",
+        ]
+    )
+    count, done, status = output.split("\t")
+    return RemoteState(
+        result_count=int(count),
+        done=done == "1",
+        exit_status=None if status == "-" else int(status),
+    )
+
+
+def append_checkpoint_log(
+    log_path: Path,
+    *,
+    event: str,
+    archive_name: str,
+    result_count: int,
+    detail: str = "",
+) -> None:
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with log_path.open("a") as handle:
+        handle.write(
+            f"{timestamp}\t{event}\t{archive_name}\t{result_count}\t{detail}\n"
+        )
+
+
+def pull_checkpoint(
+    *,
+    client: SSHClient,
+    runner_root: str,
+    remote_root: str,
+    run_label: str,
+    raw_dir: Path,
+    log_path: Path,
+    sequence: int,
+) -> int:
+    archive_name = (
+        f"{run_label}-checkpoint-{sequence:04d}-artifacts.tar.gz"
+    )
+    remote_script = f"{runner_root}/scripts/native_eval/remote_checkpoint.sh"
+    remote_path = client.run(
+        [remote_script, remote_root, run_label, archive_name]
+    )
+    local_path = raw_dir / archive_name
+    if local_path.exists():
+        raise FileExistsError(f"refusing to overwrite checkpoint: {local_path}")
+    client.copy_from(remote_path, local_path)
+    result_count = count_result_json(local_path)
+    append_checkpoint_log(
+        log_path,
+        event="checkpoint",
+        archive_name=archive_name,
+        result_count=result_count,
+    )
+    return result_count
+
+
+def pull_final(
+    *,
+    client: SSHClient,
+    run_label: str,
+    raw_dir: Path,
+    log_path: Path,
+) -> int:
+    archive_name = f"{run_label}-final-artifacts.tar.gz"
+    local_path = raw_dir / archive_name
+    if local_path.exists():
+        raise FileExistsError(f"refusing to overwrite final archive: {local_path}")
+    client.copy_from(f"/tmp/{archive_name}", local_path)
+    result_count = count_result_json(local_path)
+    append_checkpoint_log(
+        log_path,
+        event="final",
+        archive_name=archive_name,
+        result_count=result_count,
+    )
+    return result_count
+
+
+def run_loop(args: argparse.Namespace) -> int:
+    local_root = args.local_root.resolve()
+    raw_dir = local_root / "raw"
+    logs_dir = local_root / "logs"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    args.control_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path = logs_dir / f"{args.run_label}.checkpoints.log"
+    client = SSHClient(
+        target=args.target,
+        port=args.port,
+        identity_file=args.identity_file,
+        control_path=args.control_path,
+    )
+
+    sequence = next_checkpoint_sequence(raw_dir, args.run_label)
+    last_count = 0
+    last_checkpoint_at = 0.0
+    failures = 0
+
+    while True:
+        try:
+            state = read_remote_state(client, args.remote_root, args.run_label)
+            failures = 0
+        except (OSError, subprocess.SubprocessError, ValueError) as exc:
+            failures += 1
+            append_checkpoint_log(
+                log_path,
+                event="ssh_error",
+                archive_name="",
+                result_count=last_count,
+                detail=str(exc).replace("\n", " ")[:500],
+            )
+            if failures >= args.max_ssh_failures:
+                append_checkpoint_log(
+                    log_path,
+                    event="lease_lost",
+                    archive_name="",
+                    result_count=last_count,
+                )
+                return 75
+            time.sleep(args.poll_seconds)
+            continue
+
+        now = time.monotonic()
+        checkpoint_due = (
+            state.result_count >= 1
+            and (
+                last_checkpoint_at == 0
+                or state.result_count - last_count >= args.trial_increment
+                or now - last_checkpoint_at >= args.interval_seconds
+            )
+        )
+        if checkpoint_due:
+            try:
+                last_count = pull_checkpoint(
+                    client=client,
+                    runner_root=args.runner_root,
+                    remote_root=args.remote_root,
+                    run_label=args.run_label,
+                    raw_dir=raw_dir,
+                    log_path=log_path,
+                    sequence=sequence,
+                )
+                sequence += 1
+                last_checkpoint_at = time.monotonic()
+            except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
+                append_checkpoint_log(
+                    log_path,
+                    event="checkpoint_error",
+                    archive_name="",
+                    result_count=last_count,
+                    detail=str(exc).replace("\n", " ")[:500],
+                )
+
+        if state.done:
+            if state.result_count != last_count and state.result_count:
+                last_count = pull_checkpoint(
+                    client=client,
+                    runner_root=args.runner_root,
+                    remote_root=args.remote_root,
+                    run_label=args.run_label,
+                    raw_dir=raw_dir,
+                    log_path=log_path,
+                    sequence=sequence,
+                )
+            final_count = pull_final(
+                client=client,
+                run_label=args.run_label,
+                raw_dir=raw_dir,
+                log_path=log_path,
+            )
+            return state.exit_status or (0 if final_count else 1)
+
+        time.sleep(args.poll_seconds)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--identity-file", type=Path, required=True)
+    parser.add_argument("--control-path", type=Path, required=True)
+    parser.add_argument("--runner-root", required=True)
+    parser.add_argument("--remote-root", required=True)
+    parser.add_argument("--run-label", required=True)
+    parser.add_argument("--local-root", type=Path, required=True)
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--interval-seconds", type=int, default=600)
+    parser.add_argument("--trial-increment", type=int, default=10)
+    parser.add_argument("--max-ssh-failures", type=int, default=3)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_loop(parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_eval/checkpoint_loop.py
+++ b/scripts/native_eval/checkpoint_loop.py
@@ -193,8 +193,10 @@ def pull_checkpoint(
 def pull_final(
     *,
     client: SSHClient,
+    remote_root: str,
     run_label: str,
     raw_dir: Path,
+    logs_dir: Path,
     log_path: Path,
 ) -> int:
     archive_name = f"{run_label}-final-artifacts.tar.gz"
@@ -209,6 +211,14 @@ def pull_final(
         archive_name=archive_name,
         result_count=result_count,
     )
+    for suffix in ("stdout", "stderr"):
+        local_log = logs_dir / f"{run_label}.{suffix}.log"
+        if local_log.exists():
+            raise FileExistsError(f"refusing to overwrite run log: {local_log}")
+        client.copy_from(
+            f"{remote_root}/run-logs/{run_label}.{suffix}.log",
+            local_log,
+        )
     return result_count
 
 
@@ -306,8 +316,10 @@ def run_loop(args: argparse.Namespace) -> int:
                 )
             final_count = pull_final(
                 client=client,
+                remote_root=args.remote_root,
                 run_label=args.run_label,
                 raw_dir=raw_dir,
+                logs_dir=logs_dir,
                 log_path=log_path,
             )
             return state.exit_status or (0 if final_count else 1)

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -10,8 +10,9 @@ import subprocess
 import sys
 import tarfile
 import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from collections import Counter
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol, Sequence
 
@@ -42,6 +43,8 @@ RESUMABLE_STATUSES = {
     "stop_pending",
 }
 RERUN_STATUSES = {"failed", "lease_lost"}
+ACTIVE_RUN_STATUSES = {"leasing", "bootstrapping", "ready", "running"}
+CLEANUP_STATUSES = {"exported", "stop_pending"}
 
 
 class CommandExecutor(Protocol):
@@ -138,6 +141,8 @@ class FleetConfig:
     max_leases: int = 10
     max_attempts: int = 2
     task_concurrency: int = 16
+    model_max_runs: dict[str, int] = field(default_factory=dict)
+    model_task_concurrency: dict[str, int] = field(default_factory=dict)
     crabbox_bin: str = "crabbox"
     python_bin: str = sys.executable
     machine_class: str = "beast"
@@ -233,6 +238,10 @@ class FleetController:
             raise ValueError("max_leases must be at least 1")
         if config.max_attempts < 1:
             raise ValueError("max_attempts must be at least 1")
+        if config.task_concurrency < 1:
+            raise ValueError("task_concurrency must be at least 1")
+        _validate_model_values(config.model_max_runs, "model_max_runs")
+        _validate_model_values(config.model_task_concurrency, "model_task_concurrency")
         self.config = config
         self.executor = executor or SubprocessExecutor()
         self.store: RunIndexStore | None = None
@@ -253,27 +262,33 @@ class FleetController:
             self._schedule_existing_reruns()
 
             attempted_labels: set[str] = set()
-            while True:
-                labels = [
-                    label
-                    for label in self.store.labels_with_status(RESUMABLE_STATUSES)
-                    if label not in attempted_labels
-                ]
-                if not labels:
-                    break
-                wave = labels[: self.config.max_leases]
-                attempted_labels.update(wave)
-                with ThreadPoolExecutor(max_workers=len(wave)) as pool:
-                    futures = {pool.submit(self._execute_entry, label): label for label in wave}
-                    for future in as_completed(futures):
+            with ThreadPoolExecutor(max_workers=self.config.max_leases) as pool:
+                futures: dict[Future[bool], str] = {}
+                while True:
+                    while len(futures) < self.config.max_leases:
+                        label = self._next_schedulable_label(
+                            attempted_labels,
+                            set(futures.values()),
+                        )
+                        if label is None:
+                            break
+                        attempted_labels.add(label)
+                        futures[pool.submit(self._execute_entry, label)] = label
+
+                    if not futures:
+                        break
+
+                    completed, _ = wait(futures, return_when=FIRST_COMPLETED)
+                    for future in completed:
+                        label = futures.pop(future)
                         try:
                             future.result()
                         except Exception as exc:
                             self._mark_recovery_required(
-                                futures[future],
+                                label,
                                 f"unexpected controller error: {exc}",
                             )
-                self._schedule_existing_reruns()
+                    self._schedule_existing_reruns()
 
             unfinished = self.store.labels_with_status(RESUMABLE_STATUSES | {"recovery_required"})
             return 1 if unfinished or not self._matrix_satisfied() else 0
@@ -377,6 +392,8 @@ class FleetController:
                 "region": self.config.region,
                 "max_leases": self.config.max_leases,
                 "task_concurrency": self.config.task_concurrency,
+                "model_max_runs": self.config.model_max_runs,
+                "model_task_concurrency": self.config.model_task_concurrency,
                 "crabbox_cli_version": self.crabbox_cli_version,
                 "controller_started_at_utc": utc_now(),
             }
@@ -737,7 +754,7 @@ printf '%s\n' "$pid"
             str(run.expected_task_count),
             str(self._store.data["public_tasks_commit"]),
             run.run_date,
-            str(self.config.task_concurrency),
+            str(self._task_concurrency(run.model_slug)),
         ]
         self._checked(
             self._ssh_command(
@@ -765,6 +782,60 @@ printf '%s\n' "$pid"
         self._store.update(
             run.run_label,
             dispatched_at_utc=utc_now(),
+            task_concurrency=self._task_concurrency(run.model_slug),
+        )
+
+    def _next_schedulable_label(
+        self,
+        attempted_labels: set[str],
+        in_flight_labels: set[str],
+    ) -> str | None:
+        entries = self._store.all_entries()
+        candidates = [
+            entry
+            for entry in entries
+            if entry.get("status") in RESUMABLE_STATUSES
+            and entry["run_label"] not in attempted_labels
+        ]
+        for statuses in (CLEANUP_STATUSES, ACTIVE_RUN_STATUSES):
+            for entry in candidates:
+                if entry.get("status") in statuses:
+                    return str(entry["run_label"])
+
+        active_entries = [
+            entry for entry in entries if entry.get("status") in ACTIVE_RUN_STATUSES
+        ]
+        cleanup_entries = [
+            entry for entry in entries if entry.get("status") in CLEANUP_STATUSES
+        ]
+        planned_reservations = [
+            entry
+            for entry in entries
+            if entry["run_label"] in in_flight_labels and entry.get("status") == "planned"
+        ]
+        occupied_slots = (
+            len(active_entries) + len(cleanup_entries) + len(planned_reservations)
+        )
+        if occupied_slots >= self.config.max_leases:
+            return None
+
+        active_models = Counter(
+            self._run_spec(entry).model_slug
+            for entry in [*active_entries, *planned_reservations]
+        )
+        for entry in candidates:
+            if entry.get("status") != "planned":
+                continue
+            model_slug = self._run_spec(entry).model_slug
+            model_limit = self.config.model_max_runs.get(model_slug)
+            if model_limit is None or active_models[model_slug] < model_limit:
+                return str(entry["run_label"])
+        return None
+
+    def _task_concurrency(self, model_slug: str) -> int:
+        return self.config.model_task_concurrency.get(
+            model_slug,
+            self.config.task_concurrency,
         )
 
     def _run_checkpoint_loop(
@@ -1062,6 +1133,36 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _validate_model_values(values: dict[str, int], name: str) -> None:
+    for model_slug, value in values.items():
+        if not model_slug:
+            raise ValueError(f"{name} contains an empty model slug")
+        if not isinstance(value, int) or value < 1:
+            raise ValueError(f"{name}[{model_slug!r}] must be a positive integer")
+
+
+def _parse_model_values(
+    parser: argparse.ArgumentParser,
+    values: list[str],
+    option: str,
+) -> dict[str, int]:
+    parsed: dict[str, int] = {}
+    for raw in values:
+        model_slug, separator, count_value = raw.partition("=")
+        if not separator or not model_slug or not count_value:
+            parser.error(f"{option} must use MODEL=COUNT: {raw!r}")
+        if model_slug in parsed:
+            parser.error(f"{option} repeats model {model_slug!r}")
+        try:
+            count = int(count_value)
+        except ValueError:
+            parser.error(f"{option} count must be an integer: {raw!r}")
+        if count < 1:
+            parser.error(f"{option} count must be positive: {raw!r}")
+        parsed[model_slug] = count
+    return parsed
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--run-index", type=Path, required=True)
@@ -1072,6 +1173,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--max-leases", type=int, default=10)
     parser.add_argument("--max-attempts", type=int, default=2)
     parser.add_argument("--task-concurrency", type=int, default=16)
+    parser.add_argument("--model-max-runs", action="append", default=[], metavar="MODEL=COUNT")
+    parser.add_argument(
+        "--model-task-concurrency",
+        action="append",
+        default=[],
+        metavar="MODEL=COUNT",
+    )
     parser.add_argument("--crabbox-bin", default="crabbox")
     parser.add_argument("--python-bin", default=sys.executable)
     parser.add_argument("--machine-class", default="beast")
@@ -1087,7 +1195,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--checkpoint-poll-seconds", type=int, default=30)
     parser.add_argument("--runner-archive", type=Path)
     parser.add_argument("--runner-commit")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    args.model_max_runs = _parse_model_values(
+        parser,
+        args.model_max_runs,
+        "--model-max-runs",
+    )
+    args.model_task_concurrency = _parse_model_values(
+        parser,
+        args.model_task_concurrency,
+        "--model-task-concurrency",
+    )
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1101,6 +1220,8 @@ def main(argv: list[str] | None = None) -> int:
         max_leases=args.max_leases,
         max_attempts=args.max_attempts,
         task_concurrency=args.task_concurrency,
+        model_max_runs=args.model_max_runs,
+        model_task_concurrency=args.model_task_concurrency,
         crabbox_bin=args.crabbox_bin,
         python_bin=args.python_bin,
         machine_class=args.machine_class,

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -143,6 +143,7 @@ class FleetConfig:
     max_attempts: int = 2
     task_concurrency: int = 16
     model_max_runs: dict[str, int] = field(default_factory=dict)
+    provider_max_runs: dict[str, int] = field(default_factory=dict)
     model_task_concurrency: dict[str, int] = field(default_factory=dict)
     crabbox_bin: str = "crabbox"
     python_bin: str = sys.executable
@@ -248,6 +249,7 @@ class FleetController:
         if config.warmup_capacity_backoff_seconds < 0:
             raise ValueError("warmup_capacity_backoff_seconds cannot be negative")
         _validate_model_values(config.model_max_runs, "model_max_runs")
+        _validate_model_values(config.provider_max_runs, "provider_max_runs")
         _validate_model_values(config.model_task_concurrency, "model_task_concurrency")
         self.config = config
         self.executor = executor or SubprocessExecutor()
@@ -400,6 +402,7 @@ class FleetController:
                 "max_leases": self.config.max_leases,
                 "task_concurrency": self.config.task_concurrency,
                 "model_max_runs": self.config.model_max_runs,
+                "provider_max_runs": self.config.provider_max_runs,
                 "model_task_concurrency": self.config.model_task_concurrency,
                 "warmup_capacity_attempts": self.config.warmup_capacity_attempts,
                 "warmup_capacity_backoff_seconds": (
@@ -858,15 +861,28 @@ printf '%s\n' "$pid"
             self._run_spec(entry).model_slug
             for entry in [*active_entries, *pending_reservations]
         )
+        active_providers = Counter(
+            self._run_spec(entry).provider
+            for entry in [*active_entries, *pending_reservations]
+        )
         for entry in candidates:
             pending = entry.get("status") == "planned" or (
                 not entry.get("lease") and entry.get("status") in ACTIVE_RUN_STATUSES
             )
             if not pending:
                 continue
-            model_slug = self._run_spec(entry).model_slug
+            run = self._run_spec(entry)
+            model_slug = run.model_slug
             model_limit = self.config.model_max_runs.get(model_slug)
-            if model_limit is None or active_models[model_slug] < model_limit:
+            provider_limit = self.config.provider_max_runs.get(run.provider)
+            model_available = (
+                model_limit is None or active_models[model_slug] < model_limit
+            )
+            provider_available = (
+                provider_limit is None
+                or active_providers[run.provider] < provider_limit
+            )
+            if model_available and provider_available:
                 return str(entry["run_label"])
         return None
 
@@ -1213,6 +1229,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--task-concurrency", type=int, default=16)
     parser.add_argument("--model-max-runs", action="append", default=[], metavar="MODEL=COUNT")
     parser.add_argument(
+        "--provider-max-runs",
+        action="append",
+        default=[],
+        metavar="PROVIDER=COUNT",
+    )
+    parser.add_argument(
         "--model-task-concurrency",
         action="append",
         default=[],
@@ -1241,6 +1263,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         args.model_max_runs,
         "--model-max-runs",
     )
+    args.provider_max_runs = _parse_model_values(
+        parser,
+        args.provider_max_runs,
+        "--provider-max-runs",
+    )
     args.model_task_concurrency = _parse_model_values(
         parser,
         args.model_task_concurrency,
@@ -1261,6 +1288,7 @@ def main(argv: list[str] | None = None) -> int:
         max_attempts=args.max_attempts,
         task_concurrency=args.task_concurrency,
         model_max_runs=args.model_max_runs,
+        provider_max_runs=args.provider_max_runs,
         model_task_concurrency=args.model_task_concurrency,
         crabbox_bin=args.crabbox_bin,
         python_bin=args.python_bin,

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -548,7 +548,8 @@ class FleetController:
         if result.returncode:
             detail = (result.stderr or result.stdout or "").strip()
             missing = any(
-                marker in detail.lower() for marker in ("not found", "no claim", "unknown lease")
+                marker in detail.lower()
+                for marker in ("not found", "not_found", "http 404", "no claim", "unknown lease")
             )
             if not missing:
                 raise FleetError(

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -1,0 +1,1047 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import fcntl
+import hashlib
+import json
+import shlex
+import subprocess
+import sys
+import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, Sequence
+
+from scripts.native_eval.checkpoint_loop import count_result_json
+from scripts.native_eval.models import RunSpec
+from scripts.native_eval.runtime import atomic_write_json, utc_now
+
+
+RUN_SPEC_FIELDS = (
+    "run_label",
+    "harness",
+    "harness_version",
+    "model_slug",
+    "model_id",
+    "provider",
+    "proxy_model_name",
+    "repetition",
+    "expected_task_count",
+    "run_date",
+)
+RESUMABLE_STATUSES = {
+    "planned",
+    "leasing",
+    "bootstrapping",
+    "ready",
+    "running",
+    "exported",
+    "stop_pending",
+}
+RERUN_STATUSES = {"failed", "lease_lost"}
+
+
+class CommandExecutor(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+class SubprocessExecutor:
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            list(command),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE if capture_output else None,
+            stderr=subprocess.PIPE if capture_output else None,
+        )
+
+
+class FleetError(RuntimeError):
+    pass
+
+
+class LeaseUnavailableError(FleetError):
+    pass
+
+
+@dataclass(frozen=True)
+class Lease:
+    lease_id: str
+    slug: str
+    host: str
+    user: str
+    port: int
+    identity_file: Path
+    instance_type: str
+    region: str
+
+    @property
+    def target(self) -> str:
+        return f"{self.user}@{self.host}"
+
+    @classmethod
+    def from_inspect(cls, value: dict[str, Any], *, region: str) -> Lease:
+        required = ("id", "slug", "sshHost", "sshUser", "sshPort", "sshKey")
+        missing = [field for field in required if not value.get(field)]
+        if missing:
+            raise FleetError(f"Crabbox inspect omitted fields: {', '.join(missing)}")
+        if value.get("state") != "active":
+            raise LeaseUnavailableError(f"lease {value['id']} is no longer active")
+        if not value.get("ready"):
+            raise FleetError(f"lease {value['id']} is active but not ready")
+        return cls(
+            lease_id=str(value["id"]),
+            slug=str(value["slug"]),
+            host=str(value["sshHost"]),
+            user=str(value["sshUser"]),
+            port=int(value["sshPort"]),
+            identity_file=Path(str(value["sshKey"])),
+            instance_type=str(value.get("serverType") or ""),
+            region=region,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.lease_id,
+            "slug": self.slug,
+            "provider": "aws",
+            "instance_type": self.instance_type,
+            "region": self.region,
+            "host": self.host,
+            "ssh_user": self.user,
+            "ssh_port": self.port,
+            "identity_file": str(self.identity_file),
+            "state": "active",
+        }
+
+
+@dataclass(frozen=True)
+class FleetConfig:
+    run_index: Path
+    local_root: Path
+    runner_root: Path
+    task_archive: Path
+    env_file: Path
+    max_leases: int = 10
+    max_attempts: int = 2
+    task_concurrency: int = 16
+    crabbox_bin: str = "crabbox"
+    python_bin: str = sys.executable
+    machine_class: str = "beast"
+    instance_type: str = "c7a.24xlarge"
+    market: str = "on-demand"
+    region: str = "eu-west-1"
+    ttl: str = "12h"
+    idle_timeout: str = "12h"
+    remote_root: str = "/work/crabbox/shellbench-native"
+    checkpoint_poll_seconds: int = 30
+    runner_archive: Path | None = None
+    runner_commit: str | None = None
+
+
+class RunIndexStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path.resolve()
+        self._thread_lock = threading.RLock()
+        lock_path = self.path.with_name(f"{self.path.name}.fleet.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_handle = lock_path.open("a+")
+        try:
+            fcntl.flock(self._lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            self._lock_handle.close()
+            raise FleetError(f"another fleet controller owns {lock_path}") from exc
+        self.data = json.loads(self.path.read_text(encoding="utf-8"))
+
+    def close(self) -> None:
+        fcntl.flock(self._lock_handle.fileno(), fcntl.LOCK_UN)
+        self._lock_handle.close()
+
+    def __enter__(self) -> RunIndexStore:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def save(self) -> None:
+        with self._thread_lock:
+            self.data["updated_at_utc"] = utc_now()
+            atomic_write_json(self.path, self.data)
+
+    def update_root(self, **changes: Any) -> None:
+        with self._thread_lock:
+            self.data.update(changes)
+            self.save()
+
+    def get(self, run_label: str) -> dict[str, Any]:
+        with self._thread_lock:
+            for entry in self.data["runs"]:
+                if entry["run_label"] == run_label:
+                    return copy.deepcopy(entry)
+        raise KeyError(run_label)
+
+    def update(self, run_label: str, **changes: Any) -> dict[str, Any]:
+        with self._thread_lock:
+            for entry in self.data["runs"]:
+                if entry["run_label"] == run_label:
+                    entry.update(changes)
+                    entry["updated_at_utc"] = utc_now()
+                    self.save()
+                    return copy.deepcopy(entry)
+        raise KeyError(run_label)
+
+    def append(self, entry: dict[str, Any]) -> None:
+        with self._thread_lock:
+            labels = {item["run_label"] for item in self.data["runs"]}
+            if entry["run_label"] in labels:
+                raise FleetError(f"duplicate run label: {entry['run_label']}")
+            self.data["runs"].append(entry)
+            self.save()
+
+    def labels_with_status(self, statuses: set[str]) -> list[str]:
+        with self._thread_lock:
+            return [
+                entry["run_label"] for entry in self.data["runs"] if entry.get("status") in statuses
+            ]
+
+    def all_entries(self) -> list[dict[str, Any]]:
+        with self._thread_lock:
+            return copy.deepcopy(self.data["runs"])
+
+
+class FleetController:
+    def __init__(
+        self,
+        config: FleetConfig,
+        *,
+        executor: CommandExecutor | None = None,
+    ) -> None:
+        if config.max_leases < 1:
+            raise ValueError("max_leases must be at least 1")
+        if config.max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        self.config = config
+        self.executor = executor or SubprocessExecutor()
+        self.store: RunIndexStore | None = None
+        self.runner_archive: Path | None = None
+        self.runner_commit = ""
+        self.runner_archive_sha256 = ""
+        self.task_archive_sha256 = ""
+
+    def run(self) -> int:
+        self._prepare_local_layout()
+        with RunIndexStore(self.config.run_index) as store:
+            self.store = store
+            self._validate_plan()
+            self._prepare_inputs()
+            self._record_fleet_metadata()
+            self._resume_recovery_entries()
+            self._schedule_existing_reruns()
+
+            attempted_labels: set[str] = set()
+            while True:
+                labels = [
+                    label
+                    for label in self.store.labels_with_status(RESUMABLE_STATUSES)
+                    if label not in attempted_labels
+                ]
+                if not labels:
+                    break
+                wave = labels[: self.config.max_leases]
+                attempted_labels.update(wave)
+                with ThreadPoolExecutor(max_workers=len(wave)) as pool:
+                    futures = {pool.submit(self._execute_entry, label): label for label in wave}
+                    for future in as_completed(futures):
+                        try:
+                            future.result()
+                        except Exception as exc:
+                            self._mark_recovery_required(
+                                futures[future],
+                                f"unexpected controller error: {exc}",
+                            )
+                self._schedule_existing_reruns()
+
+            unfinished = self.store.labels_with_status(RESUMABLE_STATUSES | {"recovery_required"})
+            return 1 if unfinished or not self._matrix_satisfied() else 0
+
+    @property
+    def _store(self) -> RunIndexStore:
+        if self.store is None:
+            raise RuntimeError("fleet store is not open")
+        return self.store
+
+    def _prepare_local_layout(self) -> None:
+        for relative in ("raw", "logs", "manifests"):
+            (self.config.local_root / relative).mkdir(parents=True, exist_ok=True)
+
+    def _validate_plan(self) -> None:
+        expected = int(self._store.data["expected_task_count"])
+        for entry in self._store.all_entries():
+            run = self._run_spec(entry)
+            if run.expected_task_count != expected:
+                raise FleetError(
+                    f"{run.run_label} expects {run.expected_task_count}, index expects {expected}"
+                )
+
+    def _prepare_inputs(self) -> None:
+        for path, description in (
+            (self.config.task_archive, "task archive"),
+            (self.config.env_file, "environment file"),
+        ):
+            if not path.is_file():
+                raise FleetError(f"{description} does not exist: {path}")
+
+        if self.config.runner_commit:
+            self.runner_commit = self.config.runner_commit
+        else:
+            result = self._checked(
+                [
+                    "git",
+                    "-C",
+                    str(self.config.runner_root),
+                    "rev-parse",
+                    "HEAD",
+                ],
+                capture_output=True,
+                description="resolve runner commit",
+            )
+            self.runner_commit = result.stdout.strip()
+
+        if self.config.runner_archive:
+            self.runner_archive = self.config.runner_archive
+        else:
+            archive = (
+                self.config.local_root
+                / "manifests"
+                / f"native-runner-{self.runner_commit[:12]}.tar.gz"
+            )
+            if not archive.exists():
+                self._checked(
+                    [
+                        "git",
+                        "-C",
+                        str(self.config.runner_root),
+                        "archive",
+                        "--format=tar.gz",
+                        f"--output={archive}",
+                        self.runner_commit,
+                    ],
+                    capture_output=True,
+                    description="archive pinned runner",
+                )
+            self.runner_archive = archive
+
+        for archive in (self.runner_archive, self.config.task_archive):
+            if archive is None or not archive.is_file():
+                raise FleetError(f"archive does not exist: {archive}")
+            try:
+                with tarfile.open(archive, "r:gz") as handle:
+                    handle.getmembers()
+            except tarfile.TarError as exc:
+                raise FleetError(f"invalid archive: {archive}") from exc
+        self.runner_archive_sha256 = _sha256(self.runner_archive)
+        self.task_archive_sha256 = _sha256(self.config.task_archive)
+
+    def _record_fleet_metadata(self) -> None:
+        assert self.runner_archive is not None
+        metadata = dict(self._store.data.get("fleet") or {})
+        metadata.update(
+            {
+                "runner_commit": self.runner_commit,
+                "runner_archive_sha256": self.runner_archive_sha256,
+                "task_archive_sha256": self.task_archive_sha256,
+                "provider": "aws",
+                "machine_class": self.config.machine_class,
+                "instance_type": self.config.instance_type,
+                "market": self.config.market,
+                "region": self.config.region,
+                "max_leases": self.config.max_leases,
+                "task_concurrency": self.config.task_concurrency,
+                "controller_started_at_utc": utc_now(),
+            }
+        )
+        self._store.update_root(fleet=metadata)
+
+    def _execute_entry(self, run_label: str) -> bool:
+        entry = self._store.get(run_label)
+        run = self._run_spec(entry)
+        try:
+            verified, result_count, artifacts = self._verify_final(run.run_label)
+            if verified:
+                self._store.update(
+                    run.run_label,
+                    status="exported",
+                    verified_final_export=True,
+                    final_result_count=result_count,
+                    artifacts=artifacts,
+                )
+                return self._finish_exported(
+                    self._store.get(run.run_label),
+                    run,
+                )
+            if entry["status"] in {"exported", "stop_pending"}:
+                return self._finish_exported(entry, run)
+
+            lease = self._ensure_lease(entry)
+            remote_state = self._probe_remote(lease, run.run_label)
+            if remote_state == "missing":
+                if self._local_artifacts(run.run_label):
+                    raise FleetError("local artifacts exist but the remote run state is missing")
+                self._hydrate_lease(lease)
+                self._dispatch(lease, run)
+            elif remote_state == "stale":
+                raise FleetError("remote run state is stale and cannot be overwritten")
+
+            self._store.update(
+                run.run_label,
+                status="running",
+                started_at_utc=entry.get("started_at_utc") or utc_now(),
+                last_error=None,
+            )
+            checkpoint = self._run_checkpoint_loop(lease, run.run_label)
+            verified, result_count, artifacts = self._verify_final(run.run_label)
+            if not verified:
+                self._mark_recovery_required(
+                    run.run_label,
+                    f"checkpoint loop exited {checkpoint.returncode} without a verified final export",
+                )
+                return False
+
+            self._store.update(
+                run.run_label,
+                status="exported",
+                verified_final_export=True,
+                final_result_count=result_count,
+                run_exit_code=checkpoint.returncode,
+                artifacts=artifacts,
+            )
+            return self._finish_exported(self._store.get(run.run_label), run)
+        except LeaseUnavailableError as exc:
+            self._store.update(
+                run.run_label,
+                status="lease_lost",
+                finished_at_utc=utc_now(),
+                last_error=str(exc),
+            )
+            self._schedule_rerun(self._store.get(run.run_label))
+            return False
+        except (FleetError, OSError, subprocess.SubprocessError, ValueError) as exc:
+            current = self._store.get(run.run_label)
+            if current.get("lease") or current.get("requested_lease_slug"):
+                self._mark_recovery_required(run.run_label, str(exc))
+            else:
+                self._store.update(
+                    run.run_label,
+                    status="failed",
+                    finished_at_utc=utc_now(),
+                    last_error=str(exc),
+                )
+                self._schedule_rerun(self._store.get(run.run_label))
+            return False
+
+    def _ensure_lease(self, entry: dict[str, Any]) -> Lease:
+        lease_value = entry.get("lease")
+        if lease_value:
+            identifier = str(lease_value["id"])
+            return self._inspect_lease(identifier, required=True)
+
+        slug = str(entry.get("requested_lease_slug") or self._lease_slug(entry["run_label"]))
+        self._store.update(
+            entry["run_label"],
+            status="leasing",
+            requested_lease_slug=slug,
+        )
+        existing = self._inspect_lease(slug, required=False)
+        if existing is None:
+            command = [
+                self.config.crabbox_bin,
+                "warmup",
+                "--provider",
+                "aws",
+                "--class",
+                self.config.machine_class,
+                "--slug",
+                slug,
+                "--market",
+                self.config.market,
+                "--ttl",
+                self.config.ttl,
+                "--idle-timeout",
+                self.config.idle_timeout,
+            ]
+            if self.config.instance_type:
+                command.extend(["--type", self.config.instance_type])
+            self._checked(
+                command,
+                capture_output=True,
+                description=f"lease Crabbox {slug}",
+            )
+            existing = self._inspect_lease(slug, required=True)
+        self._store.update(
+            entry["run_label"],
+            status="bootstrapping",
+            lease={**existing.to_dict(), "started_at_utc": utc_now()},
+        )
+        return existing
+
+    def _inspect_lease(self, identifier: str, *, required: bool) -> Lease | None:
+        result = self.executor.run(
+            [
+                self.config.crabbox_bin,
+                "inspect",
+                "--provider",
+                "aws",
+                "--id",
+                identifier,
+                "--json",
+            ],
+            capture_output=True,
+        )
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "").strip()
+            missing = any(
+                marker in detail.lower() for marker in ("not found", "no claim", "unknown lease")
+            )
+            if not missing:
+                raise FleetError(
+                    f"Crabbox inspect failed for {identifier}: "
+                    f"{detail[:500] or f'exit {result.returncode}'}"
+                )
+            if required:
+                raise LeaseUnavailableError(f"Crabbox lease {identifier} could not be inspected")
+            return None
+        try:
+            value = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise FleetError(f"invalid Crabbox inspect JSON for {identifier}") from exc
+        return Lease.from_inspect(value, region=self.config.region)
+
+    def _hydrate_lease(self, lease: Lease) -> None:
+        assert self.runner_archive is not None
+        remote_runner_archive = f"/tmp/{lease.slug}-runner.tar.gz"
+        remote_task_archive = f"/tmp/{lease.slug}-tasks.tar.gz"
+        remote_env = f"/tmp/{lease.slug}-provider.env"
+        self._checked(
+            self._ssh_command(
+                lease,
+                ["mkdir", "-p", self.config.remote_root],
+            ),
+            capture_output=True,
+            description=f"prepare {lease.slug}",
+        )
+        for local_path, remote_path in (
+            (self.runner_archive, remote_runner_archive),
+            (self.config.task_archive, remote_task_archive),
+            (self.config.env_file, remote_env),
+        ):
+            self._checked(
+                self._scp_command(lease, local_path, remote_path),
+                capture_output=True,
+                description=f"sync {local_path.name} to {lease.slug}",
+            )
+
+        script = """
+set -euo pipefail
+root=$1
+runner_archive=$2
+task_archive=$3
+source_env=$4
+runner_commit=$5
+runner_sha256=$6
+task_sha256=$7
+printf '%s  %s\n' "$runner_sha256" "$runner_archive" | sha256sum -c -
+printf '%s  %s\n' "$task_sha256" "$task_archive" | sha256sum -c -
+rm -rf "$root/runner.new" "$root/public-tasks.new"
+mkdir -p "$root/runner.new" "$root/public-tasks.new" "$root/secrets"
+tar -xzf "$runner_archive" -C "$root/runner.new"
+tar -xzf "$task_archive" -C "$root/public-tasks.new"
+install -m 0600 "$source_env" "$root/secrets/provider.env"
+rm -rf "$root/runner" "$root/public-tasks"
+mv "$root/runner.new" "$root/runner"
+mv "$root/public-tasks.new" "$root/public-tasks"
+printf '%s\n' "$runner_commit" > "$root/runner.commit"
+rm -f "$runner_archive" "$task_archive" "$source_env"
+bash "$root/runner/scripts/native_eval/bootstrap_beast.sh"
+"""
+        self._checked(
+            self._ssh_command(
+                lease,
+                [
+                    "bash",
+                    "-c",
+                    script,
+                    "fleet-hydrate",
+                    self.config.remote_root,
+                    remote_runner_archive,
+                    remote_task_archive,
+                    remote_env,
+                    self.runner_commit,
+                    self.runner_archive_sha256,
+                    self.task_archive_sha256,
+                ],
+            ),
+            capture_output=False,
+            description=f"bootstrap {lease.slug}",
+        )
+        self._store.update(
+            self._run_label_for_lease(lease.lease_id),
+            status="ready",
+            bootstrapped_at_utc=utc_now(),
+        )
+
+    def _probe_remote(self, lease: Lease, run_label: str) -> str:
+        script = """
+set -eu
+root=$1
+label=$2
+state="/tmp/shellbench-runs/$label"
+job="$root/results/jobs/$label"
+if [ -f "$state/done" ]; then
+  printf 'done\n'
+elif [ -f "$state/pid" ] && kill -0 "$(cat "$state/pid")" 2>/dev/null; then
+  printf 'running\n'
+elif [ -e "$state" ] || [ -e "$job" ]; then
+  printf 'stale\n'
+else
+  printf 'missing\n'
+fi
+"""
+        result = self._checked(
+            self._ssh_command(
+                lease,
+                [
+                    "bash",
+                    "-c",
+                    script,
+                    "fleet-probe",
+                    self.config.remote_root,
+                    run_label,
+                ],
+            ),
+            capture_output=True,
+            description=f"probe {run_label}",
+        )
+        state = result.stdout.strip()
+        if state not in {"missing", "running", "done", "stale"}:
+            raise FleetError(f"unexpected remote state for {run_label}: {state!r}")
+        return state
+
+    def _dispatch(self, lease: Lease, run: RunSpec) -> None:
+        script = """
+set -euo pipefail
+root=$1
+label=$2
+shift 2
+mkdir -p "$root/run-logs"
+stdout="$root/run-logs/$label.stdout.log"
+stderr="$root/run-logs/$label.stderr.log"
+nohup "$root/runner/scripts/native_eval/remote_run.sh" "$@" \
+  >"$stdout" 2>"$stderr" </dev/null &
+pid=$!
+sleep 1
+kill -0 "$pid"
+printf '%s\n' "$pid"
+"""
+        args = [
+            self.config.remote_root,
+            f"{self.config.remote_root}/public-tasks/combined tasks/tasks",
+            f"{self.config.remote_root}/secrets/provider.env",
+            run.run_label,
+            run.harness,
+            run.model_slug,
+            str(run.repetition),
+            str(run.expected_task_count),
+            str(self._store.data["public_tasks_commit"]),
+            run.run_date,
+            str(self.config.task_concurrency),
+        ]
+        self._checked(
+            self._ssh_command(
+                lease,
+                [
+                    "bash",
+                    "-c",
+                    script,
+                    "fleet-dispatch",
+                    self.config.remote_root,
+                    run.run_label,
+                    *args,
+                ],
+            ),
+            capture_output=True,
+            description=f"dispatch {run.run_label}",
+        )
+        self._store.update(
+            run.run_label,
+            dispatched_at_utc=utc_now(),
+        )
+
+    def _run_checkpoint_loop(
+        self,
+        lease: Lease,
+        run_label: str,
+    ) -> subprocess.CompletedProcess[str]:
+        control_hash = hashlib.sha256(lease.lease_id.encode()).hexdigest()[:16]
+        control_path = Path("/tmp") / f"shellbench-fleet-{control_hash}.sock"
+        return self.executor.run(
+            [
+                self.config.python_bin,
+                "-m",
+                "scripts.native_eval.checkpoint_loop",
+                "--target",
+                lease.target,
+                "--port",
+                str(lease.port),
+                "--identity-file",
+                str(lease.identity_file),
+                "--control-path",
+                str(control_path),
+                "--runner-root",
+                f"{self.config.remote_root}/runner",
+                "--remote-root",
+                self.config.remote_root,
+                "--run-label",
+                run_label,
+                "--local-root",
+                str(self.config.local_root),
+                "--poll-seconds",
+                str(self.config.checkpoint_poll_seconds),
+            ],
+            capture_output=False,
+        )
+
+    def _verify_final(self, run_label: str) -> tuple[bool, int, list[str]]:
+        archive = self.config.local_root / "raw" / f"{run_label}-final-artifacts.tar.gz"
+        if not archive.is_file():
+            return False, 0, self._local_artifacts(run_label)
+        try:
+            with tarfile.open(archive, "r:gz") as handle:
+                handle.getmembers()
+            result_count = count_result_json(archive)
+        except (OSError, tarfile.TarError):
+            return False, 0, self._local_artifacts(run_label)
+        return True, result_count, self._local_artifacts(run_label)
+
+    def _finish_exported(self, entry: dict[str, Any], run: RunSpec) -> bool:
+        verified, result_count, artifacts = self._verify_final(run.run_label)
+        if not verified:
+            self._mark_recovery_required(
+                run.run_label,
+                "run was marked exported but its final archive is unavailable",
+            )
+            return False
+        lease_value = entry.get("lease")
+        if not lease_value:
+            self._mark_recovery_required(
+                run.run_label,
+                "verified export has no lease metadata for cleanup",
+            )
+            return False
+        stop = self.executor.run(
+            [
+                self.config.crabbox_bin,
+                "stop",
+                "--provider",
+                "aws",
+                "--id",
+                str(lease_value["id"]),
+            ],
+            capture_output=True,
+        )
+        if stop.returncode:
+            self._store.update(
+                run.run_label,
+                status="stop_pending",
+                verified_final_export=True,
+                final_result_count=result_count,
+                artifacts=artifacts,
+                last_error=f"Crabbox stop failed with exit {stop.returncode}",
+            )
+            return False
+
+        lease_value = dict(lease_value)
+        lease_value.update({"state": "stopped", "stopped_at_utc": utc_now()})
+        raw_exit_code = entry.get("run_exit_code")
+        run_exit_code = int(raw_exit_code) if raw_exit_code is not None else None
+        completed = run_exit_code == 0 and result_count == run.expected_task_count
+        status = "completed" if completed else "failed"
+        self._store.update(
+            run.run_label,
+            status=status,
+            lease=lease_value,
+            verified_final_export=True,
+            final_result_count=result_count,
+            artifacts=artifacts,
+            finished_at_utc=utc_now(),
+            last_error=(
+                None
+                if completed
+                else (
+                    f"run exit {run_exit_code if run_exit_code is not None else 'unknown'}; "
+                    f"result coverage {result_count}/{run.expected_task_count}"
+                )
+            ),
+        )
+        if not completed:
+            self._schedule_rerun(self._store.get(run.run_label))
+        return completed
+
+    def _mark_recovery_required(self, run_label: str, error: str) -> None:
+        self._store.update(
+            run_label,
+            status="recovery_required",
+            last_error=error[:1000],
+        )
+
+    def _schedule_existing_reruns(self) -> None:
+        for entry in self._store.all_entries():
+            if entry.get("status") in RERUN_STATUSES:
+                self._schedule_rerun(entry)
+
+    def _resume_recovery_entries(self) -> None:
+        for entry in self._store.all_entries():
+            if entry.get("status") != "recovery_required":
+                continue
+            verified, result_count, artifacts = self._verify_final(entry["run_label"])
+            if verified and entry.get("lease"):
+                self._store.update(
+                    entry["run_label"],
+                    status="exported",
+                    verified_final_export=True,
+                    final_result_count=result_count,
+                    artifacts=artifacts,
+                    last_error=None,
+                )
+            elif entry.get("lease"):
+                self._store.update(
+                    entry["run_label"],
+                    status="running",
+                    last_error=None,
+                )
+            elif entry.get("requested_lease_slug"):
+                self._store.update(
+                    entry["run_label"],
+                    status="leasing",
+                    last_error=None,
+                )
+            else:
+                self._store.update(
+                    entry["run_label"],
+                    status="failed",
+                    finished_at_utc=utc_now(),
+                )
+
+    def _schedule_rerun(self, entry: dict[str, Any]) -> str | None:
+        root_label = str(entry.get("rerun_of") or entry["run_label"])
+        existing = self._store.all_entries()
+        if any(
+            item.get("rerun_of") == root_label and item["status"] not in RERUN_STATUSES
+            for item in existing
+        ):
+            return None
+        attempts = {
+            int(item.get("attempt", 0))
+            for item in existing
+            if item["run_label"] == root_label or item.get("rerun_of") == root_label
+        }
+        next_attempt = max(attempts, default=0) + 1
+        if next_attempt >= self.config.max_attempts:
+            return None
+        label = f"{root_label}-rerun{next_attempt}"
+        labels = {item["run_label"] for item in existing}
+        while label in labels and next_attempt < self.config.max_attempts:
+            next_attempt += 1
+            label = f"{root_label}-rerun{next_attempt}"
+        if next_attempt >= self.config.max_attempts:
+            return None
+
+        run = self._run_spec(entry)
+        rerun = {
+            **run.to_dict(),
+            "run_label": label,
+            "attempt": next_attempt,
+            "status": "planned",
+            "leaderboard_eligible": None,
+            "rerun_of": root_label,
+            "lease": None,
+            "artifacts": [],
+            "created_at_utc": utc_now(),
+        }
+        self._store.append(rerun)
+        return label
+
+    def _matrix_satisfied(self) -> bool:
+        entries = self._store.all_entries()
+        roots = [entry["run_label"] for entry in entries if not entry.get("rerun_of")]
+        return all(
+            any(
+                candidate.get("status") == "completed"
+                and (candidate["run_label"] == root or candidate.get("rerun_of") == root)
+                for candidate in entries
+            )
+            for root in roots
+        )
+
+    def _run_spec(self, entry: dict[str, Any]) -> RunSpec:
+        try:
+            return RunSpec(**{field: entry[field] for field in RUN_SPEC_FIELDS})
+        except KeyError as exc:
+            raise FleetError(
+                f"run entry {entry.get('run_label', '<unknown>')} lacks {exc.args[0]}"
+            ) from exc
+
+    def _run_label_for_lease(self, lease_id: str) -> str:
+        for entry in self._store.all_entries():
+            if (entry.get("lease") or {}).get("id") == lease_id:
+                return str(entry["run_label"])
+        raise FleetError(f"lease {lease_id} is not assigned to a run")
+
+    def _lease_slug(self, run_label: str) -> str:
+        digest = hashlib.sha256(run_label.encode()).hexdigest()[:12]
+        return f"sb-native-{digest}"
+
+    def _local_artifacts(self, run_label: str) -> list[str]:
+        paths = [
+            *sorted((self.config.local_root / "raw").glob(f"{run_label}-*.tar.gz")),
+            *sorted((self.config.local_root / "logs").glob(f"{run_label}.*.log")),
+        ]
+        return [str(path.relative_to(self.config.local_root)) for path in paths if path.is_file()]
+
+    def _ssh_options(self, lease: Lease) -> list[str]:
+        return [
+            "-i",
+            str(lease.identity_file),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=15",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+        ]
+
+    def _ssh_command(self, lease: Lease, remote_command: Sequence[str]) -> list[str]:
+        return [
+            "ssh",
+            "-p",
+            str(lease.port),
+            *self._ssh_options(lease),
+            lease.target,
+            shlex.join(remote_command),
+        ]
+
+    def _scp_command(
+        self,
+        lease: Lease,
+        local_path: Path,
+        remote_path: str,
+    ) -> list[str]:
+        return [
+            "scp",
+            "-P",
+            str(lease.port),
+            *self._ssh_options(lease),
+            str(local_path),
+            f"{lease.target}:{remote_path}",
+        ]
+
+    def _checked(
+        self,
+        command: Sequence[str],
+        *,
+        capture_output: bool,
+        description: str,
+    ) -> subprocess.CompletedProcess[str]:
+        result = self.executor.run(command, capture_output=capture_output)
+        if result.returncode:
+            detail = (result.stderr or result.stdout or "").strip()[:500]
+            suffix = f": {detail}" if detail else ""
+            raise FleetError(f"{description} failed with exit {result.returncode}{suffix}")
+        return result
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-index", type=Path, required=True)
+    parser.add_argument("--local-root", type=Path, required=True)
+    parser.add_argument("--runner-root", type=Path, required=True)
+    parser.add_argument("--task-archive", type=Path, required=True)
+    parser.add_argument("--env-file", type=Path, required=True)
+    parser.add_argument("--max-leases", type=int, default=10)
+    parser.add_argument("--max-attempts", type=int, default=2)
+    parser.add_argument("--task-concurrency", type=int, default=16)
+    parser.add_argument("--crabbox-bin", default="crabbox")
+    parser.add_argument("--python-bin", default=sys.executable)
+    parser.add_argument("--machine-class", default="beast")
+    parser.add_argument("--instance-type", default="c7a.24xlarge")
+    parser.add_argument("--market", default="on-demand")
+    parser.add_argument("--region", default="eu-west-1")
+    parser.add_argument("--ttl", default="12h")
+    parser.add_argument("--idle-timeout", default="12h")
+    parser.add_argument(
+        "--remote-root",
+        default="/work/crabbox/shellbench-native",
+    )
+    parser.add_argument("--checkpoint-poll-seconds", type=int, default=30)
+    parser.add_argument("--runner-archive", type=Path)
+    parser.add_argument("--runner-commit")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = FleetConfig(
+        run_index=args.run_index,
+        local_root=args.local_root,
+        runner_root=args.runner_root,
+        task_archive=args.task_archive,
+        env_file=args.env_file,
+        max_leases=args.max_leases,
+        max_attempts=args.max_attempts,
+        task_concurrency=args.task_concurrency,
+        crabbox_bin=args.crabbox_bin,
+        python_bin=args.python_bin,
+        machine_class=args.machine_class,
+        instance_type=args.instance_type,
+        market=args.market,
+        region=args.region,
+        ttl=args.ttl,
+        idle_timeout=args.idle_timeout,
+        remote_root=args.remote_root,
+        checkpoint_poll_seconds=args.checkpoint_poll_seconds,
+        runner_archive=args.runner_archive,
+        runner_commit=args.runner_commit,
+    )
+    try:
+        return FleetController(config).run()
+    except (FleetError, OSError, json.JSONDecodeError) as exc:
+        print(f"fleet controller failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -240,6 +240,7 @@ class FleetController:
         self.runner_commit = ""
         self.runner_archive_sha256 = ""
         self.task_archive_sha256 = ""
+        self.crabbox_cli_version = ""
 
     def run(self) -> int:
         self._prepare_local_layout()
@@ -354,6 +355,12 @@ class FleetController:
                 raise FleetError(f"invalid archive: {archive}") from exc
         self.runner_archive_sha256 = _sha256(self.runner_archive)
         self.task_archive_sha256 = _sha256(self.config.task_archive)
+        version = self._checked(
+            [self.config.crabbox_bin, "--version"],
+            capture_output=True,
+            description="resolve Crabbox CLI version",
+        )
+        self.crabbox_cli_version = version.stdout.strip()
 
     def _record_fleet_metadata(self) -> None:
         assert self.runner_archive is not None
@@ -370,6 +377,7 @@ class FleetController:
                 "region": self.config.region,
                 "max_leases": self.config.max_leases,
                 "task_concurrency": self.config.task_concurrency,
+                "crabbox_cli_version": self.crabbox_cli_version,
                 "controller_started_at_utc": utc_now(),
             }
         )
@@ -456,7 +464,11 @@ class FleetController:
         lease_value = entry.get("lease")
         if lease_value:
             identifier = str(lease_value["id"])
-            return self._inspect_lease(identifier, required=True)
+            return self._inspect_lease(
+                identifier,
+                required=True,
+                region_hint=str(lease_value.get("region") or ""),
+            )
 
         slug = str(entry.get("requested_lease_slug") or self._lease_slug(entry["run_label"]))
         self._store.update(
@@ -467,6 +479,8 @@ class FleetController:
         existing = self._inspect_lease(slug, required=False)
         if existing is None:
             command = [
+                "env",
+                f"CRABBOX_CAPACITY_MARKET={self.config.market}",
                 self.config.crabbox_bin,
                 "warmup",
                 "--provider",
@@ -475,8 +489,6 @@ class FleetController:
                 self.config.machine_class,
                 "--slug",
                 slug,
-                "--market",
-                self.config.market,
                 "--ttl",
                 self.config.ttl,
                 "--idle-timeout",
@@ -497,7 +509,13 @@ class FleetController:
         )
         return existing
 
-    def _inspect_lease(self, identifier: str, *, required: bool) -> Lease | None:
+    def _inspect_lease(
+        self,
+        identifier: str,
+        *,
+        required: bool,
+        region_hint: str = "",
+    ) -> Lease | None:
         result = self.executor.run(
             [
                 self.config.crabbox_bin,
@@ -527,7 +545,45 @@ class FleetController:
             value = json.loads(result.stdout)
         except json.JSONDecodeError as exc:
             raise FleetError(f"invalid Crabbox inspect JSON for {identifier}") from exc
-        return Lease.from_inspect(value, region=self.config.region)
+        lease = Lease.from_inspect(
+            value,
+            region=region_hint or self.config.region,
+        )
+        return self._detect_region(lease)
+
+    def _detect_region(self, lease: Lease) -> Lease:
+        script = """
+set -eu
+token=$(curl -fsS --max-time 3 -X PUT \
+  -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' \
+  http://169.254.169.254/latest/api/token 2>/dev/null || true)
+[ -n "$token" ] || exit 0
+curl -fsS --max-time 3 \
+  -H "X-aws-ec2-metadata-token: $token" \
+  http://169.254.169.254/latest/dynamic/instance-identity/document \
+  2>/dev/null \
+  | sed -n 's/.*"region"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p'
+"""
+        result = self.executor.run(
+            self._ssh_command(
+                lease,
+                ["bash", "-c", script, "fleet-region"],
+            ),
+            capture_output=True,
+        )
+        region = result.stdout.strip() if result.returncode == 0 else ""
+        if not region:
+            return lease
+        return Lease(
+            lease_id=lease.lease_id,
+            slug=lease.slug,
+            host=lease.host,
+            user=lease.user,
+            port=lease.port,
+            identity_file=lease.identity_file,
+            instance_type=lease.instance_type,
+            region=region,
+        )
 
     def _hydrate_lease(self, lease: Lease) -> None:
         assert self.runner_archive is not None
@@ -644,11 +700,26 @@ fi
 set -euo pipefail
 root=$1
 label=$2
-shift 2
+crabbox_cli_version=$3
+crabbox_slug=$4
+crabbox_lease_id=$5
+crabbox_instance_type=$6
+crabbox_ip=$7
+crabbox_region=$8
+runner_commit=$9
+shift 9
 mkdir -p "$root/run-logs"
 stdout="$root/run-logs/$label.stdout.log"
 stderr="$root/run-logs/$label.stderr.log"
-nohup "$root/runner/scripts/native_eval/remote_run.sh" "$@" \
+nohup env \
+  "CRABBOX_CLI_VERSION=$crabbox_cli_version" \
+  "CRABBOX_SLUG=$crabbox_slug" \
+  "CRABBOX_LEASE_ID=$crabbox_lease_id" \
+  "CRABBOX_INSTANCE_TYPE=$crabbox_instance_type" \
+  "CRABBOX_IP=$crabbox_ip" \
+  "CRABBOX_REGION=$crabbox_region" \
+  "SHELLBENCH_RUNNER_COMMIT=$runner_commit" \
+  "$root/runner/scripts/native_eval/remote_run.sh" "$@" \
   >"$stdout" 2>"$stderr" </dev/null &
 pid=$!
 sleep 1
@@ -678,6 +749,13 @@ printf '%s\n' "$pid"
                     "fleet-dispatch",
                     self.config.remote_root,
                     run.run_label,
+                    self.crabbox_cli_version,
+                    lease.slug,
+                    lease.lease_id,
+                    lease.instance_type,
+                    lease.host,
+                    lease.region,
+                    self.runner_commit,
                     *args,
                 ],
             ),

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -159,6 +159,9 @@ class FleetConfig:
     warmup_capacity_backoff_seconds: float = 5.0
     runner_archive: Path | None = None
     runner_commit: str | None = None
+    harbor_reference_commit: str = ""
+    judge_model_id: str = ""
+    execution_mode: str = "native"
 
 
 class RunIndexStore:
@@ -394,6 +397,9 @@ class FleetController:
                 "runner_commit": self.runner_commit,
                 "runner_archive_sha256": self.runner_archive_sha256,
                 "task_archive_sha256": self.task_archive_sha256,
+                "harbor_reference_commit": self.config.harbor_reference_commit,
+                "judge_model_id": self.config.judge_model_id,
+                "execution_mode": self.config.execution_mode,
                 "provider": "aws",
                 "machine_class": self.config.machine_class,
                 "instance_type": self.config.instance_type,
@@ -754,6 +760,10 @@ crabbox_ip=$7
 crabbox_region=$8
 runner_commit=$9
 shift 9
+harbor_reference_commit=$1
+judge_model_id=$2
+execution_mode=$3
+shift 3
 mkdir -p "$root/run-logs"
 stdout="$root/run-logs/$label.stdout.log"
 stderr="$root/run-logs/$label.stderr.log"
@@ -765,6 +775,9 @@ nohup env \
   "CRABBOX_IP=$crabbox_ip" \
   "CRABBOX_REGION=$crabbox_region" \
   "SHELLBENCH_RUNNER_COMMIT=$runner_commit" \
+  "SHELLBENCH_HARBOR_REFERENCE_COMMIT=$harbor_reference_commit" \
+  "SHELLBENCH_JUDGE_MODEL_ID=$judge_model_id" \
+  "SHELLBENCH_EXECUTION_MODE=$execution_mode" \
   "$root/runner/scripts/native_eval/remote_run.sh" "$@" \
   >"$stdout" 2>"$stderr" </dev/null &
 pid=$!
@@ -802,6 +815,9 @@ printf '%s\n' "$pid"
                     lease.host,
                     lease.region,
                     self.runner_commit,
+                    self.config.harbor_reference_commit,
+                    self.config.judge_model_id,
+                    self.config.execution_mode,
                     *args,
                 ],
             ),
@@ -1257,6 +1273,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--warmup-capacity-backoff-seconds", type=float, default=5.0)
     parser.add_argument("--runner-archive", type=Path)
     parser.add_argument("--runner-commit")
+    parser.add_argument("--harbor-reference-commit", default="")
+    parser.add_argument("--judge-model-id", default="")
+    parser.add_argument("--execution-mode", default="native")
     args = parser.parse_args(argv)
     args.model_max_runs = _parse_model_values(
         parser,
@@ -1304,6 +1323,9 @@ def main(argv: list[str] | None = None) -> int:
         warmup_capacity_backoff_seconds=args.warmup_capacity_backoff_seconds,
         runner_archive=args.runner_archive,
         runner_commit=args.runner_commit,
+        harbor_reference_commit=args.harbor_reference_commit,
+        judge_model_id=args.judge_model_id,
+        execution_mode=args.execution_mode,
     )
     try:
         return FleetController(config).run()

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -800,32 +800,44 @@ printf '%s\n' "$pid"
         ]
         for statuses in (CLEANUP_STATUSES, ACTIVE_RUN_STATUSES):
             for entry in candidates:
-                if entry.get("status") in statuses:
+                if entry.get("lease") and entry.get("status") in statuses:
                     return str(entry["run_label"])
 
         active_entries = [
-            entry for entry in entries if entry.get("status") in ACTIVE_RUN_STATUSES
-        ]
-        cleanup_entries = [
-            entry for entry in entries if entry.get("status") in CLEANUP_STATUSES
-        ]
-        planned_reservations = [
             entry
             for entry in entries
-            if entry["run_label"] in in_flight_labels and entry.get("status") == "planned"
+            if entry.get("lease") and entry.get("status") in ACTIVE_RUN_STATUSES
+        ]
+        cleanup_entries = [
+            entry
+            for entry in entries
+            if entry.get("lease") and entry.get("status") in CLEANUP_STATUSES
+        ]
+        pending_reservations = [
+            entry
+            for entry in entries
+            if entry["run_label"] in in_flight_labels
+            and not entry.get("lease")
+            and (
+                entry.get("status") == "planned"
+                or entry.get("status") in ACTIVE_RUN_STATUSES
+            )
         ]
         occupied_slots = (
-            len(active_entries) + len(cleanup_entries) + len(planned_reservations)
+            len(active_entries) + len(cleanup_entries) + len(pending_reservations)
         )
         if occupied_slots >= self.config.max_leases:
             return None
 
         active_models = Counter(
             self._run_spec(entry).model_slug
-            for entry in [*active_entries, *planned_reservations]
+            for entry in [*active_entries, *pending_reservations]
         )
         for entry in candidates:
-            if entry.get("status") != "planned":
+            pending = entry.get("status") == "planned" or (
+                not entry.get("lease") and entry.get("status") in ACTIVE_RUN_STATUSES
+            )
+            if not pending:
                 continue
             model_slug = self._run_spec(entry).model_slug
             model_limit = self.config.model_max_runs.get(model_slug)
@@ -984,7 +996,7 @@ printf '%s\n' "$pid"
             elif entry.get("requested_lease_slug"):
                 self._store.update(
                     entry["run_label"],
-                    status="leasing",
+                    status="planned",
                     last_error=None,
                 )
             else:

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -15,6 +15,7 @@ from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any, Protocol, Sequence
 
 from scripts.native_eval.checkpoint_loop import count_result_json
@@ -797,6 +798,10 @@ printf '%s\n' "$pid"
             str(self._store.data["public_tasks_commit"]),
             run.run_date,
             str(self._task_concurrency(run.model_slug)),
+            run.harness_version,
+            run.model_id,
+            run.provider,
+            run.proxy_model_name,
         ]
         self._checked(
             self._ssh_command(
@@ -954,6 +959,48 @@ printf '%s\n' "$pid"
             return False, 0, self._local_artifacts(run_label)
         return True, result_count, self._local_artifacts(run_label)
 
+    def _archived_exit_status(self, run_label: str) -> int | None:
+        archive = self.config.local_root / "raw" / f"{run_label}-final-artifacts.tar.gz"
+        candidates: list[int] = []
+        with tarfile.open(archive, "r:gz") as handle:
+            for member in handle.getmembers():
+                if not member.isfile():
+                    continue
+                parts = PurePosixPath(member.name).parts
+                if not parts or parts[-1] != "exit_status":
+                    continue
+                if (
+                    f"shellbench_meta-{run_label}" not in parts
+                    and not (
+                        len(parts) >= 3
+                        and parts[-3:] == ("shellbench-runs", run_label, "exit_status")
+                    )
+                ):
+                    continue
+                extracted = handle.extractfile(member)
+                if extracted is None:
+                    continue
+                raw_status = extracted.read().decode("utf-8").strip()
+                try:
+                    candidates.append(int(raw_status))
+                except ValueError as exc:
+                    raise FleetError(
+                        f"invalid archived exit_status for {run_label}: {raw_status!r}"
+                    ) from exc
+        if len(set(candidates)) > 1:
+            raise FleetError(f"conflicting archived exit_status values for {run_label}")
+        return candidates[0] if candidates else None
+
+    def _checkpoint_log_has_final(self, run_label: str) -> bool:
+        log_path = self.config.local_root / "logs" / f"{run_label}.checkpoints.log"
+        if not log_path.is_file():
+            return False
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            fields = line.split("\t", 4)
+            if len(fields) >= 2 and fields[1] == "final":
+                return True
+        return False
+
     def _finish_exported(self, entry: dict[str, Any], run: RunSpec) -> bool:
         verified, result_count, artifacts = self._verify_final(run.run_label)
         if not verified:
@@ -969,6 +1016,30 @@ printf '%s\n' "$pid"
                 "verified export has no lease metadata for cleanup",
             )
             return False
+        raw_exit_code = entry.get("run_exit_code")
+        run_exit_code = int(raw_exit_code) if raw_exit_code is not None else None
+        exit_code_changes: dict[str, Any] = {}
+        if run_exit_code is None:
+            archived_exit_status = self._archived_exit_status(run.run_label)
+            if archived_exit_status is not None:
+                run_exit_code = archived_exit_status
+                exit_code_changes = {
+                    "run_exit_code": run_exit_code,
+                    "run_exit_code_source": "archived_exit_status",
+                }
+            elif (
+                result_count == run.expected_task_count
+                and self._checkpoint_log_has_final(run.run_label)
+            ):
+                run_exit_code = 0
+                exit_code_changes = {
+                    "run_exit_code": 0,
+                    "run_exit_code_source": "recovered_full_coverage_remote_done",
+                    "run_exit_code_inference": (
+                        "inferred zero from verified full-coverage archive and "
+                        "checkpoint final event after remote done"
+                    ),
+                }
         stop = self.executor.run(
             [
                 self.config.crabbox_bin,
@@ -988,13 +1059,12 @@ printf '%s\n' "$pid"
                 final_result_count=result_count,
                 artifacts=artifacts,
                 last_error=f"Crabbox stop failed with exit {stop.returncode}",
+                **exit_code_changes,
             )
             return False
 
         lease_value = dict(lease_value)
         lease_value.update({"state": "stopped", "stopped_at_utc": utc_now()})
-        raw_exit_code = entry.get("run_exit_code")
-        run_exit_code = int(raw_exit_code) if raw_exit_code is not None else None
         completed = run_exit_code == 0 and result_count == run.expected_task_count
         status = "completed" if completed else "failed"
         self._store.update(
@@ -1013,6 +1083,7 @@ printf '%s\n' "$pid"
                     f"result coverage {result_count}/{run.expected_task_count}"
                 )
             ),
+            **exit_code_changes,
         )
         if not completed:
             self._schedule_rerun(self._store.get(run.run_label))

--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tarfile
 import threading
+import time
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
@@ -153,6 +154,8 @@ class FleetConfig:
     idle_timeout: str = "12h"
     remote_root: str = "/work/crabbox/shellbench-native"
     checkpoint_poll_seconds: int = 30
+    warmup_capacity_attempts: int = 12
+    warmup_capacity_backoff_seconds: float = 5.0
     runner_archive: Path | None = None
     runner_commit: str | None = None
 
@@ -240,6 +243,10 @@ class FleetController:
             raise ValueError("max_attempts must be at least 1")
         if config.task_concurrency < 1:
             raise ValueError("task_concurrency must be at least 1")
+        if config.warmup_capacity_attempts < 1:
+            raise ValueError("warmup_capacity_attempts must be at least 1")
+        if config.warmup_capacity_backoff_seconds < 0:
+            raise ValueError("warmup_capacity_backoff_seconds cannot be negative")
         _validate_model_values(config.model_max_runs, "model_max_runs")
         _validate_model_values(config.model_task_concurrency, "model_task_concurrency")
         self.config = config
@@ -394,6 +401,10 @@ class FleetController:
                 "task_concurrency": self.config.task_concurrency,
                 "model_max_runs": self.config.model_max_runs,
                 "model_task_concurrency": self.config.model_task_concurrency,
+                "warmup_capacity_attempts": self.config.warmup_capacity_attempts,
+                "warmup_capacity_backoff_seconds": (
+                    self.config.warmup_capacity_backoff_seconds
+                ),
                 "crabbox_cli_version": self.crabbox_cli_version,
                 "controller_started_at_utc": utc_now(),
             }
@@ -513,11 +524,7 @@ class FleetController:
             ]
             if self.config.instance_type:
                 command.extend(["--type", self.config.instance_type])
-            self._checked(
-                command,
-                capture_output=True,
-                description=f"lease Crabbox {slug}",
-            )
+            self._warmup_lease(command, slug)
             existing = self._inspect_lease(slug, required=True)
         self._store.update(
             entry["run_label"],
@@ -525,6 +532,24 @@ class FleetController:
             lease={**existing.to_dict(), "started_at_utc": utc_now()},
         )
         return existing
+
+    def _warmup_lease(self, command: Sequence[str], slug: str) -> None:
+        for attempt in range(1, self.config.warmup_capacity_attempts + 1):
+            result = self.executor.run(command, capture_output=True)
+            if result.returncode == 0:
+                return
+            detail = (result.stderr or result.stdout or "").strip()
+            capacity_pending = all(
+                marker in detail.lower()
+                for marker in ("429", "cost_limit_exceeded", "active lease limit")
+            )
+            if not capacity_pending or attempt == self.config.warmup_capacity_attempts:
+                suffix = f": {detail[:500]}" if detail else ""
+                raise FleetError(
+                    f"lease Crabbox {slug} failed with exit {result.returncode}{suffix}"
+                )
+            if self.config.warmup_capacity_backoff_seconds:
+                time.sleep(self.config.warmup_capacity_backoff_seconds)
 
     def _inspect_lease(
         self,
@@ -1206,6 +1231,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="/work/crabbox/shellbench-native",
     )
     parser.add_argument("--checkpoint-poll-seconds", type=int, default=30)
+    parser.add_argument("--warmup-capacity-attempts", type=int, default=12)
+    parser.add_argument("--warmup-capacity-backoff-seconds", type=float, default=5.0)
     parser.add_argument("--runner-archive", type=Path)
     parser.add_argument("--runner-commit")
     args = parser.parse_args(argv)
@@ -1245,6 +1272,8 @@ def main(argv: list[str] | None = None) -> int:
         idle_timeout=args.idle_timeout,
         remote_root=args.remote_root,
         checkpoint_poll_seconds=args.checkpoint_poll_seconds,
+        warmup_capacity_attempts=args.warmup_capacity_attempts,
+        warmup_capacity_backoff_seconds=args.warmup_capacity_backoff_seconds,
         runner_archive=args.runner_archive,
         runner_commit=args.runner_commit,
     )

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -135,9 +135,22 @@ def _hermes(
     mcp_servers: tuple[McpServer, ...],
 ) -> HarnessCommand:
     home = "/tmp/shellbench-hermes"
+    provider_name = "custom:shellbench"
     config: dict[str, object] = {
-        "model": run.proxy_model_name,
-        "provider": "openai",
+        "model": {
+            "default": run.proxy_model_name,
+            "provider": provider_name,
+        },
+        "providers": {
+            "shellbench": {
+                "name": "shellbench",
+                "api": f"{proxy_url.rstrip('/')}/v1",
+                "key_env": "SHELLBENCH_PROXY_KEY",
+                "transport": "chat_completions",
+                "default_model": run.proxy_model_name,
+                "models": {run.proxy_model_name: {}},
+            }
+        },
         "toolsets": ["hermes-cli"],
         "agent": {"max_turns": 90},
         "memory": {"memory_enabled": False, "user_profile_enabled": False},
@@ -165,8 +178,13 @@ def _hermes(
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
         "export TERMINAL_ENV=local; export TERMINAL_CWD=\"$PWD\"; "
         "hermes --yolo chat -q \"$(cat /tmp/shellbench-instruction.md)\" -Q "
-        f"--model {shlex.quote(run.proxy_model_name)} --provider openai "
-        "2>&1 | tee /logs/agent/hermes.txt"
+        f"--model {shlex.quote(run.proxy_model_name)} "
+        f"--provider {shlex.quote(provider_name)} "
+        ">/logs/agent/hermes.txt 2>&1; status=$?; "
+        "cat /logs/agent/hermes.txt; "
+        "if grep -Eq \"Unknown provider|No LLM provider configured\" "
+        "/logs/agent/hermes.txt; then exit 64; fi; "
+        "exit \"$status\""
     )
     cleanup = (
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
@@ -178,8 +196,7 @@ def _hermes(
         run_command=run_command,
         cleanup_command=cleanup,
         env={
-            "OPENAI_API_KEY": proxy_key,
-            "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+            "SHELLBENCH_PROXY_KEY": proxy_key,
         },
     )
 

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -54,7 +54,7 @@ def _openclaw(
     mcp_servers: tuple[McpServer, ...],
 ) -> HarnessCommand:
     provider = "openai"
-    model = f"{provider}/{run.proxy_model_name}"
+    model = f"{provider}/{run.model_id}"
     servers: dict[str, dict[str, object]] = {}
     for server in mcp_servers:
         if server.transport == "stdio":
@@ -78,8 +78,8 @@ def _openclaw(
                     "apiKey": proxy_key,
                     "models": [
                         {
-                            "id": run.proxy_model_name,
-                            "name": run.proxy_model_name,
+                            "id": run.model_id,
+                            "name": run.model_id,
                         }
                     ],
                 }
@@ -139,7 +139,7 @@ def _hermes(
     provider_name = "custom:shellbench"
     config: dict[str, object] = {
         "model": {
-            "default": run.proxy_model_name,
+            "default": run.model_id,
             "provider": provider_name,
         },
         "providers": {
@@ -148,8 +148,8 @@ def _hermes(
                 "api": f"{proxy_url.rstrip('/')}/v1",
                 "key_env": "SHELLBENCH_PROXY_KEY",
                 "transport": "chat_completions",
-                "default_model": run.proxy_model_name,
-                "models": {run.proxy_model_name: {}},
+                "default_model": run.model_id,
+                "models": {run.model_id: {}},
             }
         },
         "toolsets": ["hermes-cli"],
@@ -179,7 +179,7 @@ def _hermes(
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
         "export TERMINAL_ENV=local; export TERMINAL_CWD=\"$PWD\"; "
         "hermes --yolo chat -q \"$(cat /tmp/shellbench-instruction.md)\" -Q "
-        f"--model {shlex.quote(run.proxy_model_name)} "
+        f"--model {shlex.quote(run.model_id)} "
         f"--provider {shlex.quote(provider_name)} "
         ">/logs/agent/hermes.txt 2>&1; status=$?; "
         "cat /logs/agent/hermes.txt; "
@@ -231,7 +231,7 @@ def _codex(
         f"export PATH={_base_path()}; export CODEX_HOME={home}; "
         "codex exec --dangerously-bypass-approvals-and-sandbox "
         "--skip-git-repo-check "
-        f"--model {shlex.quote(run.proxy_model_name)} "
+        f"--model {shlex.quote(run.model_id)} "
         "--json --enable unified_exec -- "
         "\"$(cat /tmp/shellbench-instruction.md)\" "
         ">/logs/agent/codex.txt 2>&1 </dev/null; status=$?; "
@@ -283,7 +283,7 @@ def _claude_code(
         f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
         "claude --verbose --output-format=stream-json "
         "--permission-mode=bypassPermissions --print "
-        f"--model {shlex.quote(run.proxy_model_name)} "
+        f"--model {shlex.quote(run.model_id)} "
         "\"$(cat /tmp/shellbench-instruction.md)\" "
         ">/logs/agent/claude-code.txt 2>&1 </dev/null; status=$?; "
         "cat /logs/agent/claude-code.txt; exit \"$status\""
@@ -296,11 +296,11 @@ def _claude_code(
             "ANTHROPIC_API_KEY": proxy_key,
             "ANTHROPIC_AUTH_TOKEN": proxy_key,
             "ANTHROPIC_BASE_URL": proxy_url.rstrip("/"),
-            "ANTHROPIC_MODEL": run.proxy_model_name,
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": run.proxy_model_name,
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": run.proxy_model_name,
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": run.proxy_model_name,
-            "CLAUDE_CODE_SUBAGENT_MODEL": run.proxy_model_name,
+            "ANTHROPIC_MODEL": run.model_id,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": run.model_id,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": run.model_id,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": run.model_id,
+            "CLAUDE_CODE_SUBAGENT_MODEL": run.model_id,
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "IS_SANDBOX": "1",
         },

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -102,7 +102,8 @@ def _openclaw(
         "openclaw agent --local --json --agent main --thinking off "
         f"--model {shlex.quote(model)} "
         "--message \"$(cat /tmp/shellbench-instruction.md)\" "
-        "2>&1 </dev/null | tee /logs/agent/openclaw.txt"
+        ">/logs/agent/openclaw.txt 2>&1 </dev/null; status=$?; "
+        "cat /logs/agent/openclaw.txt; exit \"$status\""
     )
     cleanup = (
         "python3 - <<'PY'\n"
@@ -233,7 +234,8 @@ def _codex(
         f"--model {shlex.quote(run.proxy_model_name)} "
         "--json --enable unified_exec -- "
         "\"$(cat /tmp/shellbench-instruction.md)\" "
-        "2>&1 </dev/null | tee /logs/agent/codex.txt"
+        ">/logs/agent/codex.txt 2>&1 </dev/null; status=$?; "
+        "cat /logs/agent/codex.txt; exit \"$status\""
     )
     cleanup = (
         "rm -rf /logs/agent/sessions; "
@@ -279,10 +281,12 @@ def _claude_code(
     )
     run_command = (
         f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
-        "cat /tmp/shellbench-instruction.md | "
         "claude --verbose --output-format=stream-json "
         "--permission-mode=bypassPermissions --print "
-        "2>&1 | tee /logs/agent/claude-code.txt"
+        f"--model {shlex.quote(run.proxy_model_name)} "
+        "\"$(cat /tmp/shellbench-instruction.md)\" "
+        ">/logs/agent/claude-code.txt 2>&1 </dev/null; status=$?; "
+        "cat /logs/agent/claude-code.txt; exit \"$status\""
     )
     return HarnessCommand(
         setup_command=setup,

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from scripts.native_eval.models import RunSpec
+from scripts.native_eval.tasks import McpServer
+
+
+TOOLCHAIN_ROOT = PurePosixPath("/opt/shellbench-native")
+NODE_BIN = TOOLCHAIN_ROOT / "node" / "bin"
+NPM_BIN = TOOLCHAIN_ROOT / "npm-packages" / "node_modules" / ".bin"
+HERMES_BIN = TOOLCHAIN_ROOT / "home" / ".local" / "bin"
+
+
+@dataclass(frozen=True)
+class HarnessCommand:
+    setup_command: str
+    run_command: str
+    cleanup_command: str
+    env: dict[str, str]
+
+
+def build_harness_command(
+    run: RunSpec,
+    *,
+    proxy_url: str,
+    proxy_key: str,
+    mcp_servers: tuple[McpServer, ...],
+) -> HarnessCommand:
+    builders = {
+        "openclaw": _openclaw,
+        "hermes": _hermes,
+        "codex": _codex,
+        "claude-code": _claude_code,
+    }
+    try:
+        builder = builders[run.harness]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported harness: {run.harness}") from exc
+    return builder(run, proxy_url, proxy_key, mcp_servers)
+
+
+def _base_path() -> str:
+    return f"{NODE_BIN}:{NPM_BIN}:{HERMES_BIN}:$PATH"
+
+
+def _openclaw(
+    run: RunSpec,
+    proxy_url: str,
+    proxy_key: str,
+    mcp_servers: tuple[McpServer, ...],
+) -> HarnessCommand:
+    provider = "openai"
+    model = f"{provider}/{run.proxy_model_name}"
+    servers: dict[str, dict[str, object]] = {}
+    for server in mcp_servers:
+        if server.transport == "stdio":
+            servers[server.name] = {
+                "command": server.command,
+                "args": list(server.args),
+            }
+        else:
+            servers[server.name] = {
+                "url": server.url,
+                "transport": server.transport,
+            }
+    config = {
+        "agents": {"defaults": {"workspace": "."}},
+        "gateway": {"mode": "local"},
+        "models": {
+            "providers": {
+                provider: {
+                    "baseUrl": f"{proxy_url.rstrip('/')}/v1",
+                    "api": "openai-responses",
+                    "apiKey": proxy_key,
+                    "models": [{"id": model, "name": model}],
+                }
+            }
+        },
+        "tools": {"deny": ["message"]},
+    }
+    if servers:
+        config["mcp"] = {"servers": servers}
+    config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
+    home = "/tmp/shellbench-openclaw"
+    setup = (
+        f"export PATH={_base_path()}; export HOME={home}; "
+        "rm -rf \"$HOME\"; mkdir -p \"$HOME/.openclaw\"; "
+        "openclaw setup --baseline --workspace . >/logs/agent/setup.log 2>&1; "
+        f"printf %s {config_json} > \"$HOME/.openclaw/openclaw.json\""
+    )
+    run_command = (
+        f"export PATH={_base_path()}; export HOME={home}; "
+        "openclaw agent --local --json --agent main --thinking off "
+        f"--model {shlex.quote(model)} "
+        "--message \"$(cat /tmp/shellbench-instruction.md)\" "
+        "2>&1 </dev/null | tee /logs/agent/openclaw.txt"
+    )
+    cleanup = (
+        "python3 - <<'PY'\n"
+        "import json, pathlib, shutil\n"
+        "p=pathlib.Path('/logs/agent/openclaw.txt')\n"
+        "try:\n"
+        " d=json.loads(p.read_text())\n"
+        " src=((d.get('meta') or {}).get('agentMeta') or {}).get('sessionFile')\n"
+        " if src and pathlib.Path(src).is_file():\n"
+        "  shutil.copy2(src, '/logs/agent/openclaw.session.jsonl')\n"
+        "except Exception:\n"
+        " pass\n"
+        "PY"
+    )
+    return HarnessCommand(
+        setup_command=setup,
+        run_command=run_command,
+        cleanup_command=cleanup,
+        env={
+            "OPENAI_API_KEY": proxy_key,
+            "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+        },
+    )
+
+
+def _hermes(
+    run: RunSpec,
+    proxy_url: str,
+    proxy_key: str,
+    mcp_servers: tuple[McpServer, ...],
+) -> HarnessCommand:
+    home = "/tmp/shellbench-hermes"
+    config: dict[str, object] = {
+        "model": run.proxy_model_name,
+        "provider": "openai",
+        "toolsets": ["hermes-cli"],
+        "agent": {"max_turns": 90},
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "compression": {"enabled": True, "threshold": 0.85},
+        "terminal": {"backend": "local", "timeout": 180},
+        "delegation": {"max_iterations": 50},
+        "checkpoints": {"enabled": False},
+    }
+    if mcp_servers:
+        config["mcp_servers"] = {
+            server.name: (
+                {"command": server.command, "args": list(server.args)}
+                if server.transport == "stdio"
+                else {"url": server.url}
+            )
+            for server in mcp_servers
+        }
+    config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
+    setup = (
+        f"export PATH={_base_path()}; export HERMES_HOME={home}; "
+        "rm -rf \"$HERMES_HOME\"; mkdir -p \"$HERMES_HOME\"; "
+        f"printf %s {config_json} > \"$HERMES_HOME/config.yaml\""
+    )
+    run_command = (
+        f"export PATH={_base_path()}; export HERMES_HOME={home}; "
+        "export TERMINAL_ENV=local; export TERMINAL_CWD=\"$PWD\"; "
+        "hermes --yolo chat -q \"$(cat /tmp/shellbench-instruction.md)\" -Q "
+        f"--model {shlex.quote(run.proxy_model_name)} --provider openai "
+        "2>&1 | tee /logs/agent/hermes.txt"
+    )
+    cleanup = (
+        f"export PATH={_base_path()}; export HERMES_HOME={home}; "
+        "hermes sessions export /logs/agent/hermes-session.jsonl "
+        "--source cli 2>/dev/null || true"
+    )
+    return HarnessCommand(
+        setup_command=setup,
+        run_command=run_command,
+        cleanup_command=cleanup,
+        env={
+            "OPENAI_API_KEY": proxy_key,
+            "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+        },
+    )
+
+
+def _codex(
+    run: RunSpec,
+    proxy_url: str,
+    proxy_key: str,
+    mcp_servers: tuple[McpServer, ...],
+) -> HarnessCommand:
+    home = "/tmp/shellbench-codex"
+    config_lines = [f'openai_base_url = "{proxy_url.rstrip("/")}/v1"']
+    for server in mcp_servers:
+        config_lines.append(f"[mcp_servers.{server.name}]")
+        if server.transport == "stdio":
+            command = shlex.join(
+                [server.command or "", *server.args]
+            )
+            config_lines.append(f"command = {json.dumps(command)}")
+        else:
+            config_lines.append(f"url = {json.dumps(server.url)}")
+    config_text = shlex.quote("\n".join(config_lines) + "\n")
+    auth_json = shlex.quote(json.dumps({"OPENAI_API_KEY": proxy_key}))
+    setup = (
+        f"export PATH={_base_path()}; export CODEX_HOME={home}; "
+        "rm -rf \"$CODEX_HOME\"; mkdir -p \"$CODEX_HOME\"; "
+        f"printf %s {auth_json} > \"$CODEX_HOME/auth.json\"; "
+        f"printf %s {config_text} > \"$CODEX_HOME/config.toml\""
+    )
+    run_command = (
+        f"export PATH={_base_path()}; export CODEX_HOME={home}; "
+        "codex exec --dangerously-bypass-approvals-and-sandbox "
+        "--skip-git-repo-check "
+        f"--model {shlex.quote(run.proxy_model_name)} "
+        "--json --enable unified_exec -- "
+        "\"$(cat /tmp/shellbench-instruction.md)\" "
+        "2>&1 </dev/null | tee /logs/agent/codex.txt"
+    )
+    cleanup = (
+        "rm -rf /logs/agent/sessions; "
+        f"if [ -d {home}/sessions ]; then cp -R {home}/sessions /logs/agent/sessions; fi"
+    )
+    return HarnessCommand(
+        setup_command=setup,
+        run_command=run_command,
+        cleanup_command=cleanup,
+        env={
+            "OPENAI_API_KEY": proxy_key,
+            "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+        },
+    )
+
+
+def _claude_code(
+    run: RunSpec,
+    proxy_url: str,
+    proxy_key: str,
+    mcp_servers: tuple[McpServer, ...],
+) -> HarnessCommand:
+    home = "/tmp/shellbench-claude"
+    servers: dict[str, dict[str, object]] = {}
+    for server in mcp_servers:
+        if server.transport == "stdio":
+            servers[server.name] = {
+                "type": "stdio",
+                "command": server.command,
+                "args": list(server.args),
+            }
+        else:
+            servers[server.name] = {
+                "type": "http" if server.transport == "streamable-http" else server.transport,
+                "url": server.url,
+            }
+    mcp_json = shlex.quote(json.dumps({"mcpServers": servers}, separators=(",", ":")))
+    setup = (
+        f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
+        "rm -rf \"$CLAUDE_CONFIG_DIR\"; "
+        "mkdir -p \"$CLAUDE_CONFIG_DIR/debug\" \"$CLAUDE_CONFIG_DIR/projects/-app\"; "
+        f"printf %s {mcp_json} > \"$CLAUDE_CONFIG_DIR/.claude.json\""
+    )
+    run_command = (
+        f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
+        "cat /tmp/shellbench-instruction.md | "
+        "claude --verbose --output-format=stream-json "
+        "--permission-mode=bypassPermissions --print "
+        "2>&1 | tee /logs/agent/claude-code.txt"
+    )
+    return HarnessCommand(
+        setup_command=setup,
+        run_command=run_command,
+        cleanup_command="true",
+        env={
+            "ANTHROPIC_API_KEY": proxy_key,
+            "ANTHROPIC_AUTH_TOKEN": proxy_key,
+            "ANTHROPIC_BASE_URL": proxy_url.rstrip("/"),
+            "ANTHROPIC_MODEL": run.proxy_model_name,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": run.proxy_model_name,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": run.proxy_model_name,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": run.proxy_model_name,
+            "CLAUDE_CODE_SUBAGENT_MODEL": run.proxy_model_name,
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "IS_SANDBOX": "1",
+        },
+    )

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -76,7 +76,12 @@ def _openclaw(
                     "baseUrl": f"{proxy_url.rstrip('/')}/v1",
                     "api": "openai-responses",
                     "apiKey": proxy_key,
-                    "models": [{"id": model, "name": model}],
+                    "models": [
+                        {
+                            "id": run.proxy_model_name,
+                            "name": run.proxy_model_name,
+                        }
+                    ],
                 }
             }
         },

--- a/scripts/native_eval/models.py
+++ b/scripts/native_eval/models.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    slug: str
+    friendly_name: str
+    provider: str
+    provider_model_id: str
+    proxy_model_name: str
+
+
+@dataclass(frozen=True)
+class HarnessSpec:
+    name: str
+    version: str
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    run_label: str
+    harness: str
+    harness_version: str
+    model_slug: str
+    model_id: str
+    provider: str
+    proxy_model_name: str
+    repetition: int
+    expected_task_count: int
+    run_date: str
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+MODELS: tuple[ModelSpec, ...] = (
+    ModelSpec("gpt55", "gpt-5.5", "openai", "gpt-5.5", "sb-gpt55"),
+    ModelSpec(
+        "gpt56-sol",
+        "gpt-5.6-sol",
+        "openai",
+        "gpt-5.6-sol",
+        "sb-gpt56-sol",
+    ),
+    ModelSpec(
+        "fable5",
+        "fable-5",
+        "anthropic",
+        "claude-fable-5",
+        "sb-fable5",
+    ),
+    ModelSpec(
+        "opus47",
+        "opus-4.7",
+        "anthropic",
+        "claude-opus-4-7",
+        "sb-opus47",
+    ),
+    ModelSpec(
+        "opus48",
+        "opus-4.8",
+        "anthropic",
+        "claude-opus-4-8",
+        "sb-opus48",
+    ),
+    ModelSpec(
+        "opus5",
+        "opus-5",
+        "anthropic",
+        "claude-opus-5",
+        "sb-opus5",
+    ),
+)
+
+HARNESSES: tuple[HarnessSpec, ...] = (
+    HarnessSpec("openclaw", "2026.7.1-2"),
+    HarnessSpec("hermes", "cb06017b1d6e1b9ae0cb35f99a48ffa6bcbaa828"),
+    HarnessSpec("codex", "0.145.0"),
+    HarnessSpec("claude-code", "2.1.220"),
+)
+
+NODE_VERSION = "22.23.1"
+LITELLM_VERSION = "1.93.0"
+
+
+def model_by_slug(slug: str) -> ModelSpec:
+    for model in MODELS:
+        if model.slug == slug:
+            return model
+    raise KeyError(f"Unknown model slug: {slug}")
+
+
+def harness_by_name(name: str) -> HarnessSpec:
+    for harness in HARNESSES:
+        if harness.name == name:
+            return harness
+    raise KeyError(f"Unknown harness: {name}")
+
+
+def build_matrix_plan(
+    expected_task_count: int,
+    *,
+    run_date: str | None = None,
+    harnesses: Iterable[HarnessSpec] = HARNESSES,
+    models: Iterable[ModelSpec] = MODELS,
+    repetitions: Iterable[int] = (1, 2, 3),
+) -> list[RunSpec]:
+    stamp = run_date or date.today().strftime("%Y%m%d")
+    plan: list[RunSpec] = []
+    for harness in harnesses:
+        for model in models:
+            for repetition in repetitions:
+                label = (
+                    f"{harness.name}-{model.slug}-full-"
+                    f"{expected_task_count}-r{repetition}-{stamp}"
+                )
+                plan.append(
+                    RunSpec(
+                        run_label=label,
+                        harness=harness.name,
+                        harness_version=harness.version,
+                        model_slug=model.slug,
+                        model_id=model.provider_model_id,
+                        provider=model.provider,
+                        proxy_model_name=model.proxy_model_name,
+                        repetition=repetition,
+                        expected_task_count=expected_task_count,
+                        run_date=stamp,
+                    )
+                )
+    return plan
+

--- a/scripts/native_eval/models.py
+++ b/scripts/native_eval/models.py
@@ -38,41 +38,41 @@ class RunSpec:
 
 
 MODELS: tuple[ModelSpec, ...] = (
-    ModelSpec("gpt55", "gpt-5.5", "openai", "gpt-5.5", "sb-gpt55"),
+    ModelSpec("gpt55", "gpt-5.5", "openai", "gpt-5.5", "gpt-5.5"),
     ModelSpec(
         "gpt56-sol",
         "gpt-5.6-sol",
         "openai",
         "gpt-5.6-sol",
-        "sb-gpt56-sol",
+        "gpt-5.6-sol",
     ),
     ModelSpec(
         "fable5",
         "fable-5",
         "anthropic",
         "claude-fable-5",
-        "sb-fable5",
+        "claude-fable-5",
     ),
     ModelSpec(
         "opus47",
         "opus-4.7",
         "anthropic",
         "claude-opus-4-7",
-        "sb-opus47",
+        "claude-opus-4-7",
     ),
     ModelSpec(
         "opus48",
         "opus-4.8",
         "anthropic",
         "claude-opus-4-8",
-        "sb-opus48",
+        "claude-opus-4-8",
     ),
     ModelSpec(
         "opus5",
         "opus-5",
         "anthropic",
         "claude-opus-5",
-        "sb-opus5",
+        "claude-opus-5",
     ),
 )
 
@@ -133,4 +133,3 @@ def build_matrix_plan(
                     )
                 )
     return plan
-

--- a/scripts/native_eval/models.py
+++ b/scripts/native_eval/models.py
@@ -85,6 +85,7 @@ HARNESSES: tuple[HarnessSpec, ...] = (
 
 NODE_VERSION = "22.23.1"
 LITELLM_VERSION = "1.93.0"
+REAL_TRAJECTORY_HARNESSES = frozenset({"codex"})
 
 
 def model_by_slug(slug: str) -> ModelSpec:
@@ -99,6 +100,12 @@ def harness_by_name(name: str) -> HarnessSpec:
         if harness.name == name:
             return harness
     raise KeyError(f"Unknown harness: {name}")
+
+
+def trajectory_mode_for_harness(name: str) -> str:
+    if name in REAL_TRAJECTORY_HARNESSES:
+        return "real_harness_events"
+    return "unsupported"
 
 
 def build_matrix_plan(

--- a/scripts/native_eval/plan.py
+++ b/scripts/native_eval/plan.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.native_eval.models import build_matrix_plan
+from scripts.native_eval.runtime import atomic_write_json, utc_now
+from scripts.native_eval.tasks import validate_suite
+
+
+def write_run_index(
+    *,
+    tasks_root: Path,
+    output: Path,
+    public_tasks_commit: str,
+    run_date: str,
+) -> list[dict[str, object]]:
+    tasks = validate_suite(tasks_root)
+    runs = build_matrix_plan(len(tasks), run_date=run_date)
+    entries = [
+        {
+            **run.to_dict(),
+            "attempt": 0,
+            "status": "planned",
+            "leaderboard_eligible": None,
+            "rerun_of": None,
+            "lease": None,
+            "artifacts": [],
+        }
+        for run in runs
+    ]
+    atomic_write_json(
+        output,
+        {
+            "created_at_utc": utc_now(),
+            "public_tasks_commit": public_tasks_commit,
+            "task_suite_path": "combined tasks/tasks",
+            "expected_task_count": len(tasks),
+            "planned_run_count": len(entries),
+            "runs": entries,
+        },
+    )
+    return entries
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tasks-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--public-tasks-commit", required=True)
+    parser.add_argument("--run-date", required=True)
+    args = parser.parse_args()
+    entries = write_run_index(
+        tasks_root=args.tasks_root,
+        output=args.output,
+        public_tasks_commit=args.public_tasks_commit,
+        run_date=args.run_date,
+    )
+    print(f"wrote {len(entries)} planned runs to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/native_eval/proxy.py
+++ b/scripts/native_eval/proxy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.native_eval.models import LITELLM_VERSION, MODELS
+
+
+def write_proxy_config(path: Path) -> None:
+    model_list = []
+    for model in MODELS:
+        model_list.append(
+            {
+                "model_name": model.proxy_model_name,
+                "litellm_params": {
+                    "model": f"{model.provider}/{model.provider_model_id}",
+                    "api_key": f"os.environ/{model.provider.upper()}_API_KEY",
+                },
+                "model_info": {
+                    "friendly_name": model.friendly_name,
+                    "provider": model.provider,
+                    "provider_model_id": model.provider_model_id,
+                },
+            }
+        )
+    config = {
+        "model_list": model_list,
+        "general_settings": {
+            "master_key": "os.environ/SHELLBENCH_PROXY_KEY",
+            "disable_spend_logs": False,
+        },
+        "litellm_settings": {
+            "drop_params": True,
+            "modify_params": True,
+            "route_all_chat_openai_to_responses": True,
+        },
+        "router_settings": {
+            "routing_strategy": "simple-shuffle",
+            "num_retries": 2,
+            "retry_after": 1,
+        },
+        "shellbench_native": {
+            "litellm_version": LITELLM_VERSION,
+            "models": [
+                {
+                    "slug": model.slug,
+                    "provider": model.provider,
+                    "provider_model_id": model.provider_model_id,
+                    "proxy_model_name": model.proxy_model_name,
+                }
+                for model in MODELS
+            ],
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+

--- a/scripts/native_eval/proxy.py
+++ b/scripts/native_eval/proxy.py
@@ -9,13 +9,16 @@ from scripts.native_eval.models import LITELLM_VERSION, MODELS
 def write_proxy_config(path: Path) -> None:
     model_list = []
     for model in MODELS:
+        litellm_params = {
+            "model": f"{model.provider}/{model.provider_model_id}",
+            "api_key": f"os.environ/{model.provider.upper()}_API_KEY",
+        }
+        if model.slug == "gpt55":
+            litellm_params["additional_drop_params"] = ["temperature"]
         model_list.append(
             {
                 "model_name": model.proxy_model_name,
-                "litellm_params": {
-                    "model": f"{model.provider}/{model.provider_model_id}",
-                    "api_key": f"os.environ/{model.provider.upper()}_API_KEY",
-                },
+                "litellm_params": litellm_params,
                 "model_info": {
                     "friendly_name": model.friendly_name,
                     "provider": model.provider,
@@ -54,4 +57,3 @@ def write_proxy_config(path: Path) -> None:
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
-

--- a/scripts/native_eval/proxy.py
+++ b/scripts/native_eval/proxy.py
@@ -13,7 +13,7 @@ def write_proxy_config(path: Path) -> None:
             "model": f"{model.provider}/{model.provider_model_id}",
             "api_key": f"os.environ/{model.provider.upper()}_API_KEY",
         }
-        if model.slug == "gpt55":
+        if model.slug in {"gpt55", "gpt56-sol"}:
             litellm_params["additional_drop_params"] = ["temperature"]
         model_list.append(
             {

--- a/scripts/native_eval/remote_checkpoint.sh
+++ b/scripts/native_eval/remote_checkpoint.sh
@@ -42,6 +42,15 @@ if [[ -d "$PROXY_DIR" ]]; then
   rsync -a --exclude '*.tmp' "$PROXY_DIR/" \
     "$SNAPSHOT_DIR/proxy/$RUN_LABEL/"
 fi
+if [[ -d "$ROOT/run-logs" ]]; then
+  mkdir -p "$SNAPSHOT_DIR/run-logs"
+  for suffix in stdout stderr; do
+    source_log="$ROOT/run-logs/$RUN_LABEL.$suffix.log"
+    if [[ -f "$source_log" ]]; then
+      cp "$source_log" "$SNAPSHOT_DIR/run-logs/"
+    fi
+  done
+fi
 
 META_DIR="$SNAPSHOT_DIR/shellbench_meta-$RUN_LABEL"
 date -u +%Y-%m-%dT%H:%M:%SZ > "$META_DIR/exported_at_utc.txt"

--- a/scripts/native_eval/remote_checkpoint.sh
+++ b/scripts/native_eval/remote_checkpoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: remote_checkpoint.sh ROOT RUN_LABEL ARCHIVE_NAME" >&2
+  exit 2
+fi
+
+ROOT="$1"
+RUN_LABEL="$2"
+ARCHIVE_NAME="$3"
+JOB_DIR="$ROOT/results/jobs/$RUN_LABEL"
+PROXY_DIR="$ROOT/proxy/$RUN_LABEL"
+SNAPSHOT_DIR="$(mktemp -d "/tmp/$RUN_LABEL-checkpoint.XXXXXX")"
+ARCHIVE_PATH="/tmp/$ARCHIVE_NAME"
+TEMP_ARCHIVE="$ARCHIVE_PATH.tmp"
+
+cleanup() {
+  rm -rf "$SNAPSHOT_DIR"
+  rm -f "$TEMP_ARCHIVE"
+}
+trap cleanup EXIT
+
+case "$ARCHIVE_NAME" in
+  "$RUN_LABEL"-checkpoint-[0-9][0-9][0-9][0-9]-artifacts.tar.gz) ;;
+  *)
+    echo "invalid checkpoint archive name: $ARCHIVE_NAME" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p \
+  "$SNAPSHOT_DIR/results/jobs/$RUN_LABEL" \
+  "$SNAPSHOT_DIR/shellbench_meta-$RUN_LABEL"
+
+if [[ -d "$JOB_DIR" ]]; then
+  rsync -a --exclude '*.tmp' "$JOB_DIR/" \
+    "$SNAPSHOT_DIR/results/jobs/$RUN_LABEL/"
+fi
+if [[ -d "$PROXY_DIR" ]]; then
+  mkdir -p "$SNAPSHOT_DIR/proxy/$RUN_LABEL"
+  rsync -a --exclude '*.tmp' "$PROXY_DIR/" \
+    "$SNAPSHOT_DIR/proxy/$RUN_LABEL/"
+fi
+
+META_DIR="$SNAPSHOT_DIR/shellbench_meta-$RUN_LABEL"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$META_DIR/exported_at_utc.txt"
+hostname > "$META_DIR/hostname.txt"
+find "$SNAPSHOT_DIR/results/jobs/$RUN_LABEL" \
+  -mindepth 2 -maxdepth 2 -name result.json \
+  | wc -l | tr -d ' ' > "$META_DIR/result_json_count.txt"
+cp "$JOB_DIR/run_manifest.json" "$META_DIR/run_manifest.json" 2>/dev/null || true
+cp /opt/shellbench-native/manifest.json \
+  "$META_DIR/toolchain_manifest.json" 2>/dev/null || true
+
+tar -czf "$TEMP_ARCHIVE" -C "$SNAPSHOT_DIR" .
+tar -tzf "$TEMP_ARCHIVE" >/dev/null
+mv "$TEMP_ARCHIVE" "$ARCHIVE_PATH"
+printf '%s\n' "$ARCHIVE_PATH"

--- a/scripts/native_eval/remote_run.sh
+++ b/scripts/native_eval/remote_run.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: remote_run.sh ROOT TASKS_ROOT ENV_FILE RUN_LABEL HARNESS MODEL_SLUG REP EXPECTED_COUNT PUBLIC_TASKS_COMMIT RUN_DATE CONCURRENCY [TASK_NAME ...]" >&2
+  exit 2
+}
+
+[[ $# -ge 11 ]] || usage
+
+ROOT="$1"
+TASKS_ROOT="$2"
+ENV_FILE="$3"
+RUN_LABEL="$4"
+HARNESS="$5"
+MODEL_SLUG="$6"
+REPETITION="$7"
+EXPECTED_TASK_COUNT="$8"
+PUBLIC_TASKS_COMMIT="$9"
+RUN_DATE="${10}"
+CONCURRENCY="${11}"
+shift 11
+TASK_NAMES=("$@")
+TASK_SUITE_PATH="combined tasks/tasks"
+TOOLCHAIN_ROOT="${TOOLCHAIN_ROOT:-/opt/shellbench-native}"
+PROXY_DIR="$ROOT/proxy/$RUN_LABEL"
+PROXY_CONFIG="$PROXY_DIR/config.json"
+PROXY_LOG="$PROXY_DIR/proxy.log"
+PROXY_PID=""
+RUN_STATE_DIR="/tmp/shellbench-runs/$RUN_LABEL"
+RUN_STATUS=1
+
+cleanup() {
+  if [[ -n "$PROXY_PID" ]] && kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+  fi
+  mkdir -p "$RUN_STATE_DIR"
+  printf '%s\n' "$RUN_STATUS" > "$RUN_STATE_DIR/exit_status"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$RUN_STATE_DIR/finished_at_utc"
+  touch "$RUN_STATE_DIR/done"
+}
+trap cleanup EXIT
+
+umask 077
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+mkdir -p \
+  "$ROOT/results/jobs" \
+  "$PROXY_DIR" \
+  /tmp/"shellbench_meta-$RUN_LABEL" \
+  "$RUN_STATE_DIR"
+printf '%s\n' "$$" > "$RUN_STATE_DIR/pid"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$RUN_STATE_DIR/started_at_utc"
+printf '%s\n' "running" > "$RUN_STATE_DIR/state"
+export SHELLBENCH_PROXY_KEY="${SHELLBENCH_PROXY_KEY:-$(openssl rand -hex 32)}"
+
+cd "$ROOT/runner"
+python3 - <<PY
+from pathlib import Path
+from scripts.native_eval.proxy import write_proxy_config
+write_proxy_config(Path(${PROXY_CONFIG@Q}))
+PY
+
+"$TOOLCHAIN_ROOT/litellm-venv/bin/litellm" \
+  --config "$PROXY_CONFIG" \
+  --host 0.0.0.0 \
+  --port 4000 \
+  >"$PROXY_LOG" 2>&1 &
+PROXY_PID="$!"
+
+for _ in $(seq 1 120); do
+  if curl -fsS \
+    -H "Authorization: Bearer $SHELLBENCH_PROXY_KEY" \
+    http://127.0.0.1:4000/health/liveliness >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$PROXY_PID" 2>/dev/null; then
+    echo "LiteLLM proxy exited during startup" >&2
+    tail -100 "$PROXY_LOG" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+curl -fsS \
+  -H "Authorization: Bearer $SHELLBENCH_PROXY_KEY" \
+  http://127.0.0.1:4000/health/liveliness >/dev/null
+
+RUN_COMMAND=(
+  python3 -m scripts.native_eval.run_job
+  --tasks-root "$TASKS_ROOT"
+  --jobs-dir "$ROOT/results/jobs"
+  --run-label "$RUN_LABEL"
+  --harness "$HARNESS"
+  --model-slug "$MODEL_SLUG"
+  --repetition "$REPETITION"
+  --expected-task-count "$EXPECTED_TASK_COUNT"
+  --public-tasks-commit "$PUBLIC_TASKS_COMMIT"
+  --task-suite-path "$TASK_SUITE_PATH"
+  --run-date "$RUN_DATE"
+  --toolchain-root "$TOOLCHAIN_ROOT"
+  --proxy-url "http://host.docker.internal:4000"
+  --concurrency "$CONCURRENCY"
+)
+for task_name in "${TASK_NAMES[@]}"; do
+  RUN_COMMAND+=(--task "$task_name")
+done
+
+set +e
+"${RUN_COMMAND[@]}"
+RUN_STATUS="$?"
+set -e
+
+META_DIR="/tmp/shellbench_meta-$RUN_LABEL"
+date -u +%Y-%m-%dT%H:%M:%SZ > "$META_DIR/exported_at_utc.txt"
+hostname > "$META_DIR/hostname.txt"
+git -C "$ROOT/runner" rev-parse HEAD > "$META_DIR/runner_commit.txt" || true
+find "$ROOT/results/jobs/$RUN_LABEL" -mindepth 2 -maxdepth 2 -name result.json \
+  | wc -l | tr -d ' ' > "$META_DIR/result_json_count.txt"
+find "$ROOT/results/jobs/$RUN_LABEL" -mindepth 1 -maxdepth 1 -type d -print \
+  > "$META_DIR/trial_dirs.txt"
+cp "$ROOT/results/jobs/$RUN_LABEL/run_manifest.json" \
+  "$META_DIR/run_manifest.json" 2>/dev/null || true
+cp "$TOOLCHAIN_ROOT/manifest.json" \
+  "$META_DIR/toolchain_manifest.json" 2>/dev/null || true
+sha256sum "$ROOT/results/jobs/$RUN_LABEL/run_manifest.json" \
+  > "$META_DIR/run_manifest.sha256" 2>/dev/null || true
+
+tar -czf "/tmp/$RUN_LABEL-final-artifacts.tar.gz" \
+  -C "$ROOT" "results/jobs/$RUN_LABEL" \
+  -C "$ROOT" "proxy/$RUN_LABEL" \
+  -C /tmp "shellbench_meta-$RUN_LABEL"
+
+exit "$RUN_STATUS"

--- a/scripts/native_eval/remote_run.sh
+++ b/scripts/native_eval/remote_run.sh
@@ -30,11 +30,24 @@ PROXY_PID=""
 RUN_STATE_DIR="/tmp/shellbench-runs/$RUN_LABEL"
 RUN_STATUS=1
 
-cleanup() {
-  if [[ -n "$PROXY_PID" ]] && kill -0 "$PROXY_PID" 2>/dev/null; then
-    kill "$PROXY_PID" 2>/dev/null || true
-    wait "$PROXY_PID" 2>/dev/null || true
+# shellcheck disable=SC2329
+stop_proxy() {
+  [[ -n "$PROXY_PID" ]] || return
+  kill -0 "$PROXY_PID" 2>/dev/null || return
+  kill "$PROXY_PID" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    kill -0 "$PROXY_PID" 2>/dev/null || break
+    sleep 1
+  done
+  if kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill -KILL "$PROXY_PID" 2>/dev/null || true
   fi
+  wait "$PROXY_PID" 2>/dev/null || true
+}
+
+# shellcheck disable=SC2329
+cleanup() {
+  stop_proxy
   mkdir -p "$RUN_STATE_DIR"
   printf '%s\n' "$RUN_STATUS" > "$RUN_STATE_DIR/exit_status"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$RUN_STATE_DIR/finished_at_utc"

--- a/scripts/native_eval/remote_run.sh
+++ b/scripts/native_eval/remote_run.sh
@@ -130,9 +130,16 @@ cp "$TOOLCHAIN_ROOT/manifest.json" \
 sha256sum "$ROOT/results/jobs/$RUN_LABEL/run_manifest.json" \
   > "$META_DIR/run_manifest.sha256" 2>/dev/null || true
 
-tar -czf "/tmp/$RUN_LABEL-final-artifacts.tar.gz" \
-  -C "$ROOT" "results/jobs/$RUN_LABEL" \
-  -C "$ROOT" "proxy/$RUN_LABEL" \
-  -C /tmp "shellbench_meta-$RUN_LABEL"
+ARCHIVE_ITEMS=(
+  -C "$ROOT" "results/jobs/$RUN_LABEL"
+  -C "$ROOT" "proxy/$RUN_LABEL"
+)
+for suffix in stdout stderr; do
+  if [[ -f "$ROOT/run-logs/$RUN_LABEL.$suffix.log" ]]; then
+    ARCHIVE_ITEMS+=(-C "$ROOT" "run-logs/$RUN_LABEL.$suffix.log")
+  fi
+done
+ARCHIVE_ITEMS+=(-C /tmp "shellbench_meta-$RUN_LABEL")
+tar -czf "/tmp/$RUN_LABEL-final-artifacts.tar.gz" "${ARCHIVE_ITEMS[@]}"
 
 exit "$RUN_STATUS"

--- a/scripts/native_eval/remote_run.sh
+++ b/scripts/native_eval/remote_run.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: remote_run.sh ROOT TASKS_ROOT ENV_FILE RUN_LABEL HARNESS MODEL_SLUG REP EXPECTED_COUNT PUBLIC_TASKS_COMMIT RUN_DATE CONCURRENCY [TASK_NAME ...]" >&2
+  echo "usage: remote_run.sh ROOT TASKS_ROOT ENV_FILE RUN_LABEL HARNESS MODEL_SLUG REP EXPECTED_COUNT PUBLIC_TASKS_COMMIT RUN_DATE CONCURRENCY HARNESS_VERSION MODEL_ID MODEL_PROVIDER PROXY_MODEL_NAME [TASK_NAME ...]" >&2
   exit 2
 }
 
-[[ $# -ge 11 ]] || usage
+[[ $# -ge 15 ]] || usage
 
 ROOT="$1"
 TASKS_ROOT="$2"
@@ -19,7 +19,11 @@ EXPECTED_TASK_COUNT="$8"
 PUBLIC_TASKS_COMMIT="$9"
 RUN_DATE="${10}"
 CONCURRENCY="${11}"
-shift 11
+HARNESS_VERSION="${12}"
+MODEL_ID="${13}"
+MODEL_PROVIDER="${14}"
+PROXY_MODEL_NAME="${15}"
+shift 15
 TASK_NAMES=("$@")
 TASK_SUITE_PATH="combined tasks/tasks"
 TOOLCHAIN_ROOT="${TOOLCHAIN_ROOT:-/opt/shellbench-native}"
@@ -109,7 +113,11 @@ RUN_COMMAND=(
   --jobs-dir "$ROOT/results/jobs"
   --run-label "$RUN_LABEL"
   --harness "$HARNESS"
+  --harness-version "$HARNESS_VERSION"
   --model-slug "$MODEL_SLUG"
+  --model-id "$MODEL_ID"
+  --model-provider "$MODEL_PROVIDER"
+  --proxy-model-name "$PROXY_MODEL_NAME"
   --repetition "$REPETITION"
   --expected-task-count "$EXPECTED_TASK_COUNT"
   --public-tasks-commit "$PUBLIC_TASKS_COMMIT"

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -204,6 +204,11 @@ def _run_manifest(
         "provider": "aws",
         "runner": "shellbench-native",
         "execution_mode": os.environ.get("SHELLBENCH_EXECUTION_MODE", "native"),
+        "canonical_model_identity": run.proxy_model_name == run.model_id,
+        "trajectory_mode": "real_harness_events",
+        "parity_validated": (
+            os.environ.get("SHELLBENCH_PARITY_VALIDATED", "").lower() == "true"
+        ),
         "harbor_reference_commit": os.environ.get(
             "SHELLBENCH_HARBOR_REFERENCE_COMMIT"
         ),

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -219,6 +219,9 @@ def _run_manifest(
 
 
 def _git_commit() -> str:
+    configured = os.environ.get("SHELLBENCH_RUNNER_COMMIT", "").strip()
+    if configured:
+        return configured
     return subprocess.check_output(
         ["git", "rev-parse", "HEAD"],
         text=True,

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -203,6 +203,11 @@ def _run_manifest(
         "agent_concurrency": concurrency,
         "provider": "aws",
         "runner": "shellbench-native",
+        "execution_mode": os.environ.get("SHELLBENCH_EXECUTION_MODE", "native"),
+        "harbor_reference_commit": os.environ.get(
+            "SHELLBENCH_HARBOR_REFERENCE_COMMIT"
+        ),
+        "judge_model_id": os.environ.get("SHELLBENCH_JUDGE_MODEL_ID"),
         "runner_commit": _git_commit(),
         "runner_patch_hash": _runner_patch_hash(),
         "public_tasks_commit": public_tasks_commit,

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -10,7 +10,12 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from scripts.native_eval.models import RunSpec, harness_by_name, model_by_slug
+from scripts.native_eval.models import (
+    RunSpec,
+    harness_by_name,
+    model_by_slug,
+    trajectory_mode_for_harness,
+)
 from scripts.native_eval.runtime import atomic_write_json, run_trial, utc_now
 from scripts.native_eval.tasks import TaskSpec, validate_suite
 
@@ -123,6 +128,24 @@ async def run_job(
     atomic_write_json(job_dir / "result.json", state)
     manifest["finished_at_utc"] = state["finished_at"]
     manifest["result_json_count"] = len(results)
+    agent_results = [
+        result.get("agent_result")
+        for result in results
+        if isinstance(result.get("agent_result"), dict)
+    ]
+    manifest["canonical_model_identity"] = bool(agent_results) and all(
+        result.get("canonical_model_identity") is True for result in agent_results
+    )
+    manifest["observed_model_ids"] = sorted(
+        {
+            str(result.get("runtime_model_name"))
+            for result in agent_results
+            if result.get("runtime_model_name")
+        }
+    )
+    manifest["trajectory_complete"] = bool(agent_results) and all(
+        result.get("trajectory_status") == "real" for result in agent_results
+    )
     atomic_write_json(job_dir / "run_manifest.json", manifest)
     return state
 
@@ -185,6 +208,7 @@ def _run_manifest(
         "harness_version": run.harness_version,
         "model_slug": run.model_slug,
         "model_id": run.model_id,
+        "provider_model_id": run.model_id,
         "model_provider": run.provider,
         "proxy_model_name": run.proxy_model_name,
         "repetition": run.repetition,
@@ -204,8 +228,15 @@ def _run_manifest(
         "provider": "aws",
         "runner": "shellbench-native",
         "execution_mode": os.environ.get("SHELLBENCH_EXECUTION_MODE", "native"),
-        "canonical_model_identity": run.proxy_model_name == run.model_id,
-        "trajectory_mode": "real_harness_events",
+        "canonical_model_identity": None,
+        "intended_model_identity": {
+            "provider": run.provider,
+            "provider_model_id": run.model_id,
+            "proxy_model_name": run.proxy_model_name,
+        },
+        "observed_model_ids": [],
+        "trajectory_mode": trajectory_mode_for_harness(run.harness),
+        "trajectory_complete": False,
         "parity_validated": (
             os.environ.get("SHELLBENCH_PARITY_VALIDATED", "").lower() == "true"
         ),
@@ -258,11 +289,11 @@ def build_run_spec(args: argparse.Namespace) -> RunSpec:
     return RunSpec(
         run_label=args.run_label,
         harness=harness.name,
-        harness_version=harness.version,
+        harness_version=args.harness_version or harness.version,
         model_slug=model.slug,
-        model_id=model.provider_model_id,
-        provider=model.provider,
-        proxy_model_name=model.proxy_model_name,
+        model_id=args.model_id or model.provider_model_id,
+        provider=args.model_provider or model.provider,
+        proxy_model_name=args.proxy_model_name or model.proxy_model_name,
         repetition=args.repetition,
         expected_task_count=args.expected_task_count,
         run_date=args.run_date,
@@ -275,7 +306,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--jobs-dir", type=Path, required=True)
     parser.add_argument("--run-label", required=True)
     parser.add_argument("--harness", required=True)
+    parser.add_argument("--harness-version")
     parser.add_argument("--model-slug", required=True)
+    parser.add_argument("--model-id")
+    parser.add_argument("--model-provider")
+    parser.add_argument("--proxy-model-name")
     parser.add_argument("--repetition", type=int, choices=(1, 2, 3), required=True)
     parser.add_argument("--expected-task-count", type=int, required=True)
     parser.add_argument("--public-tasks-commit", required=True)

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from scripts.native_eval.models import RunSpec, harness_by_name, model_by_slug
+from scripts.native_eval.runtime import atomic_write_json, run_trial, utc_now
+from scripts.native_eval.tasks import TaskSpec, validate_suite
+
+
+async def run_job(
+    *,
+    tasks_root: Path,
+    jobs_dir: Path,
+    run: RunSpec,
+    public_tasks_commit: str,
+    task_suite_path: str,
+    toolchain_root: Path,
+    proxy_url: str,
+    proxy_key: str,
+    concurrency: int,
+    task_names: set[str] | None = None,
+) -> dict[str, Any]:
+    tasks = validate_suite(tasks_root)
+    if task_names:
+        tasks = [task for task in tasks if task.name in task_names]
+        missing = task_names - {task.name for task in tasks}
+        if missing:
+            raise ValueError(f"Unknown task names: {', '.join(sorted(missing))}")
+    if len(tasks) != run.expected_task_count:
+        raise ValueError(
+            f"Expected {run.expected_task_count} tasks, found {len(tasks)}"
+        )
+    if not toolchain_root.is_dir():
+        raise FileNotFoundError(f"Toolchain not found: {toolchain_root}")
+    if not proxy_key:
+        raise ValueError("SHELLBENCH_PROXY_KEY is required")
+
+    job_dir = jobs_dir / run.run_label
+    job_dir.mkdir(parents=True, exist_ok=False)
+    job_id = str(uuid.uuid4())
+    started_at = utc_now()
+    manifest = _run_manifest(
+        run,
+        public_tasks_commit=public_tasks_commit,
+        task_suite_path=task_suite_path,
+        concurrency=concurrency,
+        started_at=started_at,
+        tasks_root=tasks_root,
+        tasks=tasks,
+    )
+    atomic_write_json(job_dir / "run_manifest.json", manifest)
+    atomic_write_json(
+        job_dir / "config.json",
+        {
+            "job_name": run.run_label,
+            "jobs_dir": str(jobs_dir),
+            "n_concurrent_trials": concurrency,
+            "trials": [],
+            "native_run": asdict(run),
+        },
+    )
+    atomic_write_json(
+        job_dir / "lock.json",
+        {
+            "schema_version": 3,
+            "created_at": started_at,
+            "harbor": {
+                "version": None,
+                "git_commit_hash": None,
+                "is_editable": None,
+            },
+            "n_concurrent_trials": concurrency,
+            "retry": {"max_retries": 0},
+            "trials": [],
+            "native_runner": {
+                "git_commit": manifest["runner_commit"],
+                "patch_hash": manifest["runner_patch_hash"],
+            },
+        },
+    )
+
+    state: dict[str, Any] = {
+        "id": job_id,
+        "started_at": started_at,
+        "updated_at": started_at,
+        "finished_at": None,
+        "n_total_trials": len(tasks),
+        "stats": _empty_stats(len(tasks)),
+    }
+    atomic_write_json(job_dir / "result.json", state)
+
+    semaphore = asyncio.Semaphore(concurrency)
+    results: list[dict[str, Any]] = []
+    result_lock = asyncio.Lock()
+
+    async def execute(task: TaskSpec) -> None:
+        async with semaphore:
+            result = await run_trial(
+                task,
+                run,
+                job_dir=job_dir,
+                toolchain_root=toolchain_root,
+                proxy_url=proxy_url,
+                proxy_key=proxy_key,
+            )
+        async with result_lock:
+            results.append(result)
+            _update_job_result(state, results, len(tasks))
+            atomic_write_json(job_dir / "result.json", state)
+
+    await asyncio.gather(*(execute(task) for task in tasks))
+    state["finished_at"] = utc_now()
+    state["updated_at"] = state["finished_at"]
+    _update_job_result(state, results, len(tasks))
+    atomic_write_json(job_dir / "result.json", state)
+    manifest["finished_at_utc"] = state["finished_at"]
+    manifest["result_json_count"] = len(results)
+    atomic_write_json(job_dir / "run_manifest.json", manifest)
+    return state
+
+
+def _empty_stats(total: int) -> dict[str, Any]:
+    return {
+        "n_completed_trials": 0,
+        "n_errored_trials": 0,
+        "n_running_trials": 0,
+        "n_pending_trials": total,
+        "n_cancelled_trials": 0,
+        "n_retries": 0,
+        "evals": {},
+        "n_input_tokens": None,
+        "n_cache_tokens": None,
+        "n_output_tokens": None,
+        "cost_usd": None,
+    }
+
+
+def _update_job_result(
+    state: dict[str, Any],
+    results: list[dict[str, Any]],
+    total: int,
+) -> None:
+    stats = state["stats"]
+    stats["n_completed_trials"] = len(results)
+    stats["n_errored_trials"] = sum(
+        result.get("exception_info") is not None for result in results
+    )
+    stats["n_pending_trials"] = total - len(results)
+    for field in (
+        "n_input_tokens",
+        "n_cache_tokens",
+        "n_output_tokens",
+        "cost_usd",
+    ):
+        values = [
+            (result.get("agent_result") or {}).get(field)
+            for result in results
+            if isinstance((result.get("agent_result") or {}).get(field), (int, float))
+        ]
+        stats[field] = sum(values) if values else None
+    state["updated_at"] = utc_now()
+
+
+def _run_manifest(
+    run: RunSpec,
+    *,
+    public_tasks_commit: str,
+    task_suite_path: str,
+    concurrency: int,
+    started_at: str,
+    tasks_root: Path,
+    tasks: list[TaskSpec],
+) -> dict[str, Any]:
+    return {
+        "run_label": run.run_label,
+        "harness": run.harness,
+        "harness_version": run.harness_version,
+        "model_slug": run.model_slug,
+        "model_id": run.model_id,
+        "model_provider": run.provider,
+        "proxy_model_name": run.proxy_model_name,
+        "repetition": run.repetition,
+        "task_suite": task_suite_path,
+        "task_suite_root": str(tasks_root.resolve()),
+        "expected_task_count": run.expected_task_count,
+        "tasks": [
+            {
+                "name": task.name,
+                "path": str(task.path.resolve()),
+                "checksum": task.checksum,
+            }
+            for task in tasks
+        ],
+        "task_concurrency": concurrency,
+        "agent_concurrency": concurrency,
+        "provider": "aws",
+        "runner": "shellbench-native",
+        "runner_commit": _git_commit(),
+        "runner_patch_hash": _runner_patch_hash(),
+        "public_tasks_commit": public_tasks_commit,
+        "crabbox_cli_version": os.environ.get("CRABBOX_CLI_VERSION"),
+        "crabbox_slug": os.environ.get("CRABBOX_SLUG"),
+        "crabbox_lease_id": os.environ.get("CRABBOX_LEASE_ID"),
+        "crabbox_instance_type": os.environ.get("CRABBOX_INSTANCE_TYPE"),
+        "crabbox_ip": os.environ.get("CRABBOX_IP"),
+        "crabbox_region": os.environ.get("CRABBOX_REGION"),
+        "started_at_utc": started_at,
+        "finished_at_utc": None,
+        "result_json_count": 0,
+    }
+
+
+def _git_commit() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+
+
+def _runner_patch_hash() -> str:
+    paths = sorted(Path("scripts/native_eval").glob("*"))
+    digest = subprocess.run(
+        ["git", "hash-object", *[str(path) for path in paths if path.is_file()]],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    ).stdout
+    import hashlib
+
+    return hashlib.sha256(digest.encode("utf-8")).hexdigest()
+
+
+def build_run_spec(args: argparse.Namespace) -> RunSpec:
+    harness = harness_by_name(args.harness)
+    model = model_by_slug(args.model_slug)
+    return RunSpec(
+        run_label=args.run_label,
+        harness=harness.name,
+        harness_version=harness.version,
+        model_slug=model.slug,
+        model_id=model.provider_model_id,
+        provider=model.provider,
+        proxy_model_name=model.proxy_model_name,
+        repetition=args.repetition,
+        expected_task_count=args.expected_task_count,
+        run_date=args.run_date,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tasks-root", type=Path, required=True)
+    parser.add_argument("--jobs-dir", type=Path, required=True)
+    parser.add_argument("--run-label", required=True)
+    parser.add_argument("--harness", required=True)
+    parser.add_argument("--model-slug", required=True)
+    parser.add_argument("--repetition", type=int, choices=(1, 2, 3), required=True)
+    parser.add_argument("--expected-task-count", type=int, required=True)
+    parser.add_argument("--public-tasks-commit", required=True)
+    parser.add_argument("--task-suite-path", required=True)
+    parser.add_argument("--run-date", required=True)
+    parser.add_argument(
+        "--toolchain-root",
+        type=Path,
+        default=Path("/opt/shellbench-native"),
+    )
+    parser.add_argument(
+        "--proxy-url",
+        default="http://host.docker.internal:4000",
+    )
+    parser.add_argument("--concurrency", type=int, default=16)
+    parser.add_argument(
+        "--task",
+        action="append",
+        dest="task_names",
+        help="Run only the named task. Repeat for multiple tasks.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    proxy_key = os.environ.get("SHELLBENCH_PROXY_KEY", "")
+    state = asyncio.run(
+        run_job(
+            tasks_root=args.tasks_root,
+            jobs_dir=args.jobs_dir,
+            run=build_run_spec(args),
+            public_tasks_commit=args.public_tasks_commit,
+            task_suite_path=args.task_suite_path,
+            toolchain_root=args.toolchain_root,
+            proxy_url=args.proxy_url,
+            proxy_key=proxy_key,
+            concurrency=args.concurrency,
+            task_names=set(args.task_names or []),
+        )
+    )
+    print(json.dumps(state, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/native_eval/runtime.py
+++ b/scripts/native_eval/runtime.py
@@ -1,0 +1,878 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import traceback
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.native_eval.harnesses import TOOLCHAIN_ROOT, build_harness_command
+from scripts.native_eval.models import RunSpec
+from scripts.native_eval.tasks import TaskSpec
+
+
+class NativeEvalError(RuntimeError):
+    pass
+
+
+class EnvironmentStartTimeoutError(NativeEvalError):
+    pass
+
+
+class DockerStartupError(NativeEvalError):
+    pass
+
+
+class AgentSetupTimeoutError(NativeEvalError):
+    pass
+
+
+class NonZeroAgentExitCodeError(NativeEvalError):
+    pass
+
+
+class RewardFileNotFoundError(NativeEvalError):
+    pass
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    started_at: str
+    finished_at: str
+
+
+@dataclass
+class DockerTaskEnvironment:
+    task: TaskSpec
+    trial_dir: Path
+    container_name: str
+    project_name: str
+    toolchain_root: Path
+    workdir: str = "/app"
+    container_id: str | None = None
+    compose_override: Path | None = None
+
+    @property
+    def agent_dir(self) -> Path:
+        return self.trial_dir / "agent"
+
+    @property
+    def verifier_dir(self) -> Path:
+        return self.trial_dir / "verifier"
+
+    @property
+    def artifacts_dir(self) -> Path:
+        return self.trial_dir / "artifacts"
+
+    async def start(self) -> CommandResult:
+        for path in (
+            self.agent_dir,
+            self.verifier_dir,
+            self.artifacts_dir / "logs" / "artifacts",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+            path.chmod(0o777)
+
+        started_at = utc_now()
+        try:
+            async with asyncio.timeout(self.task.build_timeout_sec):
+                if self.task.compose_file:
+                    await self._start_compose()
+                else:
+                    await self._start_single()
+        except TimeoutError as exc:
+            raise EnvironmentStartTimeoutError(
+                f"Environment start timed out after {self.task.build_timeout_sec}s"
+            ) from exc
+        except NativeEvalError:
+            raise
+        except Exception as exc:
+            raise DockerStartupError(str(exc)) from exc
+        return CommandResult(0, started_at, utc_now())
+
+    async def _start_single(self) -> None:
+        image = f"shellbench-task:{self.task.checksum[:16]}"
+        build_log = self.trial_dir / "environment-build.log"
+        build = await run_process(
+            [
+                "docker",
+                "build",
+                "--pull=false",
+                "-f",
+                str(self.task.dockerfile),
+                "-t",
+                image,
+                str(self.task.build_context),
+            ],
+            stdout_path=build_log,
+            stderr_path=build_log,
+        )
+        if build.returncode:
+            raise DockerStartupError(f"Docker build exited {build.returncode}")
+
+        command = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            self.container_name,
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            "-v",
+            f"{self.agent_dir.resolve()}:/logs/agent",
+            "-v",
+            f"{self.verifier_dir.resolve()}:/logs/verifier",
+            "-v",
+            (
+                f"{(self.artifacts_dir / 'logs' / 'artifacts').resolve()}"
+                ":/logs/artifacts"
+            ),
+            "-v",
+            f"{self.toolchain_root.resolve()}:{TOOLCHAIN_ROOT}:ro",
+        ]
+        for key, value in self.task.environment_env.items():
+            command.extend(["-e", f"{key}={value}"])
+        command.extend([image, "sleep", "infinity"])
+        result = await run_process(
+            command,
+            stdout_path=self.trial_dir / "environment-start.log",
+            stderr_path=self.trial_dir / "environment-start.log",
+        )
+        if result.returncode:
+            raise DockerStartupError(f"docker run exited {result.returncode}")
+        self.container_id = self.container_name
+        await self._discover_workdir()
+
+    async def _start_compose(self) -> None:
+        self.compose_override = self.trial_dir / "docker-compose.native.json"
+        override = {
+            "services": {
+                "main": {
+                    "volumes": [
+                        {
+                            "type": "bind",
+                            "source": str(self.agent_dir.resolve()),
+                            "target": "/logs/agent",
+                        },
+                        {
+                            "type": "bind",
+                            "source": str(self.verifier_dir.resolve()),
+                            "target": "/logs/verifier",
+                        },
+                        {
+                            "type": "bind",
+                            "source": str(
+                                (self.artifacts_dir / "logs" / "artifacts").resolve()
+                            ),
+                            "target": "/logs/artifacts",
+                        },
+                        {
+                            "type": "bind",
+                            "source": str(self.toolchain_root.resolve()),
+                            "target": str(TOOLCHAIN_ROOT),
+                            "read_only": True,
+                        },
+                    ],
+                    "extra_hosts": ["host.docker.internal:host-gateway"],
+                    "environment": self.task.environment_env,
+                }
+            }
+        }
+        atomic_write_json(self.compose_override, override)
+        command = self._compose_prefix() + ["up", "-d", "--build", "--wait"]
+        result = await run_process(
+            command,
+            stdout_path=self.trial_dir / "environment-start.log",
+            stderr_path=self.trial_dir / "environment-start.log",
+        )
+        if result.returncode:
+            raise DockerStartupError(f"docker compose up exited {result.returncode}")
+        ps = await capture_process(self._compose_prefix() + ["ps", "-q", "main"])
+        self.container_id = ps.strip()
+        if not self.container_id:
+            raise DockerStartupError("docker compose did not return the main container")
+        await self._discover_workdir()
+
+    def _compose_prefix(self) -> list[str]:
+        files = ["-f", str(self.task.compose_file)]
+        if self.compose_override:
+            files.extend(["-f", str(self.compose_override)])
+        return ["docker", "compose", "-p", self.project_name, *files]
+
+    async def _discover_workdir(self) -> None:
+        assert self.container_id
+        output = await capture_process(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                "{{.Config.WorkingDir}}",
+                self.container_id,
+            ]
+        )
+        self.workdir = output.strip() or "/app"
+
+    async def copy_instruction(self, instruction: str) -> None:
+        local = self.trial_dir / "instruction.md"
+        local.write_text(instruction, encoding="utf-8")
+        await self.copy_to(local, "/tmp/shellbench-instruction.md")
+
+    async def install_tests(self) -> None:
+        await self.exec("rm -rf /tests && mkdir -p /tests", user="root")
+        assert self.container_id
+        result = await run_process(
+            [
+                "docker",
+                "cp",
+                f"{self.task.path / 'tests'}/.",
+                f"{self.container_id}:/tests",
+            ],
+            stdout_path=self.trial_dir / "trial.log",
+            stderr_path=self.trial_dir / "trial.log",
+        )
+        if result.returncode:
+            raise DockerStartupError(f"docker cp tests exited {result.returncode}")
+
+    async def copy_to(self, source: Path, target: str) -> None:
+        assert self.container_id
+        result = await run_process(
+            ["docker", "cp", str(source), f"{self.container_id}:{target}"],
+            stdout_path=self.trial_dir / "trial.log",
+            stderr_path=self.trial_dir / "trial.log",
+        )
+        if result.returncode:
+            raise DockerStartupError(f"docker cp exited {result.returncode}")
+
+    async def collect_artifacts(self) -> None:
+        assert self.container_id
+        diff_path = self.artifacts_dir / "container-diff.txt"
+        diff = await capture_process(["docker", "diff", self.container_id])
+        diff_path.write_text(diff, encoding="utf-8")
+
+        collected: list[dict[str, str]] = []
+        if self.task.compose_file or self.task.mcp_servers:
+            for source in ("/workspace", "/app/output", "/downloads", "/screenshots"):
+                destination = (
+                    self.artifacts_dir
+                    / "workspace"
+                    / source.lstrip("/").replace("/", "__")
+                )
+                if await self._container_path_exists(source):
+                    await self._copy_from(source, destination)
+                    collected.append(
+                        {
+                            "source": source,
+                            "destination": str(destination.relative_to(self.trial_dir)),
+                            "type": "directory",
+                            "status": "collected",
+                            "service": "main",
+                        }
+                    )
+        else:
+            changed_files = []
+            for line in diff.splitlines():
+                if len(line) < 3 or line[0] not in {"A", "C"}:
+                    continue
+                source = line[2:]
+                if source == self.workdir or not source.startswith(
+                    self.workdir.rstrip("/") + "/"
+                ):
+                    continue
+                if await self._container_file_exists(source):
+                    changed_files.append(source)
+            for source in sorted(set(changed_files)):
+                relative = source.removeprefix(self.workdir.rstrip("/") + "/")
+                destination = self.artifacts_dir / "workspace" / relative
+                await self._copy_from(source, destination)
+                collected.append(
+                    {
+                        "source": source,
+                        "destination": str(destination.relative_to(self.trial_dir)),
+                        "type": "file",
+                        "status": "collected",
+                        "service": "main",
+                    }
+                )
+        atomic_write_json(self.artifacts_dir / "manifest.json", collected)
+
+    async def _container_path_exists(self, source: str) -> bool:
+        result = await self.exec(
+            f"test -e {json.dumps(source)}",
+            user="root",
+        )
+        return result.returncode == 0
+
+    async def _container_file_exists(self, source: str) -> bool:
+        result = await self.exec(
+            f"test -f {json.dumps(source)} -o -L {json.dumps(source)}",
+            user="root",
+        )
+        return result.returncode == 0
+
+    async def _copy_from(self, source: str, destination: Path) -> None:
+        assert self.container_id
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        result = await run_process(
+            [
+                "docker",
+                "cp",
+                f"{self.container_id}:{source}",
+                str(destination),
+            ],
+            stdout_path=self.trial_dir / "trial.log",
+            stderr_path=self.trial_dir / "trial.log",
+        )
+        if result.returncode:
+            raise DockerStartupError(
+                f"docker cp from {source} exited {result.returncode}"
+            )
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+        stdout_path: Path | None = None,
+        stderr_path: Path | None = None,
+        workdir: str | None = None,
+        user: str | None = None,
+    ) -> CommandResult:
+        assert self.container_id
+        args = ["docker", "exec", "-i"]
+        if user:
+            args.extend(["--user", user])
+        args.extend(["--workdir", workdir or self.workdir])
+        for key, value in (env or {}).items():
+            args.extend(["--env", f"{key}={value}"])
+        args.extend([self.container_id, "sh", "-lc", command])
+        try:
+            if timeout is None:
+                return await run_process(
+                    args,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                )
+            async with asyncio.timeout(timeout):
+                return await run_process(
+                    args,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                )
+        except TimeoutError:
+            await run_process(
+                ["docker", "kill", self.container_id],
+                stdout_path=self.trial_dir / "trial.log",
+                stderr_path=self.trial_dir / "trial.log",
+            )
+            raise
+
+    async def stop(self) -> None:
+        if self.task.compose_file:
+            await run_process(
+                self._compose_prefix()
+                + ["down", "--volumes", "--remove-orphans", "--timeout", "10"],
+                stdout_path=self.trial_dir / "environment-stop.log",
+                stderr_path=self.trial_dir / "environment-stop.log",
+            )
+        else:
+            await run_process(
+                ["docker", "rm", "-f", self.container_name],
+                stdout_path=self.trial_dir / "environment-stop.log",
+                stderr_path=self.trial_dir / "environment-stop.log",
+            )
+
+
+async def run_trial(
+    task: TaskSpec,
+    run: RunSpec,
+    *,
+    job_dir: Path,
+    toolchain_root: Path,
+    proxy_url: str,
+    proxy_key: str,
+) -> dict[str, Any]:
+    trial_suffix = uuid.uuid5(uuid.NAMESPACE_URL, f"{run.run_label}/{task.name}").hex[:7]
+    trial_name = f"{task.name[:32].rstrip('_-')}__{trial_suffix}"
+    trial_dir = job_dir / trial_name
+    trial_dir.mkdir(parents=True, exist_ok=False)
+    (trial_dir / "agent").mkdir()
+    (trial_dir / "verifier").mkdir()
+    (trial_dir / "artifacts").mkdir()
+    atomic_write_json(trial_dir / "artifacts" / "manifest.json", [])
+
+    started_at = utc_now()
+    result = _initial_trial_result(task, run, trial_name, trial_dir, started_at)
+    atomic_write_json(trial_dir / "config.json", result["config"])
+    atomic_write_json(trial_dir / "lock.json", _trial_lock(task, run))
+    atomic_write_json(trial_dir / "result.json", result)
+
+    environment = DockerTaskEnvironment(
+        task=task,
+        trial_dir=trial_dir,
+        container_name=f"sb-{trial_suffix}-{uuid.uuid4().hex[:6]}",
+        project_name=f"sb-{trial_suffix}-{uuid.uuid4().hex[:6]}",
+        toolchain_root=toolchain_root,
+    )
+    recorded_exception: BaseException | None = None
+    agent_command = build_harness_command(
+        run,
+        proxy_url=proxy_url,
+        proxy_key=proxy_key,
+        mcp_servers=task.mcp_servers,
+    )
+
+    try:
+        env_start = await environment.start()
+        result["environment_setup"] = _timing(env_start)
+        atomic_write_json(trial_dir / "result.json", result)
+
+        await environment.copy_instruction(task.instruction)
+
+        setup_started = utc_now()
+        try:
+            setup = await environment.exec(
+                agent_command.setup_command,
+                env=agent_command.env,
+                timeout=300,
+                stdout_path=trial_dir / "agent" / "setup-stdout.txt",
+                stderr_path=trial_dir / "agent" / "setup-stderr.txt",
+            )
+            if setup.returncode:
+                raise NativeEvalError(f"Agent setup exited {setup.returncode}")
+        except TimeoutError as exc:
+            raise AgentSetupTimeoutError("Agent setup timed out after 300s") from exc
+        finally:
+            result["agent_setup"] = {
+                "started_at": setup_started,
+                "finished_at": utc_now(),
+            }
+            atomic_write_json(trial_dir / "result.json", result)
+
+        agent_started = utc_now()
+        try:
+            agent = await environment.exec(
+                agent_command.run_command,
+                env=agent_command.env,
+                timeout=task.agent_timeout_sec,
+                stdout_path=trial_dir / "agent" / "stdout.txt",
+                stderr_path=trial_dir / "agent" / "stderr.txt",
+            )
+            if agent.returncode:
+                raise NonZeroAgentExitCodeError(
+                    f"Agent exited with code {agent.returncode}"
+                )
+        except TimeoutError:
+            recorded_exception = NonZeroAgentExitCodeError(
+                f"Agent timed out after {task.agent_timeout_sec}s"
+            )
+        except BaseException as exc:
+            recorded_exception = exc
+        finally:
+            result["agent_execution"] = {
+                "started_at": agent_started,
+                "finished_at": utc_now(),
+            }
+            try:
+                await environment.exec(
+                    agent_command.cleanup_command,
+                    env=agent_command.env,
+                    timeout=60,
+                    stdout_path=trial_dir / "agent" / "cleanup-stdout.txt",
+                    stderr_path=trial_dir / "agent" / "cleanup-stderr.txt",
+                )
+            except Exception:
+                pass
+            result["agent_result"] = collect_agent_metrics(
+                run.harness, trial_dir / "agent"
+            )
+            write_minimal_trajectory(task, run, trial_dir / "agent")
+            await environment.collect_artifacts()
+            atomic_write_json(trial_dir / "result.json", result)
+
+        await environment.install_tests()
+        verifier_started = utc_now()
+        verifier_env = task.resolved_verifier_env()
+        judge_env = {
+            "AGENT_JUDGE_API_URL": (
+                f"{proxy_url.rstrip('/')}/v1/chat/completions"
+            ),
+            "AGENT_JUDGE_MODEL": "sb-gpt55",
+            "AGENT_JUDGE_API_KEY": proxy_key,
+            "LLM_JUDGE_API_URL": f"{proxy_url.rstrip('/')}/v1",
+            "LLM_JUDGE_MODEL": "sb-gpt55",
+            "LLM_JUDGE_API_KEY": proxy_key,
+            "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+            "OPENROUTER_API_KEY": proxy_key,
+        }
+        for key, value in judge_env.items():
+            if not verifier_env.get(key):
+                verifier_env[key] = value
+        verifier = await environment.exec(
+            _verifier_command(task.verifier_command),
+            env=verifier_env,
+            timeout=task.verifier_timeout_sec,
+            stdout_path=trial_dir / "verifier" / "test-stdout.txt",
+            stderr_path=trial_dir / "verifier" / "test-stderr.txt",
+        )
+        result["verifier"] = {
+            "started_at": verifier_started,
+            "finished_at": utc_now(),
+        }
+        reward = read_reward(trial_dir / "verifier")
+        result["verifier_result"] = {"rewards": reward}
+        if verifier.returncode and recorded_exception is None and not reward:
+            recorded_exception = RewardFileNotFoundError(
+                f"Verifier exited {verifier.returncode} without a reward"
+            )
+    except BaseException as exc:
+        if recorded_exception is None:
+            recorded_exception = exc
+    finally:
+        try:
+            await environment.stop()
+        except Exception as exc:
+            if recorded_exception is None:
+                recorded_exception = exc
+        result["finished_at"] = utc_now()
+        if recorded_exception is not None:
+            result["exception_info"] = exception_info(recorded_exception)
+            (trial_dir / "exception.txt").write_text(
+                "".join(
+                    traceback.format_exception(
+                        type(recorded_exception),
+                        recorded_exception,
+                        recorded_exception.__traceback__,
+                    )
+                ),
+                encoding="utf-8",
+            )
+        atomic_write_json(trial_dir / "result.json", result)
+    return result
+
+
+def _initial_trial_result(
+    task: TaskSpec,
+    run: RunSpec,
+    trial_name: str,
+    trial_dir: Path,
+    started_at: str,
+) -> dict[str, Any]:
+    config = {
+        "task": {"path": str(task.path)},
+        "trial_name": trial_name,
+        "trials_dir": str(trial_dir.parent),
+        "timeout_multiplier": 1.0,
+        "agent": {
+            "name": run.harness,
+            "model_name": f"{run.provider}/{run.model_id}",
+            "override_timeout_sec": task.agent_timeout_sec,
+            "override_setup_timeout_sec": 300,
+            "kwargs": {"native_runner": True},
+        },
+        "environment": {"type": "docker", "delete": True},
+        "verifier": {"override_timeout_sec": task.verifier_timeout_sec},
+        "artifacts": [],
+        "extra_instruction_paths": [],
+    }
+    return {
+        "id": str(uuid.uuid4()),
+        "task_name": task.title,
+        "trial_name": trial_name,
+        "trial_uri": trial_dir.resolve().as_uri(),
+        "task_id": {"path": str(task.path)},
+        "source": "shellbench-native",
+        "task_checksum": task.checksum,
+        "config": config,
+        "agent_info": {
+            "name": run.harness,
+            "version": run.harness_version,
+            "model_info": {"name": run.model_id, "provider": run.provider},
+        },
+        "agent_result": None,
+        "verifier_result": None,
+        "verifier_environment_mode": "shared",
+        "exception_info": None,
+        "started_at": started_at,
+        "finished_at": None,
+        "environment_setup": None,
+        "agent_setup": None,
+        "agent_execution": None,
+        "verifier": None,
+        "step_results": None,
+    }
+
+
+def _trial_lock(task: TaskSpec, run: RunSpec) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "task": {
+            "name": task.name,
+            "version": None,
+            "type": "local",
+            "digest": f"sha256:{task.checksum}",
+            "source": "shellbench-native",
+            "path": str(task.path),
+            "git_url": None,
+            "git_commit_id": None,
+        },
+        "install_only": False,
+        "timeout_multiplier": 1.0,
+        "agent": {
+            "name": run.harness,
+            "model_name": f"{run.provider}/{run.model_id}",
+            "kwargs": {"native_runner": True},
+        },
+        "skills": [],
+        "environment": {"type": "docker", "delete": True},
+        "verifier": {"environment_mode": "shared"},
+    }
+
+
+def _verifier_command(command: str) -> str:
+    normalized = command.replace("tests/", "/tests/")
+    if normalized.startswith("bash /tests/"):
+        return normalized
+    if normalized.startswith("bash tests/"):
+        return normalized.replace("bash tests/", "bash /tests/", 1)
+    return normalized
+
+
+def read_reward(verifier_dir: Path) -> dict[str, float | int]:
+    reward_json = verifier_dir / "reward.json"
+    reward_text = verifier_dir / "reward.txt"
+    if reward_json.is_file() and reward_json.stat().st_size:
+        value = json.loads(reward_json.read_text(encoding="utf-8"))
+        if isinstance(value, dict):
+            return {
+                str(key): number
+                for key, number in value.items()
+                if isinstance(number, (int, float))
+            }
+    if reward_text.is_file() and reward_text.stat().st_size:
+        return {"reward": float(reward_text.read_text(encoding="utf-8").strip())}
+    raise RewardFileNotFoundError(
+        f"No reward file found under {verifier_dir}"
+    )
+
+
+def collect_agent_metrics(harness: str, agent_dir: Path) -> dict[str, Any]:
+    metrics: dict[str, Any] = {
+        "n_input_tokens": None,
+        "n_cache_tokens": None,
+        "n_output_tokens": None,
+        "cost_usd": None,
+        "rollout_details": None,
+        "metadata": {"native_harness": harness},
+    }
+    candidates = {
+        "openclaw": agent_dir / "openclaw.txt",
+        "codex": agent_dir / "codex.txt",
+        "claude-code": agent_dir / "claude-code.txt",
+        "hermes": agent_dir / "hermes-session.jsonl",
+    }
+    path = candidates.get(harness)
+    if path is None or not path.is_file():
+        return metrics
+    events = _load_json_events(path)
+    for event in events:
+        usage = _find_usage(event)
+        if not usage:
+            continue
+        _merge_usage(metrics, usage)
+    return metrics
+
+
+def _load_json_events(path: Path) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return [parsed]
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+    except json.JSONDecodeError:
+        pass
+    events = []
+    for line in text.splitlines():
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            events.append(item)
+    return events
+
+
+def _find_usage(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        for key in ("usage", "token_usage", "final_metrics"):
+            candidate = value.get(key)
+            if isinstance(candidate, dict):
+                return candidate
+        for item in value.values():
+            found = _find_usage(item)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = _find_usage(item)
+            if found:
+                return found
+    return None
+
+
+def _merge_usage(metrics: dict[str, Any], usage: dict[str, Any]) -> None:
+    aliases = {
+        "n_input_tokens": (
+            "input_tokens",
+            "input",
+            "prompt_tokens",
+            "total_prompt_tokens",
+        ),
+        "n_cache_tokens": (
+            "cache_read_input_tokens",
+            "cacheRead",
+            "cached_tokens",
+            "total_cached_tokens",
+        ),
+        "n_output_tokens": (
+            "output_tokens",
+            "output",
+            "completion_tokens",
+            "total_completion_tokens",
+        ),
+        "cost_usd": ("cost_usd", "total_cost_usd", "total_cost"),
+    }
+    for target, keys in aliases.items():
+        for key in keys:
+            value = usage.get(key)
+            if isinstance(value, (int, float)):
+                metrics[target] = value
+                break
+
+
+def write_minimal_trajectory(task: TaskSpec, run: RunSpec, agent_dir: Path) -> None:
+    raw_files = sorted(
+        path.name
+        for path in agent_dir.iterdir()
+        if path.is_file() and path.name != "trajectory.json"
+    )
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "session_id": str(uuid.uuid4()),
+        "agent": {
+            "name": run.harness,
+            "version": run.harness_version,
+            "model_name": f"{run.provider}/{run.model_id}",
+        },
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": utc_now(),
+                "source": "user",
+                "message": task.instruction,
+                "tool_calls": [],
+                "observation": None,
+            }
+        ],
+        "final_metrics": {
+            "total_steps": 1,
+            "native_raw_trace_files": raw_files,
+        },
+    }
+    atomic_write_json(agent_dir / "trajectory.json", trajectory)
+
+
+def exception_info(exc: BaseException) -> dict[str, str]:
+    return {
+        "exception_type": type(exc).__name__,
+        "exception_message": str(exc),
+        "exception_traceback": "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        ),
+        "occurred_at": utc_now(),
+    }
+
+
+def _timing(result: CommandResult) -> dict[str, str]:
+    return {
+        "started_at": result.started_at,
+        "finished_at": result.finished_at,
+    }
+
+
+async def run_process(
+    args: list[str],
+    *,
+    stdout_path: Path | None = None,
+    stderr_path: Path | None = None,
+) -> CommandResult:
+    started_at = utc_now()
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await asyncio.gather(
+        _drain(process.stdout, stdout_path),
+        _drain(process.stderr, stderr_path),
+    )
+    returncode = await process.wait()
+    return CommandResult(returncode, started_at, utc_now())
+
+
+async def capture_process(args: list[str]) -> str:
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode:
+        raise DockerStartupError(
+            stderr.decode("utf-8", errors="replace").strip()
+            or f"Command exited {process.returncode}"
+        )
+    return stdout.decode("utf-8", errors="replace")
+
+
+async def _drain(
+    stream: asyncio.StreamReader | None,
+    output_path: Path | None,
+) -> None:
+    if stream is None:
+        return
+    handle = None
+    try:
+        if output_path:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            handle = output_path.open("ab")
+        while chunk := await stream.read(64 * 1024):
+            if handle:
+                handle.write(chunk)
+                handle.flush()
+    finally:
+        if handle:
+            handle.close()
+
+
+def atomic_write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/scripts/native_eval/runtime.py
+++ b/scripts/native_eval/runtime.py
@@ -682,9 +682,9 @@ def collect_agent_metrics(harness: str, agent_dir: Path) -> dict[str, Any]:
     events = _load_json_events(path)
     for event in events:
         usage = _find_usage(event)
-        if not usage:
-            continue
-        _merge_usage(metrics, usage)
+        if usage:
+            _merge_usage(metrics, usage)
+        _merge_event_cost(metrics, event)
     return metrics
 
 
@@ -739,6 +739,7 @@ def _merge_usage(metrics: dict[str, Any], usage: dict[str, Any]) -> None:
         ),
         "n_cache_tokens": (
             "cache_read_input_tokens",
+            "cached_input_tokens",
             "cacheRead",
             "cached_tokens",
             "total_cached_tokens",
@@ -757,6 +758,14 @@ def _merge_usage(metrics: dict[str, Any], usage: dict[str, Any]) -> None:
             if isinstance(value, (int, float)):
                 metrics[target] = value
                 break
+
+
+def _merge_event_cost(metrics: dict[str, Any], event: dict[str, Any]) -> None:
+    for key in ("total_cost_usd", "cost_usd", "total_cost"):
+        value = event.get(key)
+        if isinstance(value, (int, float)):
+            metrics["cost_usd"] = value
+            return
 
 
 def write_minimal_trajectory(task: TaskSpec, run: RunSpec, agent_dir: Path) -> None:

--- a/scripts/native_eval/runtime.py
+++ b/scripts/native_eval/runtime.py
@@ -491,7 +491,9 @@ async def run_trial(
             result["agent_result"] = collect_agent_metrics(
                 run.harness, trial_dir / "agent"
             )
-            write_minimal_trajectory(task, run, trial_dir / "agent")
+            result["agent_result"].update(
+                write_agent_trajectory(task, run, trial_dir / "agent")
+            )
             await environment.collect_artifacts()
             atomic_write_json(trial_dir / "result.json", result)
 
@@ -502,10 +504,10 @@ async def run_trial(
             "AGENT_JUDGE_API_URL": (
                 f"{proxy_url.rstrip('/')}/v1/chat/completions"
             ),
-            "AGENT_JUDGE_MODEL": "sb-gpt55",
+            "AGENT_JUDGE_MODEL": "gpt-5.5",
             "AGENT_JUDGE_API_KEY": proxy_key,
             "LLM_JUDGE_API_URL": f"{proxy_url.rstrip('/')}/v1",
-            "LLM_JUDGE_MODEL": "sb-gpt55",
+            "LLM_JUDGE_MODEL": "gpt-5.5",
             "LLM_JUDGE_API_KEY": proxy_key,
             "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
             "OPENROUTER_API_KEY": proxy_key,
@@ -768,36 +770,159 @@ def _merge_event_cost(metrics: dict[str, Any], event: dict[str, Any]) -> None:
             return
 
 
-def write_minimal_trajectory(task: TaskSpec, run: RunSpec, agent_dir: Path) -> None:
-    raw_files = sorted(
-        path.name
-        for path in agent_dir.iterdir()
-        if path.is_file() and path.name != "trajectory.json"
-    )
+def write_agent_trajectory(
+    task: TaskSpec,
+    run: RunSpec,
+    agent_dir: Path,
+) -> dict[str, Any]:
+    if run.harness != "codex":
+        return {
+            "trajectory_status": "unsupported",
+            "trajectory_source": None,
+            "trajectory_event_count": 0,
+            "runtime_model_name": run.model_id,
+            "canonical_model_identity": True,
+        }
+
+    source_path = agent_dir / "codex.txt"
+    events = _load_json_events(source_path) if source_path.is_file() else []
+    steps = [
+        {
+            "step_id": 1,
+            "source": "user",
+            "message": task.instruction,
+        }
+    ]
+    session_id = str(uuid.uuid4())
+    for event in events:
+        if event.get("type") == "thread.started" and event.get("thread_id"):
+            session_id = str(event["thread_id"])
+            continue
+        if event.get("type") != "item.completed":
+            continue
+        item = event.get("item")
+        if not isinstance(item, dict):
+            continue
+        step = _codex_item_step(item)
+        if step is None:
+            continue
+        step["step_id"] = len(steps) + 1
+        steps.append(step)
+
+    if len(steps) == 1:
+        return {
+            "trajectory_status": "unavailable",
+            "trajectory_source": str(source_path),
+            "trajectory_event_count": len(events),
+            "runtime_model_name": run.model_id,
+            "canonical_model_identity": True,
+        }
+
+    metrics = collect_agent_metrics(run.harness, agent_dir)
+    final_metrics: dict[str, Any] = {"total_steps": len(steps)}
+    metric_names = {
+        "n_input_tokens": "total_prompt_tokens",
+        "n_cache_tokens": "total_cached_tokens",
+        "n_output_tokens": "total_completion_tokens",
+        "cost_usd": "total_cost_usd",
+    }
+    for source_name, target_name in metric_names.items():
+        value = metrics.get(source_name)
+        if isinstance(value, (int, float)):
+            final_metrics[target_name] = value
+
     trajectory = {
         "schema_version": "ATIF-v1.7",
-        "session_id": str(uuid.uuid4()),
+        "session_id": session_id,
         "agent": {
             "name": run.harness,
             "version": run.harness_version,
             "model_name": f"{run.provider}/{run.model_id}",
         },
-        "steps": [
-            {
-                "step_id": 1,
-                "timestamp": utc_now(),
-                "source": "user",
-                "message": task.instruction,
-                "tool_calls": [],
-                "observation": None,
-            }
-        ],
-        "final_metrics": {
-            "total_steps": 1,
-            "native_raw_trace_files": raw_files,
+        "steps": steps,
+        "final_metrics": final_metrics,
+        "extra": {
+            "native_raw_trace_file": source_path.name,
+            "native_raw_event_count": len(events),
         },
     }
     atomic_write_json(agent_dir / "trajectory.json", trajectory)
+    return {
+        "trajectory_status": "real",
+        "trajectory_source": str(source_path),
+        "trajectory_event_count": len(events),
+        "runtime_model_name": run.model_id,
+        "canonical_model_identity": True,
+    }
+
+
+def _codex_item_step(item: dict[str, Any]) -> dict[str, Any] | None:
+    item_type = str(item.get("type") or "")
+    if item_type == "agent_message":
+        return {
+            "source": "agent",
+            "message": str(item.get("text") or ""),
+            "llm_call_count": 1,
+        }
+    if item_type == "reasoning":
+        return {
+            "source": "agent",
+            "message": "",
+            "reasoning_content": str(item.get("text") or ""),
+            "llm_call_count": 1,
+        }
+    if item_type == "error":
+        return {
+            "source": "agent",
+            "message": str(item.get("message") or ""),
+            "llm_call_count": 0,
+            "extra": {"item_type": "error"},
+        }
+    if item_type not in {"command_execution", "mcp_tool_call"}:
+        return None
+
+    call_id = str(item.get("id") or uuid.uuid4())
+    if item_type == "command_execution":
+        function_name = "shell"
+        arguments = {"command": str(item.get("command") or "")}
+        output = str(item.get("aggregated_output") or "")
+    else:
+        server = str(item.get("server") or "mcp")
+        tool = str(item.get("tool") or "unknown")
+        function_name = f"mcp__{server}__{tool}"
+        arguments = item.get("arguments")
+        if not isinstance(arguments, dict):
+            arguments = {"value": arguments}
+        result = item.get("result")
+        output = (
+            result
+            if isinstance(result, str)
+            else json.dumps(result, ensure_ascii=True, default=str)
+        )
+    observation_extra = {
+        key: item[key]
+        for key in ("exit_code", "status", "error")
+        if item.get(key) is not None
+    }
+    observation_result: dict[str, Any] = {
+        "source_call_id": call_id,
+        "content": output,
+    }
+    if observation_extra:
+        observation_result["extra"] = observation_extra
+    return {
+        "source": "agent",
+        "message": "",
+        "tool_calls": [
+            {
+                "tool_call_id": call_id,
+                "function_name": function_name,
+                "arguments": arguments,
+            }
+        ],
+        "observation": {"results": [observation_result]},
+        "llm_call_count": 1,
+    }
 
 
 def exception_info(exc: BaseException) -> dict[str, str]:

--- a/scripts/native_eval/runtime.py
+++ b/scripts/native_eval/runtime.py
@@ -713,6 +713,63 @@ def _load_json_events(path: Path) -> list[dict[str, Any]]:
     return events
 
 
+def _load_codex_stream(path: Path) -> tuple[list[dict[str, Any]], int, int]:
+    events: list[dict[str, Any]] = []
+    preamble_lines = 0
+    malformed_event_lines = 0
+    stream_started = False
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            if stream_started:
+                malformed_event_lines += 1
+            else:
+                preamble_lines += 1
+            continue
+        stream_started = True
+        if isinstance(item, dict):
+            events.append(item)
+        else:
+            malformed_event_lines += 1
+    return events, preamble_lines, malformed_event_lines
+
+
+def _observed_codex_models(agent_dir: Path) -> set[str]:
+    models: set[str] = set()
+    sessions_dir = agent_dir / "sessions"
+    if not sessions_dir.is_dir():
+        return models
+    for path in sorted(sessions_dir.rglob("*.jsonl")):
+        for event in _load_json_events(path):
+            if event.get("type") == "turn_context":
+                payload = event.get("payload")
+                if isinstance(payload, dict) and payload.get("model"):
+                    models.add(str(payload["model"]))
+            message = event.get("message")
+            if isinstance(message, dict) and message.get("model"):
+                models.add(str(message["model"]))
+    return models
+
+
+def _completed_codex_items(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    order: list[str] = []
+    latest: dict[str, dict[str, Any]] = {}
+    for event in events:
+        if event.get("type") not in {"item.started", "item.updated", "item.completed"}:
+            continue
+        item = event.get("item")
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id") or f"anonymous-{len(order)}")
+        if item_id not in latest:
+            order.append(item_id)
+        latest[item_id] = item
+    return [latest[item_id] for item_id in order]
+
+
 def _find_usage(value: Any) -> dict[str, Any] | None:
     if isinstance(value, dict):
         for key in ("usage", "token_usage", "final_metrics"):
@@ -780,12 +837,21 @@ def write_agent_trajectory(
             "trajectory_status": "unsupported",
             "trajectory_source": None,
             "trajectory_event_count": 0,
-            "runtime_model_name": run.model_id,
-            "canonical_model_identity": True,
+            "runtime_model_name": None,
+            "canonical_model_identity": False,
         }
 
     source_path = agent_dir / "codex.txt"
-    events = _load_json_events(source_path) if source_path.is_file() else []
+    if source_path.is_file():
+        events, preamble_lines, malformed_event_lines = _load_codex_stream(source_path)
+    else:
+        events, preamble_lines, malformed_event_lines = [], 0, 0
+    observed_models = _observed_codex_models(agent_dir)
+    runtime_model_name = (
+        next(iter(observed_models)) if len(observed_models) == 1 else None
+    )
+    canonical_model_identity = observed_models == {run.model_id}
+    terminal_event_seen = any(event.get("type") == "turn.completed" for event in events)
     steps = [
         {
             "step_id": 1,
@@ -797,25 +863,31 @@ def write_agent_trajectory(
     for event in events:
         if event.get("type") == "thread.started" and event.get("thread_id"):
             session_id = str(event["thread_id"])
-            continue
-        if event.get("type") != "item.completed":
-            continue
-        item = event.get("item")
-        if not isinstance(item, dict):
-            continue
+    for item in _completed_codex_items(events):
         step = _codex_item_step(item)
         if step is None:
             continue
         step["step_id"] = len(steps) + 1
         steps.append(step)
 
-    if len(steps) == 1:
+    if (
+        len(steps) == 1
+        or malformed_event_lines
+        or not terminal_event_seen
+        or runtime_model_name is None
+    ):
         return {
             "trajectory_status": "unavailable",
             "trajectory_source": str(source_path),
             "trajectory_event_count": len(events),
-            "runtime_model_name": run.model_id,
-            "canonical_model_identity": True,
+            "runtime_model_name": runtime_model_name,
+            "canonical_model_identity": canonical_model_identity,
+            "trajectory_validation": {
+                "terminal_event_seen": terminal_event_seen,
+                "preamble_lines": preamble_lines,
+                "malformed_event_lines": malformed_event_lines,
+                "observed_models": sorted(observed_models),
+            },
         }
 
     metrics = collect_agent_metrics(run.harness, agent_dir)
@@ -837,13 +909,17 @@ def write_agent_trajectory(
         "agent": {
             "name": run.harness,
             "version": run.harness_version,
-            "model_name": f"{run.provider}/{run.model_id}",
+            "model_name": f"{run.provider}/{runtime_model_name}",
         },
         "steps": steps,
         "final_metrics": final_metrics,
         "extra": {
             "native_raw_trace_file": source_path.name,
             "native_raw_event_count": len(events),
+            "native_raw_preamble_lines": preamble_lines,
+            "native_raw_malformed_event_lines": malformed_event_lines,
+            "observed_models": sorted(observed_models),
+            "terminal_event_seen": terminal_event_seen,
         },
     }
     atomic_write_json(agent_dir / "trajectory.json", trajectory)
@@ -851,8 +927,14 @@ def write_agent_trajectory(
         "trajectory_status": "real",
         "trajectory_source": str(source_path),
         "trajectory_event_count": len(events),
-        "runtime_model_name": run.model_id,
-        "canonical_model_identity": True,
+        "runtime_model_name": runtime_model_name,
+        "canonical_model_identity": canonical_model_identity,
+        "trajectory_validation": {
+            "terminal_event_seen": terminal_event_seen,
+            "preamble_lines": preamble_lines,
+            "malformed_event_lines": malformed_event_lines,
+            "observed_models": sorted(observed_models),
+        },
     }
 
 
@@ -878,7 +960,13 @@ def _codex_item_step(item: dict[str, Any]) -> dict[str, Any] | None:
             "llm_call_count": 0,
             "extra": {"item_type": "error"},
         }
-    if item_type not in {"command_execution", "mcp_tool_call"}:
+    if item_type not in {
+        "command_execution",
+        "file_change",
+        "mcp_tool_call",
+        "todo_list",
+        "web_search",
+    }:
         return None
 
     call_id = str(item.get("id") or uuid.uuid4())
@@ -886,6 +974,14 @@ def _codex_item_step(item: dict[str, Any]) -> dict[str, Any] | None:
         function_name = "shell"
         arguments = {"command": str(item.get("command") or "")}
         output = str(item.get("aggregated_output") or "")
+    elif item_type in {"file_change", "todo_list", "web_search"}:
+        function_name = item_type
+        arguments = {
+            key: value
+            for key, value in item.items()
+            if key not in {"id", "type", "aggregated_output", "result"}
+        }
+        output = str(item.get("aggregated_output") or item.get("result") or "")
     else:
         server = str(item.get("server") or "mcp")
         tool = str(item.get("tool") or "unknown")

--- a/scripts/native_eval/tasks.py
+++ b/scripts/native_eval/tasks.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import hashlib
 import os
 import re
@@ -183,4 +182,3 @@ def _directory_checksum(path: Path) -> str:
                 digest.update(chunk)
         digest.update(b"\0")
     return digest.hexdigest()
-

--- a/scripts/native_eval/tasks.py
+++ b/scripts/native_eval/tasks.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}")
+
+
+@dataclass(frozen=True)
+class McpServer:
+    name: str
+    transport: str
+    url: str | None = None
+    command: str | None = None
+    args: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    path: Path
+    name: str
+    title: str
+    instruction: str
+    raw_config: dict[str, Any]
+    dockerfile: Path
+    build_context: Path
+    compose_file: Path | None
+    verifier_command: str
+    verifier_env: dict[str, str]
+    environment_env: dict[str, str]
+    mcp_servers: tuple[McpServer, ...]
+    agent_timeout_sec: float
+    verifier_timeout_sec: float
+    build_timeout_sec: float
+    checksum: str
+
+    @classmethod
+    def load(cls, path: Path) -> "TaskSpec":
+        path = path.resolve()
+        config_path = path / "task.toml"
+        instruction_path = path / "instruction.md"
+        raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        environment = raw.get("environment") or {}
+        verifier = raw.get("verifier") or {}
+        task_meta = raw.get("task") or {}
+
+        dockerfile_rel = environment.get("dockerfile", "environment/Dockerfile")
+        context_rel = environment.get("context", "environment")
+        dockerfile = _resolve_task_path(path, dockerfile_rel)
+        build_context = _resolve_task_path(path, context_rel)
+        compose_file = path / "environment" / "docker-compose.yaml"
+        if not compose_file.is_file():
+            compose_file = None
+
+        title = str(raw.get("title") or task_meta.get("name") or path.name)
+        servers = []
+        for item in environment.get("mcp_servers") or []:
+            servers.append(
+                McpServer(
+                    name=str(item["name"]),
+                    transport=str(item.get("transport", "stdio")),
+                    url=_optional_str(item.get("url")),
+                    command=_optional_str(item.get("command")),
+                    args=tuple(str(value) for value in item.get("args") or []),
+                )
+            )
+
+        return cls(
+            path=path,
+            name=path.name,
+            title=title,
+            instruction=instruction_path.read_text(encoding="utf-8"),
+            raw_config=raw,
+            dockerfile=dockerfile,
+            build_context=build_context,
+            compose_file=compose_file,
+            verifier_command=str(verifier.get("command") or "bash tests/test.sh"),
+            verifier_env={
+                str(key): str(value)
+                for key, value in (verifier.get("env") or {}).items()
+            },
+            environment_env={
+                str(key): str(value)
+                for key, value in (environment.get("env") or {}).items()
+            },
+            mcp_servers=tuple(servers),
+            agent_timeout_sec=float((raw.get("agent") or {}).get("timeout_sec", 900)),
+            verifier_timeout_sec=float(verifier.get("timeout_sec", 300)),
+            build_timeout_sec=float(environment.get("build_timeout_sec", 900)),
+            checksum=_directory_checksum(path),
+        )
+
+    def resolved_verifier_env(self) -> dict[str, str]:
+        return {
+            key: _expand_env(value)
+            for key, value in self.verifier_env.items()
+        }
+
+
+def validate_suite(tasks_root: Path) -> list[TaskSpec]:
+    tasks_root = tasks_root.resolve()
+    if not tasks_root.is_dir():
+        raise FileNotFoundError(f"Task suite not found: {tasks_root}")
+
+    task_dirs = sorted(path for path in tasks_root.iterdir() if path.is_dir())
+    if not task_dirs:
+        raise ValueError(f"No task directories found under {tasks_root}")
+
+    errors: list[str] = []
+    tasks: list[TaskSpec] = []
+    for task_dir in task_dirs:
+        for relative in (
+            "task.toml",
+            "instruction.md",
+            "environment/Dockerfile",
+            "solution/solve.sh",
+            "tests/test.sh",
+        ):
+            if not (task_dir / relative).is_file():
+                errors.append(f"{task_dir.name}: missing {relative}")
+        if errors and errors[-1].startswith(f"{task_dir.name}:"):
+            continue
+        try:
+            task = TaskSpec.load(task_dir)
+        except Exception as exc:
+            errors.append(f"{task_dir.name}: invalid task definition: {exc}")
+            continue
+        if not task.dockerfile.is_file():
+            errors.append(f"{task_dir.name}: dockerfile not found: {task.dockerfile}")
+        if not task.build_context.is_dir():
+            errors.append(
+                f"{task_dir.name}: build context not found: {task.build_context}"
+            )
+        tasks.append(task)
+
+    if errors:
+        raise ValueError("Task suite validation failed:\n" + "\n".join(errors))
+    return tasks
+
+
+def _resolve_task_path(task_dir: Path, value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    direct = task_dir / path
+    if direct.exists():
+        return direct
+    environment_relative = task_dir / "environment" / path
+    if environment_relative.exists():
+        return environment_relative
+    return direct
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _expand_env(value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        default = match.group(2) or ""
+        return os.environ.get(name, default)
+
+    return _ENV_PATTERN.sub(replace, value)
+
+
+def _directory_checksum(path: Path) -> str:
+    digest = hashlib.sha256()
+    for file_path in sorted(item for item in path.rglob("*") if item.is_file()):
+        relative = file_path.relative_to(path).as_posix()
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        with file_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+

--- a/tests/test_native_eval_aggregate.py
+++ b/tests/test_native_eval_aggregate.py
@@ -156,7 +156,10 @@ def test_pair_aggregates_exclude_incomplete_and_infra_dominated_runs(tmp_path: P
         jobs_root,
         "model-rep-1",
         expected_task_count=2,
-        results=[_result("a", reward=1.0), _result("b", reward=0.0)],
+        results=[
+            _result("a", reward=1.0),
+            _result("b", reward=0.0, exception_type="AgentTimeoutError"),
+        ],
         pair_label=pair,
         repetition=1,
     )

--- a/tests/test_native_eval_aggregate.py
+++ b/tests/test_native_eval_aggregate.py
@@ -18,6 +18,8 @@ def _write_run(
     tasks: list[str] | None = None,
     harness: str = "openclaw",
     model_slug: str = "model",
+    native: bool = False,
+    parity_validated: bool = False,
 ) -> None:
     run_dir = jobs_root / "jobs" / run_label
     run_dir.mkdir(parents=True)
@@ -28,6 +30,15 @@ def _write_run(
         "repetition": repetition,
         "expected_task_count": expected_task_count,
     }
+    if native:
+        manifest.update(
+            {
+                "runner": "shellbench-native",
+                "canonical_model_identity": True,
+                "trajectory_mode": "real_harness_events",
+                "parity_validated": parity_validated,
+            }
+        )
     if pair_label is not None:
         manifest["pair_label"] = pair_label
     if tasks is not None:
@@ -83,6 +94,18 @@ def _result(
             "exception_traceback": "traceback",
             "occurred_at": "2026-07-27T10:00:55+00:00",
         }
+    return result
+
+
+def _native_result(task: str, *, reward: float = 1.0) -> dict:
+    result = _result(task, reward=reward, source="shellbench-native")
+    result["agent_result"].update(
+        {
+            "trajectory_status": "real",
+            "runtime_model_name": "gpt-5.5",
+            "canonical_model_identity": True,
+        }
+    )
     return result
 
 
@@ -243,6 +266,25 @@ def test_pair_label_uses_manifest_harness_and_model(tmp_path: Path):
     assert main([str(jobs_root / "jobs"), str(adjacent_summaries)]) == 0
     rerun = aggregate(jobs_root / "jobs", adjacent_summaries)
     assert len(rerun["runs"]) == 2
+
+
+def test_native_run_requires_parity_validation_for_leaderboard(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "codex-gpt55-calibration",
+        expected_task_count=1,
+        results=[_native_result("a")],
+        harness="codex",
+        model_slug="gpt55",
+        native=True,
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    assert report["runs"][0]["eligible"] is False
+    assert report["runs"][0]["exclusion_reason"] == "parity_not_validated"
 
 
 def test_unknown_exception_is_agent_exit_and_gateway_signature_is_excluded(

--- a/tests/test_native_eval_aggregate.py
+++ b/tests/test_native_eval_aggregate.py
@@ -377,3 +377,59 @@ def test_reward_above_one_counts_as_exact_pass(tmp_path: Path):
     report = aggregate(jobs_root, summaries_dir)
 
     assert report["runs"][0]["exact_passes"] == 1
+
+
+def test_extra_or_duplicate_task_results_cannot_inflate_score(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "model-rep-1",
+        expected_task_count=2,
+        tasks=["a", "b"],
+        results=[
+            _result("a", reward=1.0, trial_name="a__first"),
+            _result("a", reward=1.0, trial_name="a__duplicate"),
+            _result("b", reward=1.0, trial_name="b__only"),
+        ],
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+    run = report["runs"][0]
+
+    assert run["score"] == 1.0
+    assert run["result_file_count"] == 3
+    assert run["infra"] == 1
+    assert run["eligible"] is False
+    assert run["exclusion_reason"] == "incomplete"
+    with (summaries_dir / "per_task_results.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    duplicate = next(
+        row
+        for row in rows
+        if row["exception_type"] == "DuplicateTaskResultError"
+    )
+    assert duplicate["classification"] == "infra"
+
+
+def test_unexpected_task_result_is_excluded_from_reward_sum(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "model-rep-1",
+        expected_task_count=2,
+        tasks=["a", "b"],
+        results=[
+            _result("a", reward=1.0),
+            _result("b", reward=0.0),
+            _result("c", reward=100.0),
+        ],
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+    run = report["runs"][0]
+
+    assert run["score"] == 0.5
+    assert run["eligible"] is False
+    assert run["infra"] == 1

--- a/tests/test_native_eval_aggregate.py
+++ b/tests/test_native_eval_aggregate.py
@@ -277,7 +277,49 @@ def test_unknown_exception_is_agent_exit_and_gateway_signature_is_excluded(
     assert rows["unknown-0"]["classification"] == "agent_exit"
     assert run["harness_wide_failure"] is True
     assert run["eligible"] is False
-    assert run["exclusion_reason"] == "harness_wide_failure"
+
+
+def test_scorecard_infra_error_is_not_counted_as_clean_failure(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "model-rep-1",
+        expected_task_count=1,
+        results=[_result("judge-task", reward=0.0)],
+    )
+    scorecard_path = (
+        jobs_root
+        / "jobs"
+        / "model-rep-1"
+        / "judge-task__trial"
+        / "verifier"
+        / "scorecard.json"
+    )
+    scorecard_path.parent.mkdir()
+    scorecard_path.write_text(
+        json.dumps(
+            {
+                "status": "infra_error",
+                "judge_reasons": [
+                    "judge HTTP 400: temperature is unsupported",
+                ],
+            }
+        )
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    with (summaries_dir / "per_task_results.csv").open(newline="") as handle:
+        task = list(csv.DictReader(handle))[0]
+    run = report["runs"][0]
+    assert task["classification"] == "infra"
+    assert task["exception_type"] == "VerifierJudgeInfraError"
+    assert "temperature" in task["exception_message"]
+    assert run["infra"] == 1
+    assert run["clean_completed"] == 0
+    assert run["eligible"] is False
+    assert run["exclusion_reason"] == "infra_dominated"
 
 
 def test_reward_above_one_counts_as_exact_pass(tmp_path: Path):

--- a/tests/test_native_eval_aggregate.py
+++ b/tests/test_native_eval_aggregate.py
@@ -1,0 +1,292 @@
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.native_eval.aggregate import aggregate, main
+
+
+def _write_run(
+    jobs_root: Path,
+    run_label: str,
+    *,
+    expected_task_count: int,
+    results: list[dict],
+    pair_label: str | None = "openclaw-model",
+    repetition: int = 1,
+    tasks: list[str] | None = None,
+    harness: str = "openclaw",
+    model_slug: str = "model",
+) -> None:
+    run_dir = jobs_root / "jobs" / run_label
+    run_dir.mkdir(parents=True)
+    manifest = {
+        "run_label": run_label,
+        "harness": harness,
+        "model_slug": model_slug,
+        "repetition": repetition,
+        "expected_task_count": expected_task_count,
+    }
+    if pair_label is not None:
+        manifest["pair_label"] = pair_label
+    if tasks is not None:
+        manifest["tasks"] = tasks
+    (run_dir / "run_manifest.json").write_text(json.dumps(manifest))
+
+    for index, result in enumerate(results, start=1):
+        trial_dir = run_dir / result.get("trial_name", f"trial-{index}")
+        trial_dir.mkdir()
+        (trial_dir / "result.json").write_text(json.dumps(result))
+
+
+def _result(
+    task: str,
+    *,
+    reward: float | None = None,
+    exception_type: str | None = None,
+    exception_message: str | None = None,
+    **extra: object,
+) -> dict:
+    result = {
+        "task_name": task,
+        "task_id": {"path": f"/benchmark/tasks/{task}"},
+        "trial_name": f"{task}__trial",
+        "started_at": "2026-07-27T10:00:00+00:00",
+        "finished_at": "2026-07-27T10:01:00+00:00",
+        "environment_setup": {
+            "started_at": "2026-07-27T10:00:00+00:00",
+            "finished_at": "2026-07-27T10:00:05+00:00",
+        },
+        "agent_execution": {
+            "started_at": "2026-07-27T10:00:10+00:00",
+            "finished_at": "2026-07-27T10:00:50+00:00",
+        },
+        "verifier": {
+            "started_at": "2026-07-27T10:00:50+00:00",
+            "finished_at": "2026-07-27T10:01:00+00:00",
+        },
+        "agent_result": {
+            "n_input_tokens": 100,
+            "n_cache_tokens": 20,
+            "n_output_tokens": 30,
+            "cost_usd": 0.0125,
+        },
+        **extra,
+    }
+    if reward is not None:
+        result["verifier_result"] = {"rewards": {"reward": reward}}
+    if exception_type is not None:
+        result["exception_info"] = {
+            "exception_type": exception_type,
+            "exception_message": exception_message or f"{exception_type} happened",
+            "exception_traceback": "traceback",
+            "occurred_at": "2026-07-27T10:00:55+00:00",
+        }
+    return result
+
+
+def test_aggregate_classifies_harbor_results_and_writes_all_outputs(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "model-rep-1",
+        expected_task_count=6,
+        results=[
+            _result("pass-task", reward=1.0),
+            _result("partial-task", reward=0.4),
+            _result("fail-task", reward=0.0),
+            _result("missing-task", exception_type="RewardFileNotFoundError"),
+            _result("agent-exit-task", reward=0.0, exception_type="AgentTimeoutError"),
+            _result("infra-task", exception_type="EnvironmentStartTimeoutError"),
+        ],
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    run = report["runs"][0]
+    assert run["score"] == pytest.approx(1.4 / 6)
+    assert run["coverage"] == 1.0
+    assert run["completed_result_count"] == 6
+    assert run["exact_passes"] == 1
+    assert run["partials"] == 1
+    assert run["nonzero"] == 2
+    assert run["infra"] == 1
+    assert run["agent_exits"] == 1
+    assert run["clean_completed"] == 3
+    assert run["missing_reward"] == 1
+    assert run["eligible"] is True
+
+    with (summaries_dir / "per_task_results.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert {row["classification"] for row in rows} == {
+        "infra",
+        "agent_exit",
+        "verifier_missing_reward",
+        "clean_fail",
+        "partial",
+        "pass",
+    }
+    pass_row = next(row for row in rows if row["task_name"] == "pass-task")
+    assert pass_row["task_path"] == "/benchmark/tasks/pass-task"
+    assert pass_row["duration_sec"] == "60.0"
+    assert pass_row["agent_execution_sec"] == "40.0"
+    assert pass_row["n_input_tokens"] == "100"
+    assert pass_row["n_cache_tokens"] == "20"
+    assert pass_row["n_output_tokens"] == "30"
+    assert pass_row["cost_usd"] == "0.0125"
+
+    with (summaries_dir / "infra_failures.csv").open(newline="") as handle:
+        infra_rows = list(csv.DictReader(handle))
+    assert [row["task_name"] for row in infra_rows] == ["infra-task"]
+    assert "EnvironmentStartTimeoutError happened" in infra_rows[0]["exception_message"]
+
+    assert (summaries_dir / "aggregate_results.csv").is_file()
+    assert (summaries_dir / "aggregate_results.json").is_file()
+    assert (summaries_dir / "cleaned_leaderboard.md").is_file()
+
+
+def test_pair_aggregates_exclude_incomplete_and_infra_dominated_runs(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    pair = "openclaw-model"
+
+    _write_run(
+        jobs_root,
+        "model-rep-1",
+        expected_task_count=2,
+        results=[_result("a", reward=1.0), _result("b", reward=0.0)],
+        pair_label=pair,
+        repetition=1,
+    )
+    _write_run(
+        jobs_root,
+        "model-rep-2",
+        expected_task_count=2,
+        results=[_result("a", reward=1.0), _result("b", reward=1.0)],
+        pair_label=pair,
+        repetition=2,
+    )
+    _write_run(
+        jobs_root,
+        "model-rep-3",
+        expected_task_count=2,
+        results=[_result("a", reward=1.0)],
+        pair_label=pair,
+        repetition=3,
+        tasks=["a", "b"],
+    )
+    _write_run(
+        jobs_root,
+        "model-rep-4",
+        expected_task_count=2,
+        results=[
+            _result("a", exception_type="VerifierTimeoutError"),
+            _result("b", exception_type="EnvironmentStartTimeoutError"),
+        ],
+        pair_label=pair,
+        repetition=4,
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    pair_summary = report["pairs"][0]
+    assert pair_summary["pair_label"] == pair
+    assert pair_summary["total_repetitions"] == 4
+    assert pair_summary["eligible_repetitions"] == 2
+    assert pair_summary["excluded_repetitions"] == 2
+    assert pair_summary["mean_score"] == pytest.approx(0.75)
+    assert pair_summary["score_stdev"] == pytest.approx(0.3535533906)
+    assert pair_summary["min_score"] == 0.5
+    assert pair_summary["max_score"] == 1.0
+    assert pair_summary["mean_exact_passes"] == 1.5
+    assert pair_summary["pass_rate"] == 0.75
+    assert pair_summary["clean_complete_repetitions"] == 2
+
+    runs = {run["run_label"]: run for run in report["runs"]}
+    assert runs["model-rep-3"]["eligible"] is False
+    assert runs["model-rep-3"]["exclusion_reason"] == "incomplete"
+    assert runs["model-rep-4"]["eligible"] is False
+    assert runs["model-rep-4"]["exclusion_reason"] == "infra_dominated"
+
+    leaderboard = (summaries_dir / "cleaned_leaderboard.md").read_text()
+    assert "openclaw-model" in leaderboard
+    assert "0.7500" in leaderboard
+
+
+def test_pair_label_uses_manifest_harness_and_model(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    for repetition in (1, 2):
+        _write_run(
+            jobs_root,
+            f"openclaw-gpt55-full-1-r{repetition}-20260727",
+            expected_task_count=1,
+            results=[_result("a", reward=1.0)],
+            pair_label=None,
+            repetition=repetition,
+            harness="openclaw",
+            model_slug="gpt55",
+        )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    assert len(report["pairs"]) == 1
+    assert report["pairs"][0]["pair_label"] == "openclaw-gpt55"
+    assert report["pairs"][0]["eligible_repetitions"] == 2
+
+    adjacent_summaries = jobs_root / "jobs" / "summaries"
+    assert main([str(jobs_root / "jobs"), str(adjacent_summaries)]) == 0
+    rerun = aggregate(jobs_root / "jobs", adjacent_summaries)
+    assert len(rerun["runs"]) == 2
+
+
+def test_unknown_exception_is_agent_exit_and_gateway_signature_is_excluded(
+    tmp_path: Path,
+):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    results = [
+        _result(
+            f"gateway-{index}",
+            exception_type="NonZeroAgentExitCodeError",
+            exception_message="LiteLLM gateway connection refused on port 4000",
+        )
+        for index in range(3)
+    ]
+    results.extend(
+        _result(f"unknown-{index}", exception_type="UnexpectedAgentError")
+        for index in range(5)
+    )
+    _write_run(
+        jobs_root,
+        "openclaw-model-full-8-r1-20260727",
+        expected_task_count=8,
+        results=results,
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    run = report["runs"][0]
+    with (summaries_dir / "per_task_results.csv").open(newline="") as handle:
+        rows = {row["task_name"]: row for row in csv.DictReader(handle)}
+    assert rows["unknown-0"]["classification"] == "agent_exit"
+    assert run["harness_wide_failure"] is True
+    assert run["eligible"] is False
+    assert run["exclusion_reason"] == "harness_wide_failure"
+
+
+def test_reward_above_one_counts_as_exact_pass(tmp_path: Path):
+    jobs_root = tmp_path / "native"
+    summaries_dir = tmp_path / "summaries"
+    _write_run(
+        jobs_root,
+        "openclaw-model-full-1-r1-20260727",
+        expected_task_count=1,
+        results=[_result("bonus", reward=1.25)],
+    )
+
+    report = aggregate(jobs_root, summaries_dir)
+
+    assert report["runs"][0]["exact_passes"] == 1

--- a/tests/test_native_eval_audit.py
+++ b/tests/test_native_eval_audit.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.native_eval.audit import build_metadata_supplements, main
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value))
+
+
+def test_build_metadata_supplements_only_adds_missing_provenance(tmp_path: Path):
+    run_index = tmp_path / "run_index.json"
+    extracted = tmp_path / "extracted"
+    _write_json(
+        run_index,
+        {
+            "fleet": {
+                "execution_mode": "native",
+                "harbor_reference_commit": "harbor-sha",
+                "judge_model_id": "gpt-5.5",
+            }
+        },
+    )
+    _write_json(
+        extracted / "older" / "shellbench_meta-older" / "run_manifest.json",
+        {"run_label": "older"},
+    )
+    _write_json(
+        extracted / "newer" / "shellbench_meta-newer" / "run_manifest.json",
+        {
+            "run_label": "newer",
+            "execution_mode": "native",
+            "harbor_reference_commit": "harbor-sha",
+            "judge_model_id": "gpt-5.5",
+        },
+    )
+
+    report = build_metadata_supplements(run_index, extracted)
+
+    assert report["raw_archives_mutated"] is False
+    assert report["provenance"]["execution_mode"] == "native"
+    assert report["runs"] == [
+        {
+            "run_label": "older",
+            "archived_manifest": "older/shellbench_meta-older/run_manifest.json",
+            "supplements": {
+                "execution_mode": "native",
+                "harbor_reference_commit": "harbor-sha",
+                "judge_model_id": "gpt-5.5",
+            },
+        }
+    ]
+
+    output = tmp_path / "manifests" / "run_metadata_supplements.json"
+    assert main([str(run_index), str(extracted), str(output)]) == 0
+    assert json.loads(output.read_text())["runs"][0]["run_label"] == "older"
+
+
+def test_build_metadata_supplements_rejects_conflicting_provenance(tmp_path: Path):
+    run_index = tmp_path / "run_index.json"
+    extracted = tmp_path / "extracted"
+    _write_json(
+        run_index,
+        {
+            "fleet": {
+                "execution_mode": "native",
+                "harbor_reference_commit": "harbor-sha",
+                "judge_model_id": "gpt-5.5",
+            }
+        },
+    )
+    _write_json(
+        extracted / "run" / "shellbench_meta-run" / "run_manifest.json",
+        {
+            "run_label": "run",
+            "execution_mode": "harbor",
+        },
+    )
+
+    with pytest.raises(ValueError, match="conflicting execution_mode"):
+        build_metadata_supplements(run_index, extracted)

--- a/tests/test_native_eval_checkpoint.py
+++ b/tests/test_native_eval_checkpoint.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import io
+from argparse import Namespace
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from scripts.native_eval import checkpoint_loop
+from scripts.native_eval.checkpoint_loop import (
+    RemoteState,
+    partial_path,
+    pull_checkpoint,
+    pull_final,
+)
+
+
+def _archive_bytes(run_label: str) -> bytes:
+    payload = io.BytesIO()
+    result = b"{}"
+    with tarfile.open(fileobj=payload, mode="w:gz") as handle:
+        member = tarfile.TarInfo(
+            f"results/jobs/{run_label}/task__trial/result.json"
+        )
+        member.size = len(result)
+        handle.addfile(member, io.BytesIO(result))
+    return payload.getvalue()
+
+
+class InterruptedCopyClient:
+    def __init__(self, run_label: str) -> None:
+        self.run_label = run_label
+        self.copy_attempts = 0
+
+    def run(self, _command: list[str]) -> str:
+        return f"/tmp/{self.run_label}-checkpoint.tar.gz"
+
+    def copy_from(self, _remote_path: str, local_path: Path) -> None:
+        self.copy_attempts += 1
+        assert local_path.name.endswith(".partial")
+        if self.copy_attempts == 1:
+            local_path.write_bytes(b"interrupted")
+            raise subprocess.CalledProcessError(1, ["scp"])
+        local_path.write_bytes(_archive_bytes(self.run_label))
+
+
+class RecordingCopyClient:
+    def __init__(self, run_label: str, final_paths: list[Path]) -> None:
+        self.run_label = run_label
+        self.final_paths = final_paths
+        self.destinations: list[Path] = []
+
+    def copy_from(self, remote_path: str, local_path: Path) -> None:
+        assert all(not path.exists() for path in self.final_paths)
+        assert local_path.name.endswith(".partial")
+        self.destinations.append(local_path)
+        if remote_path.endswith(".tar.gz"):
+            local_path.write_bytes(_archive_bytes(self.run_label))
+        else:
+            local_path.write_text(remote_path, encoding="utf-8")
+
+
+def test_interrupted_checkpoint_copy_replaces_stale_partial_on_retry(
+    tmp_path: Path,
+) -> None:
+    run_label = "openclaw-gpt55-full-1-r1-20260727"
+    raw_dir = tmp_path / "raw"
+    logs_dir = tmp_path / "logs"
+    raw_dir.mkdir()
+    logs_dir.mkdir()
+    log_path = logs_dir / f"{run_label}.checkpoints.log"
+    final_path = raw_dir / f"{run_label}-checkpoint-0001-artifacts.tar.gz"
+    client = InterruptedCopyClient(run_label)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pull_checkpoint(
+            client=client,
+            runner_root="/runner",
+            remote_root="/remote",
+            run_label=run_label,
+            raw_dir=raw_dir,
+            log_path=log_path,
+            sequence=1,
+        )
+
+    assert not final_path.exists()
+    assert partial_path(final_path).read_bytes() == b"interrupted"
+
+    assert pull_checkpoint(
+        client=client,
+        runner_root="/runner",
+        remote_root="/remote",
+        run_label=run_label,
+        raw_dir=raw_dir,
+        log_path=log_path,
+        sequence=1,
+    ) == 1
+    assert final_path.is_file()
+    assert not partial_path(final_path).exists()
+
+
+def test_final_pull_publishes_only_after_all_partial_downloads_and_tar_verify(
+    tmp_path: Path,
+) -> None:
+    run_label = "openclaw-gpt55-full-1-r1-20260727"
+    raw_dir = tmp_path / "raw"
+    logs_dir = tmp_path / "logs"
+    raw_dir.mkdir()
+    logs_dir.mkdir()
+    log_path = logs_dir / f"{run_label}.checkpoints.log"
+    final_paths = [
+        raw_dir / f"{run_label}-final-artifacts.tar.gz",
+        logs_dir / f"{run_label}.stdout.log",
+        logs_dir / f"{run_label}.stderr.log",
+    ]
+    client = RecordingCopyClient(run_label, final_paths)
+
+    assert pull_final(
+        client=client,
+        remote_root="/remote",
+        run_label=run_label,
+        raw_dir=raw_dir,
+        logs_dir=logs_dir,
+        log_path=log_path,
+    ) == 1
+
+    assert all(path.is_file() for path in final_paths)
+    assert client.destinations == [partial_path(path) for path in final_paths]
+    assert all(not partial_path(path).exists() for path in final_paths)
+
+
+def test_done_final_copy_failure_logs_recovery_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_label = "openclaw-gpt55-full-1-r1-20260727"
+    args = Namespace(
+        local_root=tmp_path,
+        control_path=tmp_path / "control.sock",
+        target="example",
+        port=22,
+        identity_file=tmp_path / "identity",
+        remote_root="/remote",
+        runner_root="/runner",
+        run_label=run_label,
+        poll_seconds=0,
+        interval_seconds=60,
+        trial_increment=10,
+        max_ssh_failures=3,
+    )
+
+    monkeypatch.setattr(checkpoint_loop, "SSHClient", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        checkpoint_loop,
+        "read_remote_state",
+        lambda *_args: RemoteState(0, 0, True, 0),
+    )
+
+    def fail_final(**_kwargs: object) -> int:
+        raise subprocess.CalledProcessError(1, ["scp"])
+
+    monkeypatch.setattr(checkpoint_loop, "pull_final", fail_final)
+
+    assert checkpoint_loop.run_loop(args) == 75
+    log_path = tmp_path / "logs" / f"{run_label}.checkpoints.log"
+    assert "\tfinal_error\t" in log_path.read_text(encoding="utf-8")

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -101,6 +101,7 @@ class FakeExecutor:
         checkpoint_blocks: dict[str, threading.Event] | None = None,
         stop_code: int = 0,
         inspect_errors: set[str] | None = None,
+        warmup_capacity_failures: dict[str, int] | None = None,
     ) -> None:
         self.local_root = local_root
         self.expected_counts = expected_counts
@@ -110,6 +111,8 @@ class FakeExecutor:
         self.checkpoint_blocks = checkpoint_blocks or {}
         self.stop_code = stop_code
         self.inspect_errors = inspect_errors or set()
+        self.warmup_capacity_failures = warmup_capacity_failures or {}
+        self.warmup_attempts: dict[str, int] = {}
         self.leases: dict[str, dict[str, object]] = {}
         self.commands: list[list[str]] = []
         self.events: list[tuple[str, str]] = []
@@ -162,6 +165,18 @@ class FakeExecutor:
         if argv[:2] == ["crabbox", "warmup"]:
             slug = argv[argv.index("--slug") + 1]
             with self._lock:
+                attempt = self.warmup_attempts.get(slug, 0) + 1
+                self.warmup_attempts[slug] = attempt
+                if attempt <= self.warmup_capacity_failures.get(slug, 0):
+                    return _result(
+                        argv,
+                        1,
+                        stderr=(
+                            "coordinator POST /v1/leases: http 429: "
+                            '{"error":"cost_limit_exceeded",'
+                            '"message":"Active lease limit 11/10"}'
+                        ),
+                    )
                 self._next_lease += 1
                 lease_id = f"cbx_{self._next_lease}"
                 self.active_leases += 1
@@ -264,6 +279,8 @@ def _config(
     task_concurrency: int = 16,
     model_max_runs: dict[str, int] | None = None,
     model_task_concurrency: dict[str, int] | None = None,
+    warmup_capacity_attempts: int = 12,
+    warmup_capacity_backoff_seconds: float = 0,
 ) -> FleetConfig:
     runner_archive = tmp_path / "runner.tar.gz"
     task_archive = tmp_path / "tasks.tar.gz"
@@ -285,6 +302,8 @@ def _config(
         model_max_runs=model_max_runs or {},
         model_task_concurrency=model_task_concurrency or {},
         checkpoint_poll_seconds=1,
+        warmup_capacity_attempts=warmup_capacity_attempts,
+        warmup_capacity_backoff_seconds=warmup_capacity_backoff_seconds,
     )
 
 
@@ -315,6 +334,43 @@ def test_controller_runs_bounded_wave_and_stops_after_verified_export(
         stop_at = executor.events.index(("stop", lease_id))
         assert checkpoint_at < stop_at
     assert "TOPSECRET" not in "\n".join(" ".join(command) for command in executor.commands)
+
+
+def test_capacity_warmup_retries_same_run_without_recovery_churn(
+    tmp_path: Path,
+) -> None:
+    retry_label = "openclaw-gpt55-full-2-r1-20260727"
+    untouched_label = "openclaw-gpt55-full-2-r2-20260727"
+    retry_run = _planned(_run_spec(retry_label))
+    retry_run["requested_lease_slug"] = "capacity-retry"
+    untouched_run = _planned(_run_spec(untouched_label))
+    untouched_run["requested_lease_slug"] = "untouched"
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [retry_run, untouched_run])
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=1,
+        warmup_capacity_attempts=3,
+        warmup_capacity_backoff_seconds=0,
+    )
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={retry_label: 2, untouched_label: 2},
+        warmup_capacity_failures={"capacity-retry": 2},
+    )
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    runs = json.loads(run_index.read_text(encoding="utf-8"))["runs"]
+    assert [run["run_label"] for run in runs] == [retry_label, untouched_label]
+    assert [run["status"] for run in runs] == ["completed", "completed"]
+    assert all(run["rerun_of"] is None for run in runs)
+    assert executor.warmup_attempts == {
+        "capacity-retry": 3,
+        "untouched": 1,
+    }
+    assert executor.dispatches == [retry_label, untouched_label]
 
 
 def test_model_cap_counts_adopted_run_before_dispatching_same_model(

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -121,6 +121,12 @@ class FakeExecutor:
         with self._lock:
             self.commands.append(argv)
 
+        if argv == ["crabbox", "--version"]:
+            return _result(argv, 0, stdout="crabbox version 0.36.0\n")
+
+        if argv[:2] == ["env", "CRABBOX_CAPACITY_MARKET=on-demand"]:
+            argv = argv[2:]
+
         if argv[:2] == ["crabbox", "inspect"]:
             identifier = argv[argv.index("--id") + 1]
             if identifier in self.inspect_errors:
@@ -265,6 +271,9 @@ def test_controller_runs_bounded_wave_and_stops_after_verified_export(
     assert [run["status"] for run in index["runs"]] == ["completed", "completed"]
     assert executor.dispatches == labels
     assert executor.max_active_leases == 1
+    warmup = next(command for command in executor.commands if "warmup" in command)
+    assert warmup[:2] == ["env", "CRABBOX_CAPACITY_MARKET=on-demand"]
+    assert "--market" not in warmup
     for label in labels:
         checkpoint_at = executor.events.index(("checkpoint", label))
         lease_id = index["runs"][labels.index(label)]["lease"]["id"]

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -76,13 +76,23 @@ def _write_archive(path: Path) -> None:
         handle.add(source, arcname=".")
 
 
-def _write_final(local_root: Path, run_label: str, result_count: int) -> None:
+def _write_final(
+    local_root: Path,
+    run_label: str,
+    result_count: int,
+    *,
+    exit_status: int | None = None,
+) -> None:
     source = local_root / f".archive-{run_label}"
     job = source / "results" / "jobs" / run_label
     for index in range(result_count):
         trial = job / f"task-{index}__trial"
         trial.mkdir(parents=True, exist_ok=True)
         (trial / "result.json").write_text("{}", encoding="utf-8")
+    if exit_status is not None:
+        meta = source / f"shellbench_meta-{run_label}"
+        meta.mkdir(parents=True, exist_ok=True)
+        (meta / "exit_status").write_text(f"{exit_status}\n", encoding="utf-8")
     archive = local_root / "raw" / f"{run_label}-final-artifacts.tar.gz"
     archive.parent.mkdir(parents=True, exist_ok=True)
     with tarfile.open(archive, "w:gz") as handle:
@@ -118,6 +128,7 @@ class FakeExecutor:
         self.events: list[tuple[str, str]] = []
         self.dispatches: list[str] = []
         self.dispatch_concurrency: dict[str, int] = {}
+        self.dispatch_arguments: dict[str, list[str]] = {}
         self.stops: list[str] = []
         self._lock = threading.Lock()
         self._dispatch_condition = threading.Condition(self._lock)
@@ -237,9 +248,12 @@ class FakeExecutor:
                 if candidate in joined
             )
             remote_command = shlex.split(argv[-1])
+            dispatch_marker = remote_command.index("fleet-dispatch")
+            remote_run_args = remote_command[dispatch_marker + 13 :]
             with self._dispatch_condition:
                 self.dispatches.append(label)
-                self.dispatch_concurrency[label] = int(remote_command[-1])
+                self.dispatch_concurrency[label] = int(remote_run_args[10])
+                self.dispatch_arguments[label] = remote_run_args
                 self.events.append(("dispatch", label))
                 self.remote_states[label] = "running"
                 self._dispatch_condition.notify_all()
@@ -327,6 +341,13 @@ def test_controller_runs_bounded_wave_and_stops_after_verified_export(
     assert [run["status"] for run in index["runs"]] == ["completed", "completed"]
     assert executor.dispatches == labels
     assert executor.max_active_leases == 1
+    for label in labels:
+        assert executor.dispatch_arguments[label][11:15] == [
+            "test",
+            "provider/gpt55",
+            "openai",
+            "sb-gpt55",
+        ]
     warmup = next(command for command in executor.commands if "warmup" in command)
     assert warmup[:2] == ["env", "CRABBOX_CAPACITY_MARKET=on-demand"]
     assert "--market" not in warmup
@@ -855,6 +876,77 @@ def test_recovery_required_resumes_existing_remote_run(tmp_path: Path) -> None:
     assert executor.dispatches == []
     final = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
     assert final["status"] == "completed"
+
+
+def test_recovery_infers_success_from_verified_full_archive_and_done_log(
+    tmp_path: Path,
+) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run["status"] = "recovery_required"
+    run["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index)
+    _write_final(config.local_root, label, 2)
+    checkpoint_log = config.local_root / "logs" / f"{label}.checkpoints.log"
+    checkpoint_log.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_log.write_text(
+        f"2026-07-27T00:00:00Z\tfinal\t{label}-final-artifacts.tar.gz\t2\t\n",
+        encoding="utf-8",
+    )
+    executor = FakeExecutor(config.local_root, expected_counts={label: 2})
+    executor.leases["cbx_existing"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "state": "active",
+        "ready": True,
+        "serverType": "c7a.24xlarge",
+        "sshHost": "192.0.2.50",
+        "sshUser": "crabbox",
+        "sshPort": "22",
+        "sshKey": "/tmp/cbx_existing.key",
+    }
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    recovered = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert recovered["status"] == "completed"
+    assert recovered["run_exit_code"] == 0
+    assert recovered["run_exit_code_source"] == "recovered_full_coverage_remote_done"
+    assert "inferred zero" in recovered["run_exit_code_inference"]
+
+
+def test_recovery_preserves_archived_nonzero_exit_status(tmp_path: Path) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run["status"] = "recovery_required"
+    run["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index, max_attempts=1)
+    _write_final(config.local_root, label, 2, exit_status=7)
+    executor = FakeExecutor(config.local_root, expected_counts={label: 2})
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 1
+
+    recovered = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert recovered["status"] == "failed"
+    assert recovered["run_exit_code"] == 7
+    assert recovered["run_exit_code_source"] == "archived_exit_status"
+    assert recovered["last_error"] == "run exit 7; result coverage 2/2"
 
 
 def test_stop_failure_is_left_pending_without_tight_retry(tmp_path: Path) -> None:

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -676,6 +676,12 @@ def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
             "opus48=2",
             "--provider-max-runs",
             "anthropic=2",
+            "--harbor-reference-commit",
+            "harbor-commit",
+            "--judge-model-id",
+            "gpt-5.5",
+            "--execution-mode",
+            "native",
             "--model-task-concurrency",
             "fable5=2",
         ]
@@ -683,6 +689,9 @@ def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
 
     assert args.model_max_runs == {"fable5": 1, "opus48": 2}
     assert args.provider_max_runs == {"anthropic": 2}
+    assert args.harbor_reference_commit == "harbor-commit"
+    assert args.judge_model_id == "gpt-5.5"
+    assert args.execution_mode == "native"
     assert args.model_task_concurrency == {"fable5": 2}
 
 

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tarfile
+import threading
+from pathlib import Path
+from typing import Sequence
+
+from scripts.native_eval.fleet import FleetConfig, FleetController
+from scripts.native_eval.models import RunSpec
+
+
+def _run_spec(label: str, *, expected_task_count: int = 2) -> RunSpec:
+    return RunSpec(
+        run_label=label,
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=expected_task_count,
+        run_date="20260727",
+    )
+
+
+def _write_index(
+    path: Path,
+    runs: list[dict[str, object]],
+    *,
+    expected_task_count: int = 2,
+) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "created_at_utc": "2026-07-27T00:00:00+00:00",
+                "public_tasks_commit": "tasks-commit",
+                "task_suite_path": "combined tasks/tasks",
+                "expected_task_count": expected_task_count,
+                "planned_run_count": len(runs),
+                "runs": runs,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _planned(run: RunSpec) -> dict[str, object]:
+    return {
+        **run.to_dict(),
+        "attempt": 0,
+        "status": "planned",
+        "leaderboard_eligible": None,
+        "rerun_of": None,
+        "lease": None,
+        "artifacts": [],
+    }
+
+
+def _write_archive(path: Path) -> None:
+    source = path.parent / f"{path.stem}-source"
+    source.mkdir()
+    (source / "marker.txt").write_text("pinned", encoding="utf-8")
+    with tarfile.open(path, "w:gz") as handle:
+        handle.add(source, arcname=".")
+
+
+def _write_final(local_root: Path, run_label: str, result_count: int) -> None:
+    source = local_root / f".archive-{run_label}"
+    job = source / "results" / "jobs" / run_label
+    for index in range(result_count):
+        trial = job / f"task-{index}__trial"
+        trial.mkdir(parents=True, exist_ok=True)
+        (trial / "result.json").write_text("{}", encoding="utf-8")
+    archive = local_root / "raw" / f"{run_label}-final-artifacts.tar.gz"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(source, arcname=".")
+
+
+class FakeExecutor:
+    def __init__(
+        self,
+        local_root: Path,
+        *,
+        expected_counts: dict[str, int],
+        checkpoint_codes: dict[str, int] | None = None,
+        omit_final: set[str] | None = None,
+        running_labels: set[str] | None = None,
+        stop_code: int = 0,
+        inspect_errors: set[str] | None = None,
+    ) -> None:
+        self.local_root = local_root
+        self.expected_counts = expected_counts
+        self.checkpoint_codes = checkpoint_codes or {}
+        self.omit_final = omit_final or set()
+        self.remote_states = {label: "running" for label in (running_labels or set())}
+        self.stop_code = stop_code
+        self.inspect_errors = inspect_errors or set()
+        self.leases: dict[str, dict[str, object]] = {}
+        self.commands: list[list[str]] = []
+        self.events: list[tuple[str, str]] = []
+        self.dispatches: list[str] = []
+        self.stops: list[str] = []
+        self._lock = threading.Lock()
+        self._next_lease = 0
+        self.active_leases = 0
+        self.max_active_leases = 0
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output
+        argv = list(command)
+        with self._lock:
+            self.commands.append(argv)
+
+        if argv[:2] == ["crabbox", "inspect"]:
+            identifier = argv[argv.index("--id") + 1]
+            if identifier in self.inspect_errors:
+                return _result(argv, 1, stderr="broker request timed out")
+            lease = next(
+                (
+                    value
+                    for value in self.leases.values()
+                    if identifier in {value["id"], value["slug"]}
+                ),
+                None,
+            )
+            if lease is None:
+                return _result(argv, 1, stderr="not found")
+            return _result(argv, 0, stdout=json.dumps(lease))
+
+        if argv[:2] == ["crabbox", "warmup"]:
+            slug = argv[argv.index("--slug") + 1]
+            with self._lock:
+                self._next_lease += 1
+                lease_id = f"cbx_{self._next_lease}"
+                self.active_leases += 1
+                self.max_active_leases = max(
+                    self.max_active_leases,
+                    self.active_leases,
+                )
+                self.leases[lease_id] = {
+                    "id": lease_id,
+                    "slug": slug,
+                    "state": "active",
+                    "ready": True,
+                    "serverType": "c7a.24xlarge",
+                    "sshHost": f"192.0.2.{self._next_lease}",
+                    "sshUser": "crabbox",
+                    "sshPort": "22",
+                    "sshKey": f"/tmp/{lease_id}.key",
+                }
+            return _result(argv, 0)
+
+        if argv[:2] == ["crabbox", "stop"]:
+            lease_id = argv[argv.index("--id") + 1]
+            with self._lock:
+                self.stops.append(lease_id)
+                self.events.append(("stop", lease_id))
+                if not self.stop_code:
+                    self.active_leases -= 1
+            return _result(argv, self.stop_code)
+
+        if "-m" in argv and "scripts.native_eval.checkpoint_loop" in argv:
+            label = argv[argv.index("--run-label") + 1]
+            with self._lock:
+                self.events.append(("checkpoint", label))
+            if label not in self.omit_final:
+                _write_final(
+                    self.local_root,
+                    label,
+                    self.expected_counts.get(label, 0),
+                )
+            return _result(argv, self.checkpoint_codes.get(label, 0))
+
+        joined = " ".join(argv)
+        if argv and argv[0] == "ssh" and "fleet-probe" in joined:
+            label = next(
+                candidate
+                for candidate in sorted(self.expected_counts, key=len, reverse=True)
+                if candidate in joined
+            )
+            return _result(argv, 0, stdout=self.remote_states.get(label, "missing"))
+
+        if argv and argv[0] == "ssh" and "fleet-dispatch" in joined:
+            label = next(
+                candidate
+                for candidate in sorted(self.expected_counts, key=len, reverse=True)
+                if candidate in joined
+            )
+            with self._lock:
+                self.dispatches.append(label)
+                self.events.append(("dispatch", label))
+                self.remote_states[label] = "running"
+            return _result(argv, 0, stdout="1234")
+
+        return _result(argv, 0)
+
+
+def _result(
+    command: Sequence[str],
+    returncode: int,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        list(command),
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _config(
+    tmp_path: Path,
+    run_index: Path,
+    *,
+    max_leases: int = 1,
+    max_attempts: int = 2,
+) -> FleetConfig:
+    runner_archive = tmp_path / "runner.tar.gz"
+    task_archive = tmp_path / "tasks.tar.gz"
+    _write_archive(runner_archive)
+    _write_archive(task_archive)
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENAI_API_KEY=TOPSECRET\n", encoding="utf-8")
+    return FleetConfig(
+        run_index=run_index,
+        local_root=tmp_path / "runs",
+        runner_root=tmp_path,
+        runner_archive=runner_archive,
+        runner_commit="runner-commit",
+        task_archive=task_archive,
+        env_file=env_file,
+        max_leases=max_leases,
+        max_attempts=max_attempts,
+        checkpoint_poll_seconds=1,
+    )
+
+
+def test_controller_runs_bounded_wave_and_stops_after_verified_export(
+    tmp_path: Path,
+) -> None:
+    labels = ["openclaw-gpt55-full-2-r1-20260727", "openclaw-gpt55-full-2-r2-20260727"]
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [_planned(_run_spec(label)) for label in labels])
+    config = _config(tmp_path, run_index, max_leases=1)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2 for label in labels},
+    )
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    index = json.loads(run_index.read_text(encoding="utf-8"))
+    assert [run["status"] for run in index["runs"]] == ["completed", "completed"]
+    assert executor.dispatches == labels
+    assert executor.max_active_leases == 1
+    for label in labels:
+        checkpoint_at = executor.events.index(("checkpoint", label))
+        lease_id = index["runs"][labels.index(label)]["lease"]["id"]
+        stop_at = executor.events.index(("stop", lease_id))
+        assert checkpoint_at < stop_at
+    assert "TOPSECRET" not in "\n".join(" ".join(command) for command in executor.commands)
+
+
+def test_failed_run_is_preserved_and_suffixed_rerun_completes(
+    tmp_path: Path,
+) -> None:
+    base = "openclaw-gpt55-full-2-r1-20260727"
+    rerun = f"{base}-rerun1"
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [_planned(_run_spec(base))])
+    config = _config(tmp_path, run_index, max_attempts=2)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={base: 1, rerun: 2},
+        checkpoint_codes={base: 1},
+    )
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    runs = json.loads(run_index.read_text(encoding="utf-8"))["runs"]
+    assert [run["run_label"] for run in runs] == [base, rerun]
+    assert runs[0]["status"] == "failed"
+    assert runs[0]["final_result_count"] == 1
+    assert runs[1]["status"] == "completed"
+    assert runs[1]["rerun_of"] == base
+    assert executor.dispatches == [base, rerun]
+    assert (config.local_root / "raw" / f"{base}-final-artifacts.tar.gz").is_file()
+    assert (config.local_root / "raw" / f"{rerun}-final-artifacts.tar.gz").is_file()
+
+
+def test_resume_attaches_to_running_lease_without_redispatch(tmp_path: Path) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run["status"] = "running"
+    run["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2},
+        running_labels={label},
+    )
+    executor.leases["cbx_existing"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "state": "active",
+        "ready": True,
+        "serverType": "c7a.24xlarge",
+        "sshHost": "192.0.2.50",
+        "sshUser": "crabbox",
+        "sshPort": "22",
+        "sshKey": "/tmp/cbx_existing.key",
+    }
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    assert executor.dispatches == []
+    assert not any(command[:2] == ["crabbox", "warmup"] for command in executor.commands)
+    assert not any(command and command[0] == "scp" for command in executor.commands)
+    final = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert final["status"] == "completed"
+
+
+def test_unverified_final_keeps_lease_for_recovery(tmp_path: Path) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [_planned(_run_spec(label))])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2},
+        checkpoint_codes={label: 75},
+        omit_final={label},
+    )
+
+    assert FleetController(config, executor=executor).run() == 1
+
+    runs = json.loads(run_index.read_text(encoding="utf-8"))["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "recovery_required"
+    assert runs[0]["lease"]["state"] == "active"
+    assert executor.stops == []
+
+
+def test_recovery_required_resumes_existing_remote_run(tmp_path: Path) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run["status"] = "recovery_required"
+    run["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2},
+        running_labels={label},
+    )
+    executor.leases["cbx_existing"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "state": "active",
+        "ready": True,
+        "serverType": "c7a.24xlarge",
+        "sshHost": "192.0.2.50",
+        "sshUser": "crabbox",
+        "sshPort": "22",
+        "sshKey": "/tmp/cbx_existing.key",
+    }
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    assert executor.dispatches == []
+    final = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert final["status"] == "completed"
+
+
+def test_stop_failure_is_left_pending_without_tight_retry(tmp_path: Path) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [_planned(_run_spec(label))])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2},
+        stop_code=1,
+    )
+
+    assert FleetController(config, executor=executor).run() == 1
+
+    run = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert run["status"] == "stop_pending"
+    assert run["verified_final_export"] is True
+    assert len(executor.stops) == 1
+
+
+def test_ambiguous_lease_inspect_error_does_not_duplicate_run(
+    tmp_path: Path,
+) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run["status"] = "running"
+    run["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2},
+        inspect_errors={"cbx_existing"},
+    )
+
+    assert FleetController(config, executor=executor).run() == 1
+
+    runs = json.loads(run_index.read_text(encoding="utf-8"))["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "recovery_required"
+    assert executor.dispatches == []
+    assert executor.stops == []
+    assert not any(command[:2] == ["crabbox", "warmup"] for command in executor.commands)

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -1,25 +1,33 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import tarfile
 import threading
 from pathlib import Path
 from typing import Sequence
 
-from scripts.native_eval.fleet import FleetConfig, FleetController
+import pytest
+
+from scripts.native_eval.fleet import FleetConfig, FleetController, parse_args
 from scripts.native_eval.models import RunSpec
 
 
-def _run_spec(label: str, *, expected_task_count: int = 2) -> RunSpec:
+def _run_spec(
+    label: str,
+    *,
+    expected_task_count: int = 2,
+    model_slug: str = "gpt55",
+) -> RunSpec:
     return RunSpec(
         run_label=label,
         harness="openclaw",
         harness_version="test",
-        model_slug="gpt55",
-        model_id="gpt-5.5",
-        provider="openai",
-        proxy_model_name="sb-gpt55",
+        model_slug=model_slug,
+        model_id=f"provider/{model_slug}",
+        provider="anthropic" if model_slug == "fable5" else "openai",
+        proxy_model_name=f"sb-{model_slug}",
         repetition=1,
         expected_task_count=expected_task_count,
         run_date="20260727",
@@ -90,6 +98,7 @@ class FakeExecutor:
         checkpoint_codes: dict[str, int] | None = None,
         omit_final: set[str] | None = None,
         running_labels: set[str] | None = None,
+        checkpoint_blocks: dict[str, threading.Event] | None = None,
         stop_code: int = 0,
         inspect_errors: set[str] | None = None,
     ) -> None:
@@ -98,14 +107,17 @@ class FakeExecutor:
         self.checkpoint_codes = checkpoint_codes or {}
         self.omit_final = omit_final or set()
         self.remote_states = {label: "running" for label in (running_labels or set())}
+        self.checkpoint_blocks = checkpoint_blocks or {}
         self.stop_code = stop_code
         self.inspect_errors = inspect_errors or set()
         self.leases: dict[str, dict[str, object]] = {}
         self.commands: list[list[str]] = []
         self.events: list[tuple[str, str]] = []
         self.dispatches: list[str] = []
+        self.dispatch_concurrency: dict[str, int] = {}
         self.stops: list[str] = []
         self._lock = threading.Lock()
+        self._dispatch_condition = threading.Condition(self._lock)
         self._next_lease = 0
         self.active_leases = 0
         self.max_active_leases = 0
@@ -179,6 +191,9 @@ class FakeExecutor:
             label = argv[argv.index("--run-label") + 1]
             with self._lock:
                 self.events.append(("checkpoint", label))
+            block = self.checkpoint_blocks.get(label)
+            if block is not None:
+                block.wait()
             if label not in self.omit_final:
                 _write_final(
                     self.local_root,
@@ -202,13 +217,23 @@ class FakeExecutor:
                 for candidate in sorted(self.expected_counts, key=len, reverse=True)
                 if candidate in joined
             )
-            with self._lock:
+            remote_command = shlex.split(argv[-1])
+            with self._dispatch_condition:
                 self.dispatches.append(label)
+                self.dispatch_concurrency[label] = int(remote_command[-1])
                 self.events.append(("dispatch", label))
                 self.remote_states[label] = "running"
+                self._dispatch_condition.notify_all()
             return _result(argv, 0, stdout="1234")
 
         return _result(argv, 0)
+
+    def wait_for_dispatch(self, run_label: str, timeout: float) -> bool:
+        with self._dispatch_condition:
+            return self._dispatch_condition.wait_for(
+                lambda: run_label in self.dispatches,
+                timeout=timeout,
+            )
 
 
 def _result(
@@ -232,6 +257,9 @@ def _config(
     *,
     max_leases: int = 1,
     max_attempts: int = 2,
+    task_concurrency: int = 16,
+    model_max_runs: dict[str, int] | None = None,
+    model_task_concurrency: dict[str, int] | None = None,
 ) -> FleetConfig:
     runner_archive = tmp_path / "runner.tar.gz"
     task_archive = tmp_path / "tasks.tar.gz"
@@ -249,6 +277,9 @@ def _config(
         env_file=env_file,
         max_leases=max_leases,
         max_attempts=max_attempts,
+        task_concurrency=task_concurrency,
+        model_max_runs=model_max_runs or {},
+        model_task_concurrency=model_task_concurrency or {},
         checkpoint_poll_seconds=1,
     )
 
@@ -280,6 +311,206 @@ def test_controller_runs_bounded_wave_and_stops_after_verified_export(
         stop_at = executor.events.index(("stop", lease_id))
         assert checkpoint_at < stop_at
     assert "TOPSECRET" not in "\n".join(" ".join(command) for command in executor.commands)
+
+
+def test_model_cap_counts_adopted_run_before_dispatching_same_model(
+    tmp_path: Path,
+) -> None:
+    adopted_label = "openclaw-fable5-full-2-r1-20260727"
+    pending_fable_label = "openclaw-fable5-full-2-r2-20260727"
+    pending_gpt_label = "openclaw-gpt55-full-2-r1-20260727"
+    adopted = _planned(_run_spec(adopted_label, model_slug="fable5"))
+    adopted["status"] = "running"
+    adopted["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(
+        run_index,
+        [
+            _planned(_run_spec(pending_fable_label, model_slug="fable5")),
+            _planned(_run_spec(pending_gpt_label)),
+            adopted,
+        ],
+    )
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=2,
+        model_max_runs={"fable5": 1},
+    )
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={
+            adopted_label: 2,
+            pending_fable_label: 2,
+            pending_gpt_label: 2,
+        },
+        running_labels={adopted_label},
+    )
+    executor.leases["cbx_existing"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "state": "active",
+        "ready": True,
+        "serverType": "c7a.24xlarge",
+        "sshHost": "192.0.2.50",
+        "sshUser": "crabbox",
+        "sshPort": "22",
+        "sshKey": "/tmp/cbx_existing.key",
+    }
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    assert executor.dispatches == [pending_gpt_label, pending_fable_label]
+    adopted_stop = executor.events.index(("stop", "cbx_existing"))
+    pending_fable_dispatch = executor.events.index(("dispatch", pending_fable_label))
+    assert adopted_stop < pending_fable_dispatch
+
+
+def test_model_task_concurrency_override_is_used_at_dispatch(tmp_path: Path) -> None:
+    fable_label = "openclaw-fable5-full-2-r1-20260727"
+    gpt_label = "openclaw-gpt55-full-2-r1-20260727"
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(
+        run_index,
+        [
+            _planned(_run_spec(fable_label, model_slug="fable5")),
+            _planned(_run_spec(gpt_label)),
+        ],
+    )
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=2,
+        task_concurrency=16,
+        model_task_concurrency={"fable5": 2},
+    )
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={fable_label: 2, gpt_label: 2},
+    )
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    assert executor.dispatch_concurrency == {
+        fable_label: 2,
+        gpt_label: 16,
+    }
+
+
+def test_slow_capped_model_does_not_block_refilling_eligible_slot(
+    tmp_path: Path,
+) -> None:
+    slow_fable = "openclaw-fable5-full-2-r1-20260727"
+    fast_gpt = "openclaw-gpt55-full-2-r1-20260727"
+    capped_fable = "openclaw-fable5-full-2-r2-20260727"
+    later_gpt = "openclaw-gpt55-full-2-r2-20260727"
+    labels = [slow_fable, fast_gpt, capped_fable, later_gpt]
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(
+        run_index,
+        [
+            _planned(_run_spec(slow_fable, model_slug="fable5")),
+            _planned(_run_spec(fast_gpt)),
+            _planned(_run_spec(capped_fable, model_slug="fable5")),
+            _planned(_run_spec(later_gpt)),
+        ],
+    )
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=2,
+        model_max_runs={"fable5": 1},
+    )
+    release_slow = threading.Event()
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2 for label in labels},
+        checkpoint_blocks={slow_fable: release_slow},
+    )
+    result: list[int] = []
+    controller = threading.Thread(
+        target=lambda: result.append(FleetController(config, executor=executor).run())
+    )
+    controller.start()
+    try:
+        assert executor.wait_for_dispatch(later_gpt, timeout=2)
+        assert capped_fable not in executor.dispatches
+        assert not release_slow.is_set()
+    finally:
+        release_slow.set()
+        controller.join(timeout=5)
+
+    assert not controller.is_alive()
+    assert result == [0]
+    assert executor.dispatches.index(later_gpt) < executor.dispatches.index(capped_fable)
+    assert executor.max_active_leases == 2
+
+
+def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
+    args = parse_args(
+        [
+            "--run-index",
+            str(tmp_path / "index.json"),
+            "--local-root",
+            str(tmp_path / "runs"),
+            "--runner-root",
+            str(tmp_path / "runner"),
+            "--task-archive",
+            str(tmp_path / "tasks.tar.gz"),
+            "--env-file",
+            str(tmp_path / ".env"),
+            "--model-max-runs",
+            "fable5=1",
+            "--model-max-runs",
+            "opus48=2",
+            "--model-task-concurrency",
+            "fable5=2",
+        ]
+    )
+
+    assert args.model_max_runs == {"fable5": 1, "opus48": 2}
+    assert args.model_task_concurrency == {"fable5": 2}
+
+
+@pytest.mark.parametrize(
+    ("option", "values"),
+    [
+        ("--model-max-runs", ["fable5"]),
+        ("--model-max-runs", ["=1"]),
+        ("--model-max-runs", ["fable5=nope"]),
+        ("--model-max-runs", ["fable5=0"]),
+        ("--model-task-concurrency", ["fable5=-1"]),
+        ("--model-task-concurrency", ["fable5=1", "fable5=2"]),
+    ],
+)
+def test_parse_args_rejects_invalid_model_values(
+    tmp_path: Path,
+    option: str,
+    values: list[str],
+) -> None:
+    argv = [
+        "--run-index",
+        str(tmp_path / "index.json"),
+        "--local-root",
+        str(tmp_path / "runs"),
+        "--runner-root",
+        str(tmp_path / "runner"),
+        "--task-archive",
+        str(tmp_path / "tasks.tar.gz"),
+        "--env-file",
+        str(tmp_path / ".env"),
+    ]
+    for value in values:
+        argv.extend([option, value])
+
+    with pytest.raises(SystemExit):
+        parse_args(argv)
 
 
 def test_failed_run_is_preserved_and_suffixed_rerun_completes(

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -456,6 +456,90 @@ def test_slow_capped_model_does_not_block_refilling_eligible_slot(
     assert executor.max_active_leases == 2
 
 
+def test_recovery_pending_entries_respect_capacity_behind_owned_runs(
+    tmp_path: Path,
+) -> None:
+    owned_labels = [f"openclaw-gpt55-full-2-r{index}-20260727" for index in range(1, 10)]
+    pending_labels = [
+        f"openclaw-fable5-full-2-r{index}-20260727" for index in range(10, 15)
+    ]
+    owned_runs: list[dict[str, object]] = []
+    for index, label in enumerate(owned_labels, start=1):
+        run = _planned(_run_spec(label))
+        run["status"] = "running"
+        run["lease"] = {
+            "id": f"cbx_owned_{index}",
+            "slug": f"owned-{index}",
+            "provider": "aws",
+            "state": "active",
+        }
+        owned_runs.append(run)
+    pending_runs: list[dict[str, object]] = []
+    for index, label in enumerate(pending_labels, start=1):
+        run = _planned(_run_spec(label, model_slug="fable5"))
+        run["status"] = "leasing" if index == 1 else "recovery_required"
+        run["requested_lease_slug"] = f"requested-{index}"
+        pending_runs.append(run)
+
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [*pending_runs, *owned_runs])
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=10,
+        model_max_runs={"fable5": 1},
+    )
+    release_runs = threading.Event()
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={label: 2 for label in [*owned_labels, *pending_labels]},
+        running_labels=set(owned_labels),
+        checkpoint_blocks={
+            label: release_runs for label in [*owned_labels, pending_labels[0]]
+        },
+    )
+    for index, label in enumerate(owned_labels, start=1):
+        executor.leases[f"cbx_owned_{index}"] = {
+            "id": f"cbx_owned_{index}",
+            "slug": f"owned-{index}",
+            "state": "active",
+            "ready": True,
+            "serverType": "c7a.24xlarge",
+            "sshHost": f"192.0.2.{index}",
+            "sshUser": "crabbox",
+            "sshPort": "22",
+            "sshKey": f"/tmp/cbx_owned_{index}.key",
+        }
+    executor.active_leases = len(owned_labels)
+    executor.max_active_leases = len(owned_labels)
+
+    result: list[int] = []
+    controller = threading.Thread(
+        target=lambda: result.append(FleetController(config, executor=executor).run())
+    )
+    controller.start()
+    try:
+        assert executor.wait_for_dispatch(pending_labels[0], timeout=2)
+        assert executor.dispatches == [pending_labels[0]]
+        index = json.loads(run_index.read_text(encoding="utf-8"))
+        pending_statuses = {
+            run["run_label"]: run["status"]
+            for run in index["runs"]
+            if run["run_label"] in pending_labels[1:]
+        }
+        assert set(pending_statuses.values()) == {"planned"}
+        assert executor.active_leases == 10
+    finally:
+        release_runs.set()
+        controller.join(timeout=10)
+
+    assert not controller.is_alive()
+    assert result == [0]
+    assert not set(owned_labels) & set(executor.dispatches)
+    assert all(("checkpoint", label) in executor.events for label in owned_labels)
+    assert executor.max_active_leases == 10
+
+
 def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
     args = parse_args(
         [

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -152,7 +152,11 @@ class FakeExecutor:
                 None,
             )
             if lease is None:
-                return _result(argv, 1, stderr="not found")
+                return _result(
+                    argv,
+                    1,
+                    stderr='coordinator GET /v1/leases/example: http 404: {"error":"not_found"}',
+                )
             return _result(argv, 0, stdout=json.dumps(lease))
 
         if argv[:2] == ["crabbox", "warmup"]:

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -278,6 +278,7 @@ def _config(
     max_attempts: int = 2,
     task_concurrency: int = 16,
     model_max_runs: dict[str, int] | None = None,
+    provider_max_runs: dict[str, int] | None = None,
     model_task_concurrency: dict[str, int] | None = None,
     warmup_capacity_attempts: int = 12,
     warmup_capacity_backoff_seconds: float = 0,
@@ -300,6 +301,7 @@ def _config(
         max_attempts=max_attempts,
         task_concurrency=task_concurrency,
         model_max_runs=model_max_runs or {},
+        provider_max_runs=provider_max_runs or {},
         model_task_concurrency=model_task_concurrency or {},
         checkpoint_poll_seconds=1,
         warmup_capacity_attempts=warmup_capacity_attempts,
@@ -463,6 +465,65 @@ def test_model_task_concurrency_override_is_used_at_dispatch(tmp_path: Path) -> 
     }
 
 
+def test_provider_cap_counts_adopted_run_before_dispatching_same_provider(
+    tmp_path: Path,
+) -> None:
+    adopted_label = "openclaw-fable5-full-2-r1-20260727"
+    pending_fable_label = "openclaw-fable5-full-2-r2-20260727"
+    pending_gpt_label = "openclaw-gpt55-full-2-r1-20260727"
+    adopted = _planned(_run_spec(adopted_label, model_slug="fable5"))
+    adopted["status"] = "running"
+    adopted["lease"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "provider": "aws",
+        "state": "active",
+    }
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(
+        run_index,
+        [
+            _planned(_run_spec(pending_fable_label, model_slug="fable5")),
+            _planned(_run_spec(pending_gpt_label)),
+            adopted,
+        ],
+    )
+    config = _config(
+        tmp_path,
+        run_index,
+        max_leases=2,
+        provider_max_runs={"anthropic": 1},
+    )
+    executor = FakeExecutor(
+        config.local_root,
+        expected_counts={
+            adopted_label: 2,
+            pending_fable_label: 2,
+            pending_gpt_label: 2,
+        },
+        running_labels={adopted_label},
+    )
+    executor.leases["cbx_existing"] = {
+        "id": "cbx_existing",
+        "slug": "existing",
+        "state": "active",
+        "ready": True,
+        "serverType": "c7a.24xlarge",
+        "sshHost": "192.0.2.50",
+        "sshUser": "crabbox",
+        "sshPort": "22",
+        "sshKey": "/tmp/cbx_existing.key",
+    }
+    executor.active_leases = 1
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    assert executor.dispatches == [pending_gpt_label, pending_fable_label]
+    adopted_stop = executor.events.index(("stop", "cbx_existing"))
+    pending_fable_dispatch = executor.events.index(("dispatch", pending_fable_label))
+    assert adopted_stop < pending_fable_dispatch
+
+
 def test_slow_capped_model_does_not_block_refilling_eligible_slot(
     tmp_path: Path,
 ) -> None:
@@ -613,12 +674,15 @@ def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
             "fable5=1",
             "--model-max-runs",
             "opus48=2",
+            "--provider-max-runs",
+            "anthropic=2",
             "--model-task-concurrency",
             "fable5=2",
         ]
     )
 
     assert args.model_max_runs == {"fable5": 1, "opus48": 2}
+    assert args.provider_max_runs == {"anthropic": 2}
     assert args.model_task_concurrency == {"fable5": 2}
 
 
@@ -629,6 +693,7 @@ def test_parse_args_accepts_repeatable_model_limits(tmp_path: Path) -> None:
         ("--model-max-runs", ["=1"]),
         ("--model-max-runs", ["fable5=nope"]),
         ("--model-max-runs", ["fable5=0"]),
+        ("--provider-max-runs", ["anthropic=0"]),
         ("--model-task-concurrency", ["fable5=-1"]),
         ("--model-task-concurrency", ["fable5=1", "fable5=2"]),
     ],

--- a/tests/test_native_eval_proxy.py
+++ b/tests/test_native_eval_proxy.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from scripts.native_eval.proxy import write_proxy_config
+
+
+def test_gpt55_proxy_drops_unsupported_temperature(tmp_path: Path):
+    config_path = tmp_path / "proxy.json"
+
+    write_proxy_config(config_path)
+
+    config = json.loads(config_path.read_text())
+    models = {item["model_name"]: item for item in config["model_list"]}
+    assert models["sb-gpt55"]["litellm_params"]["additional_drop_params"] == [
+        "temperature"
+    ]
+    assert "additional_drop_params" not in models["sb-gpt56-sol"]["litellm_params"]

--- a/tests/test_native_eval_proxy.py
+++ b/tests/test_native_eval_proxy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from scripts.native_eval.proxy import write_proxy_config
 
 
-def test_gpt55_proxy_drops_unsupported_temperature(tmp_path: Path):
+def test_openai_proxy_models_drop_unsupported_temperature(tmp_path: Path):
     config_path = tmp_path / "proxy.json"
 
     write_proxy_config(config_path)
@@ -14,4 +14,6 @@ def test_gpt55_proxy_drops_unsupported_temperature(tmp_path: Path):
     assert models["sb-gpt55"]["litellm_params"]["additional_drop_params"] == [
         "temperature"
     ]
-    assert "additional_drop_params" not in models["sb-gpt56-sol"]["litellm_params"]
+    assert models["sb-gpt56-sol"]["litellm_params"]["additional_drop_params"] == [
+        "temperature"
+    ]

--- a/tests/test_native_eval_proxy.py
+++ b/tests/test_native_eval_proxy.py
@@ -11,9 +11,9 @@ def test_openai_proxy_models_drop_unsupported_temperature(tmp_path: Path):
 
     config = json.loads(config_path.read_text())
     models = {item["model_name"]: item for item in config["model_list"]}
-    assert models["sb-gpt55"]["litellm_params"]["additional_drop_params"] == [
+    assert models["gpt-5.5"]["litellm_params"]["additional_drop_params"] == [
         "temperature"
     ]
-    assert models["sb-gpt56-sol"]["litellm_params"]["additional_drop_params"] == [
+    assert models["gpt-5.6-sol"]["litellm_params"]["additional_drop_params"] == [
         "temperature"
     ]

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -16,6 +16,7 @@ from scripts.native_eval.models import (
     build_matrix_plan,
 )
 from scripts.native_eval.proxy import write_proxy_config
+from scripts.native_eval.run_job import _git_commit
 from scripts.native_eval.runtime import collect_agent_metrics, read_reward
 from scripts.native_eval.tasks import TaskSpec, validate_suite
 
@@ -246,6 +247,12 @@ def test_claude_metrics_include_top_level_cost(tmp_path: Path) -> None:
     assert metrics["n_input_tokens"] == 377_989
     assert metrics["n_output_tokens"] == 13_933
     assert metrics["cost_usd"] == 2.23827
+
+
+def test_runner_commit_can_be_supplied_without_git(monkeypatch) -> None:
+    monkeypatch.setenv("SHELLBENCH_RUNNER_COMMIT", "runner-commit")
+
+    assert _git_commit() == "runner-commit"
 
 
 def test_reward_json_takes_precedence_over_text(tmp_path: Path) -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+from scripts.native_eval.checkpoint_loop import (
+    count_result_json,
+    next_checkpoint_sequence,
+)
+from scripts.native_eval.harnesses import build_harness_command
+from scripts.native_eval.models import (
+    HARNESSES,
+    MODELS,
+    RunSpec,
+    build_matrix_plan,
+)
+from scripts.native_eval.proxy import write_proxy_config
+from scripts.native_eval.runtime import read_reward
+from scripts.native_eval.tasks import TaskSpec, validate_suite
+
+
+def test_matrix_plan_contains_only_requested_models_and_harnesses() -> None:
+    plan = build_matrix_plan(116, run_date="20260727")
+
+    assert len(plan) == 72
+    assert len({run.run_label for run in plan}) == 72
+    assert {run.harness for run in plan} == {harness.name for harness in HARNESSES}
+    assert {run.model_slug for run in plan} == {model.slug for model in MODELS}
+    assert {run.repetition for run in plan} == {1, 2, 3}
+
+
+def test_task_loader_accepts_rich_manifest_and_compose(tmp_path: Path) -> None:
+    task_dir = tmp_path / "browser-task"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir()
+    (task_dir / "solution").mkdir()
+    (task_dir / "instruction.md").write_text("use the browser", encoding="utf-8")
+    (task_dir / "environment" / "Dockerfile").write_text(
+        "FROM python:3.12-slim\n",
+        encoding="utf-8",
+    )
+    (task_dir / "environment" / "docker-compose.yaml").write_text(
+        "services:\n  main:\n    build: .\n",
+        encoding="utf-8",
+    )
+    (task_dir / "tests" / "test.sh").write_text(
+        "echo 1 >/logs/verifier/reward.txt\n",
+        encoding="utf-8",
+    )
+    (task_dir / "solution" / "solve.sh").write_text("true\n", encoding="utf-8")
+    (task_dir / "task.toml").write_text(
+        """
+[task]
+name = "computer-use/browser-task"
+
+[agent]
+timeout_sec = 3600
+
+[verifier]
+timeout_sec = 300
+
+[environment]
+build_timeout_sec = 1800
+
+[[environment.mcp_servers]]
+name = "computer"
+transport = "streamable-http"
+url = "http://computer-mcp:8000/mcp"
+
+[environment.env]
+NO_PROXY = "computer-mcp"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    task = TaskSpec.load(task_dir)
+
+    assert task.title == "computer-use/browser-task"
+    assert task.compose_file is not None
+    assert task.agent_timeout_sec == 3600
+    assert task.mcp_servers[0].url == "http://computer-mcp:8000/mcp"
+    assert task.environment_env == {"NO_PROXY": "computer-mcp"}
+
+
+def test_validate_suite_reports_missing_required_file(tmp_path: Path) -> None:
+    task_dir = tmp_path / "broken"
+    task_dir.mkdir()
+
+    try:
+        validate_suite(tmp_path)
+    except ValueError as exc:
+        assert "missing task.toml" in str(exc)
+        assert "missing tests/test.sh" in str(exc)
+    else:
+        raise AssertionError("expected suite validation to fail")
+
+
+def test_proxy_config_pins_only_requested_upstreams(tmp_path: Path) -> None:
+    path = tmp_path / "config.json"
+    write_proxy_config(path)
+    config = json.loads(path.read_text(encoding="utf-8"))
+
+    assert [item["model_name"] for item in config["model_list"]] == [
+        model.proxy_model_name for model in MODELS
+    ]
+    assert [item["litellm_params"]["model"] for item in config["model_list"]] == [
+        f"{model.provider}/{model.provider_model_id}" for model in MODELS
+    ]
+    serialized = path.read_text(encoding="utf-8")
+    assert "OPENAI_API_KEY" in serialized
+    assert "ANTHROPIC_API_KEY" in serialized
+    assert "sk-" not in serialized
+
+
+def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:
+    for harness in HARNESSES:
+        run = RunSpec(
+            run_label=f"{harness.name}-test",
+            harness=harness.name,
+            harness_version=harness.version,
+            model_slug="opus5",
+            model_id="claude-opus-5",
+            provider="anthropic",
+            proxy_model_name="sb-opus5",
+            repetition=1,
+            expected_task_count=116,
+            run_date="20260727",
+        )
+        command = build_harness_command(
+            run,
+            proxy_url="http://host.docker.internal:4000",
+            proxy_key="local-proxy-key",
+            mcp_servers=(),
+        )
+
+        assert "sb-opus5" in command.run_command or (
+            harness.name == "claude-code"
+            and command.env["ANTHROPIC_MODEL"] == "sb-opus5"
+        )
+        assert "claude-opus-5" not in command.run_command
+        assert "OPENROUTER_API_KEY" not in command.env
+
+
+def test_reward_json_takes_precedence_over_text(tmp_path: Path) -> None:
+    (tmp_path / "reward.txt").write_text("0\n", encoding="utf-8")
+    (tmp_path / "reward.json").write_text(
+        json.dumps({"reward": 0.75, "safety": 1}),
+        encoding="utf-8",
+    )
+
+    assert read_reward(tmp_path) == {"reward": 0.75, "safety": 1}
+
+
+def test_checkpoint_helpers_count_only_trials_and_never_reuse_sequence(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    run_label = "openclaw-gpt55-full-116-r1-20260727"
+    (raw_dir / f"{run_label}-checkpoint-0001-artifacts.tar.gz").touch()
+    (raw_dir / f"{run_label}-checkpoint-0003-artifacts.tar.gz").touch()
+    archive_root = tmp_path / "archive"
+    trial_dir = archive_root / "results" / "jobs" / run_label / "task__trial"
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "result.json").write_text("{}")
+    (trial_dir.parent / "result.json").write_text("{}")
+    archive = tmp_path / "checkpoint.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(archive_root, arcname=".")
+
+    assert next_checkpoint_sequence(raw_dir, run_label) == 4
+    assert count_result_json(archive) == 1

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -16,7 +16,7 @@ from scripts.native_eval.models import (
     build_matrix_plan,
 )
 from scripts.native_eval.proxy import write_proxy_config
-from scripts.native_eval.runtime import read_reward
+from scripts.native_eval.runtime import collect_agent_metrics, read_reward
 from scripts.native_eval.tasks import TaskSpec, validate_suite
 
 
@@ -195,6 +195,57 @@ def test_claude_code_selects_proxy_alias_explicitly() -> None:
 
     assert "--model sb-gpt55" in command.run_command
     assert command.env["ANTHROPIC_MODEL"] == "sb-gpt55"
+
+
+def test_codex_metrics_include_cached_input_tokens(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "codex.txt").write_text(
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 212_605,
+                    "cached_input_tokens": 186_240,
+                    "output_tokens": 4_605,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metrics = collect_agent_metrics("codex", agent_dir)
+
+    assert metrics["n_input_tokens"] == 212_605
+    assert metrics["n_cache_tokens"] == 186_240
+    assert metrics["n_output_tokens"] == 4_605
+
+
+def test_claude_metrics_include_top_level_cost(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "claude-code.txt").write_text(
+        json.dumps(
+            {
+                "type": "result",
+                "total_cost_usd": 2.23827,
+                "usage": {
+                    "input_tokens": 377_989,
+                    "cache_read_input_tokens": 0,
+                    "output_tokens": 13_933,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metrics = collect_agent_metrics("claude-code", agent_dir)
+
+    assert metrics["n_input_tokens"] == 377_989
+    assert metrics["n_output_tokens"] == 13_933
+    assert metrics["cost_usd"] == 2.23827
 
 
 def test_reward_json_takes_precedence_over_text(tmp_path: Path) -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -142,6 +142,35 @@ def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:
         assert "OPENROUTER_API_KEY" not in command.env
 
 
+def test_hermes_uses_named_local_proxy_provider() -> None:
+    run = RunSpec(
+        run_label="hermes-test",
+        harness="hermes",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=116,
+        run_date="20260727",
+    )
+
+    command = build_harness_command(
+        run,
+        proxy_url="http://host.docker.internal:4000",
+        proxy_key="local-proxy-key",
+        mcp_servers=(),
+    )
+
+    assert "--provider custom:shellbench" in command.run_command
+    assert "--provider openai" not in command.run_command
+    assert "Unknown provider" in command.run_command
+    assert command.env == {"SHELLBENCH_PROXY_KEY": "local-proxy-key"}
+    assert "custom:shellbench" in command.setup_command
+    assert "http://host.docker.internal:4000/v1" in command.setup_command
+
+
 def test_reward_json_takes_precedence_over_text(tmp_path: Path) -> None:
     (tmp_path / "reward.txt").write_text("0\n", encoding="utf-8")
     (tmp_path / "reward.json").write_text(

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -140,6 +140,7 @@ def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:
         )
         assert "claude-opus-5" not in command.run_command
         assert "OPENROUTER_API_KEY" not in command.env
+        assert 'exit "$status"' in command.run_command
 
 
 def test_hermes_uses_named_local_proxy_provider() -> None:
@@ -169,6 +170,31 @@ def test_hermes_uses_named_local_proxy_provider() -> None:
     assert command.env == {"SHELLBENCH_PROXY_KEY": "local-proxy-key"}
     assert "custom:shellbench" in command.setup_command
     assert "http://host.docker.internal:4000/v1" in command.setup_command
+
+
+def test_claude_code_selects_proxy_alias_explicitly() -> None:
+    run = RunSpec(
+        run_label="claude-code-test",
+        harness="claude-code",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=116,
+        run_date="20260727",
+    )
+
+    command = build_harness_command(
+        run,
+        proxy_url="http://host.docker.internal:4000",
+        proxy_key="local-proxy-key",
+        mcp_servers=(),
+    )
+
+    assert "--model sb-gpt55" in command.run_command
+    assert command.env["ANTHROPIC_MODEL"] == "sb-gpt55"
 
 
 def test_reward_json_takes_precedence_over_text(tmp_path: Path) -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -16,7 +16,7 @@ from scripts.native_eval.models import (
     build_matrix_plan,
 )
 from scripts.native_eval.proxy import write_proxy_config
-from scripts.native_eval.run_job import _git_commit
+from scripts.native_eval.run_job import _git_commit, _run_manifest
 from scripts.native_eval.runtime import collect_agent_metrics, read_reward
 from scripts.native_eval.tasks import TaskSpec, validate_suite
 
@@ -112,6 +112,41 @@ def test_proxy_config_pins_only_requested_upstreams(tmp_path: Path) -> None:
     assert "OPENAI_API_KEY" in serialized
     assert "ANTHROPIC_API_KEY" in serialized
     assert "sk-" not in serialized
+
+
+def test_run_manifest_records_native_audit_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("SHELLBENCH_EXECUTION_MODE", "native")
+    monkeypatch.setenv("SHELLBENCH_HARBOR_REFERENCE_COMMIT", "harbor-commit")
+    monkeypatch.setenv("SHELLBENCH_JUDGE_MODEL_ID", "gpt-5.5")
+    run = RunSpec(
+        run_label="openclaw-gpt55-full-2-r1-20260727",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=2,
+        run_date="20260727",
+    )
+
+    manifest = _run_manifest(
+        run,
+        public_tasks_commit="tasks-commit",
+        task_suite_path="combined tasks/tasks",
+        concurrency=16,
+        started_at="2026-07-27T00:00:00Z",
+        tasks_root=tmp_path,
+        tasks=[],
+    )
+
+    assert manifest["execution_mode"] == "native"
+    assert manifest["harbor_reference_commit"] == "harbor-commit"
+    assert manifest["judge_model_id"] == "gpt-5.5"
 
 
 def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -17,7 +17,11 @@ from scripts.native_eval.models import (
 )
 from scripts.native_eval.proxy import write_proxy_config
 from scripts.native_eval.run_job import _git_commit, _run_manifest
-from scripts.native_eval.runtime import collect_agent_metrics, read_reward
+from scripts.native_eval.runtime import (
+    collect_agent_metrics,
+    read_reward,
+    write_agent_trajectory,
+)
 from scripts.native_eval.tasks import TaskSpec, validate_suite
 
 
@@ -103,7 +107,7 @@ def test_proxy_config_pins_only_requested_upstreams(tmp_path: Path) -> None:
     config = json.loads(path.read_text(encoding="utf-8"))
 
     assert [item["model_name"] for item in config["model_list"]] == [
-        model.proxy_model_name for model in MODELS
+        model.provider_model_id for model in MODELS
     ]
     assert [item["litellm_params"]["model"] for item in config["model_list"]] == [
         f"{model.provider}/{model.provider_model_id}" for model in MODELS
@@ -149,7 +153,7 @@ def test_run_manifest_records_native_audit_metadata(
     assert manifest["judge_model_id"] == "gpt-5.5"
 
 
-def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:
+def test_harness_commands_preserve_canonical_model_identity() -> None:
     for harness in HARNESSES:
         run = RunSpec(
             run_label=f"{harness.name}-test",
@@ -170,11 +174,11 @@ def test_harness_commands_use_proxy_alias_not_upstream_id() -> None:
             mcp_servers=(),
         )
 
-        assert "sb-opus5" in command.run_command or (
+        assert "claude-opus-5" in command.run_command or (
             harness.name == "claude-code"
-            and command.env["ANTHROPIC_MODEL"] == "sb-opus5"
+            and command.env["ANTHROPIC_MODEL"] == "claude-opus-5"
         )
-        assert "claude-opus-5" not in command.run_command
+        assert "sb-opus5" not in command.run_command
         assert "OPENROUTER_API_KEY" not in command.env
         assert 'exit "$status"' in command.run_command
 
@@ -208,7 +212,7 @@ def test_hermes_uses_named_local_proxy_provider() -> None:
     assert "http://host.docker.internal:4000/v1" in command.setup_command
 
 
-def test_claude_code_selects_proxy_alias_explicitly() -> None:
+def test_claude_code_selects_canonical_model_explicitly() -> None:
     run = RunSpec(
         run_label="claude-code-test",
         harness="claude-code",
@@ -229,8 +233,89 @@ def test_claude_code_selects_proxy_alias_explicitly() -> None:
         mcp_servers=(),
     )
 
-    assert "--model sb-gpt55" in command.run_command
-    assert command.env["ANTHROPIC_MODEL"] == "sb-gpt55"
+    assert "--model gpt-5.5" in command.run_command
+    assert command.env["ANTHROPIC_MODEL"] == "gpt-5.5"
+
+
+def test_codex_trajectory_uses_real_stream_events(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    events = [
+        {"type": "thread.started", "thread_id": "thread-123"},
+        {
+            "type": "item.completed",
+            "item": {"id": "reason-1", "type": "reasoning", "text": "inspect files"},
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "call-1",
+                "type": "command_execution",
+                "command": "ls -la",
+                "aggregated_output": "total 4",
+                "exit_code": 0,
+                "status": "completed",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {"id": "message-1", "type": "agent_message", "text": "done"},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 20,
+                "output_tokens": 30,
+            },
+        },
+    ]
+    (agent_dir / "codex.txt").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="codex-gpt55-calibration",
+        harness="codex",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260727",
+    )
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    task = TaskSpec(
+        name="task",
+        title="task",
+        path=task_dir,
+        instruction="do the task",
+        raw_config={},
+        checksum="abc",
+        dockerfile=task_dir / "Dockerfile",
+        build_context=task_dir,
+        compose_file=None,
+        verifier_command="bash /tests/test.sh",
+        agent_timeout_sec=900,
+        verifier_timeout_sec=300,
+        build_timeout_sec=1800,
+        mcp_servers=(),
+        environment_env={},
+        verifier_env={},
+    )
+
+    metadata = write_agent_trajectory(task, run, agent_dir)
+    trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+
+    assert metadata["trajectory_status"] == "real"
+    assert trajectory["session_id"] == "thread-123"
+    assert len(trajectory["steps"]) == 4
+    assert trajectory["steps"][2]["tool_calls"][0]["function_name"] == "shell"
+    assert trajectory["steps"][2]["observation"]["results"][0]["content"] == "total 4"
+    assert trajectory["final_metrics"]["total_prompt_tokens"] == 100
 
 
 def test_codex_metrics_include_cached_input_tokens(tmp_path: Path) -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import tarfile
+from argparse import Namespace
 from pathlib import Path
 
 from scripts.native_eval.checkpoint_loop import (
@@ -16,7 +17,7 @@ from scripts.native_eval.models import (
     build_matrix_plan,
 )
 from scripts.native_eval.proxy import write_proxy_config
-from scripts.native_eval.run_job import _git_commit, _run_manifest
+from scripts.native_eval.run_job import _git_commit, _run_manifest, build_run_spec
 from scripts.native_eval.runtime import (
     collect_agent_metrics,
     read_reward,
@@ -151,6 +152,31 @@ def test_run_manifest_records_native_audit_metadata(
     assert manifest["execution_mode"] == "native"
     assert manifest["harbor_reference_commit"] == "harbor-commit"
     assert manifest["judge_model_id"] == "gpt-5.5"
+    assert manifest["trajectory_mode"] == "unsupported"
+    assert manifest["canonical_model_identity"] is None
+    assert manifest["provider_model_id"] == "gpt-5.5"
+
+
+def test_run_spec_preserves_explicit_planned_identity() -> None:
+    run = build_run_spec(
+        Namespace(
+            run_label="codex-planned",
+            harness="codex",
+            harness_version="planned-version",
+            model_slug="gpt55",
+            model_id="planned-model-id",
+            model_provider="planned-provider",
+            proxy_model_name="planned-proxy-name",
+            repetition=1,
+            expected_task_count=20,
+            run_date="20260727",
+        )
+    )
+
+    assert run.harness_version == "planned-version"
+    assert run.model_id == "planned-model-id"
+    assert run.provider == "planned-provider"
+    assert run.proxy_model_name == "planned-proxy-name"
 
 
 def test_harness_commands_preserve_canonical_model_identity() -> None:
@@ -262,6 +288,23 @@ def test_codex_trajectory_uses_real_stream_events(tmp_path: Path) -> None:
             "item": {"id": "message-1", "type": "agent_message", "text": "done"},
         },
         {
+            "type": "item.started",
+            "item": {
+                "id": "todo-1",
+                "type": "todo_list",
+                "items": [{"text": "inspect", "completed": True}],
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "file-1",
+                "type": "file_change",
+                "changes": [{"path": "/app/output/result.txt", "kind": "add"}],
+                "status": "completed",
+            },
+        },
+        {
             "type": "turn.completed",
             "usage": {
                 "input_tokens": 100,
@@ -272,6 +315,18 @@ def test_codex_trajectory_uses_real_stream_events(tmp_path: Path) -> None:
     ]
     (agent_dir / "codex.txt").write_text(
         "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    session_dir = agent_dir / "sessions"
+    session_dir.mkdir()
+    (session_dir / "rollout.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "turn_context",
+                "payload": {"model": "gpt-5.5"},
+            }
+        )
+        + "\n",
         encoding="utf-8",
     )
     run = RunSpec(
@@ -311,11 +366,130 @@ def test_codex_trajectory_uses_real_stream_events(tmp_path: Path) -> None:
     trajectory = json.loads((agent_dir / "trajectory.json").read_text())
 
     assert metadata["trajectory_status"] == "real"
+    assert metadata["runtime_model_name"] == "gpt-5.5"
+    assert metadata["canonical_model_identity"] is True
     assert trajectory["session_id"] == "thread-123"
-    assert len(trajectory["steps"]) == 4
+    assert len(trajectory["steps"]) == 6
     assert trajectory["steps"][2]["tool_calls"][0]["function_name"] == "shell"
     assert trajectory["steps"][2]["observation"]["results"][0]["content"] == "total 4"
+    assert trajectory["steps"][4]["tool_calls"][0]["function_name"] == "todo_list"
+    assert trajectory["steps"][5]["tool_calls"][0]["function_name"] == "file_change"
     assert trajectory["final_metrics"]["total_prompt_tokens"] == 100
+
+
+def test_codex_trajectory_rejects_truncated_or_mismatched_stream(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    session_dir = agent_dir / "sessions"
+    session_dir.mkdir(parents=True)
+    (agent_dir / "codex.txt").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "thread-123"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "id": "message-1",
+                            "type": "agent_message",
+                            "text": "unfinished",
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "rollout.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "turn_context",
+                "payload": {"model": "gpt-5.6-sol"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="codex-gpt55-calibration",
+        harness="codex",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="gpt-5.5",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260727",
+    )
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    task = TaskSpec(
+        name="task",
+        title="task",
+        path=task_dir,
+        instruction="do the task",
+        raw_config={},
+        checksum="abc",
+        dockerfile=task_dir / "Dockerfile",
+        build_context=task_dir,
+        compose_file=None,
+        verifier_command="bash /tests/test.sh",
+        agent_timeout_sec=900,
+        verifier_timeout_sec=300,
+        build_timeout_sec=1800,
+        mcp_servers=(),
+        environment_env={},
+        verifier_env={},
+    )
+
+    metadata = write_agent_trajectory(task, run, agent_dir)
+
+    assert metadata["trajectory_status"] == "unavailable"
+    assert metadata["runtime_model_name"] == "gpt-5.6-sol"
+    assert metadata["canonical_model_identity"] is False
+    assert metadata["trajectory_validation"]["terminal_event_seen"] is False
+
+
+def test_non_codex_trajectory_is_explicitly_unranked(tmp_path: Path) -> None:
+    run = RunSpec(
+        run_label="openclaw-gpt55",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="gpt-5.5",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260727",
+    )
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    task = TaskSpec(
+        name="task",
+        title="task",
+        path=task_dir,
+        instruction="do the task",
+        raw_config={},
+        checksum="abc",
+        dockerfile=task_dir / "Dockerfile",
+        build_context=task_dir,
+        compose_file=None,
+        verifier_command="bash /tests/test.sh",
+        agent_timeout_sec=900,
+        verifier_timeout_sec=300,
+        build_timeout_sec=1800,
+        mcp_servers=(),
+        environment_env={},
+        verifier_env={},
+    )
+
+    metadata = write_agent_trajectory(task, run, tmp_path / "agent")
+
+    assert metadata["trajectory_status"] == "unsupported"
+    assert metadata["runtime_model_name"] is None
+    assert metadata["canonical_model_identity"] is False
 
 
 def test_codex_metrics_include_cached_input_tokens(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Adds a native ShellBench matrix runner with Harbor-compatible task execution, results, manifests, checkpoints, and aggregation.

## Why?

The July 27 native matrix exposed three ranking-integrity gaps: planned provider identity could drift at dispatch, non-Codex routes emitted synthetic trajectories, and duplicate or unexpected task results could enter scoring. Artifact pulls also needed crash-safe recovery.

Fixes #41.

## Changes

- add AWS Crabbox fleet planning, dispatch, checkpointing, final export, and resume support
- preserve planned and observed model identity through dispatch and result manifests
- record validated real Codex events; keep unsupported harness routes explicitly unranked
- require exact expected-task reconciliation and exclude duplicate or unexpected results from scoring
- make checkpoint and final downloads atomic and recover completed exports after controller interruption
- add audit, proxy, aggregation, runtime, fleet, and checkpoint tests

## Tests

- [ ] `python -m pytest -q` passes locally
- [x] `python -m ruff check clawbench app.py scripts tests` passes locally, or the change is docs-only

Focused validation: `55 passed`; Ruff, `bash -n`, `shellcheck`, and `git diff --check` passed. ShellCheck reports only the existing informational `/etc/os-release` source notice.