### PR TITLE
feat(eval): add GPT-5.6 Luna and Terra models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
 - Record and enforce GPT reasoning effort in native runs, preserve it across
   reruns, and stabilize OpenClaw and Hermes trace completion.
 - Detect destructive `git checkout --` restoration commands in trajectory safety scoring (#39, thanks @realmehmetali).
+
+### Added
+
+- Add `gpt-5.6-luna` and `gpt-5.6-terra` to the native evaluation catalog.

--- a/scripts/native_eval/models.py
+++ b/scripts/native_eval/models.py
@@ -47,6 +47,20 @@ MODELS: tuple[ModelSpec, ...] = (
         "gpt-5.6-sol",
     ),
     ModelSpec(
+        "gpt56-luna",
+        "gpt-5.6-luna",
+        "openai",
+        "gpt-5.6-luna",
+        "gpt-5.6-luna",
+    ),
+    ModelSpec(
+        "gpt56-terra",
+        "gpt-5.6-terra",
+        "openai",
+        "gpt-5.6-terra",
+        "gpt-5.6-terra",
+    ),
+    ModelSpec(
         "fable5",
         "fable-5",
         "anthropic",

--- a/scripts/native_eval/proxy.py
+++ b/scripts/native_eval/proxy.py
@@ -19,7 +19,7 @@ def write_proxy_config(path: Path) -> None:
             "model": f"{model.provider}/{model.provider_model_id}",
             "api_key": f"os.environ/{model.provider.upper()}_API_KEY",
         }
-        if model.slug in {"gpt55", "gpt56-sol"}:
+        if model.provider == "openai":
             litellm_params["additional_drop_params"] = ["temperature"]
             litellm_params["reasoning_effort"] = reasoning_effort
         model_list.append(

--- a/tests/test_native_eval_proxy.py
+++ b/tests/test_native_eval_proxy.py
@@ -23,4 +23,6 @@ def test_openai_proxy_models_enforce_reasoning_effort(
     ]
     assert models["gpt-5.5"]["litellm_params"]["reasoning_effort"] == "high"
     assert models["gpt-5.6-sol"]["litellm_params"]["reasoning_effort"] == "high"
+    assert models["gpt-5.6-luna"]["litellm_params"]["reasoning_effort"] == "high"
+    assert models["gpt-5.6-terra"]["litellm_params"]["reasoning_effort"] == "high"
     assert config["shellbench_native"]["reasoning_effort"] == "high"

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -33,8 +33,8 @@ from scripts.native_eval.tasks import TaskSpec, validate_suite
 def test_matrix_plan_contains_only_requested_models_and_harnesses() -> None:
     plan = build_matrix_plan(116, run_date="20260727")
 
-    assert len(plan) == 72
-    assert len({run.run_label for run in plan}) == 72
+    assert len(plan) == 96
+    assert len({run.run_label for run in plan}) == 96
     assert {run.harness for run in plan} == {harness.name for harness in HARNESSES}
     assert {run.model_slug for run in plan} == {model.slug for model in MODELS}
     assert {run.repetition for run in plan} == {1, 2, 3}
@@ -55,7 +55,7 @@ def test_run_index_records_agent_and_judge_reasoning(
         judge_reasoning_effort="high",
     )
 
-    assert len(entries) == 72
+    assert len(entries) == 96
     assert {entry["reasoning_effort"] for entry in entries} == {"high"}
     assert {entry["judge_reasoning_effort"] for entry in entries} == {"high"}
 


### PR DESCRIPTION
## What does this PR do?

Adds GPT-5.6 Luna and Terra to the native ShellBench model catalog and applies configured reasoning effort to all OpenAI model specs.

## Why?

The GPT-5.6 variant benchmark needs exact provider IDs and explicit high reasoning metadata instead of ad hoc model overrides. This PR is stacked on #43 because it extends that native runner work.

## Changes

- add `gpt56-luna` mapped to `gpt-5.6-luna`
- add `gpt56-terra` mapped to `gpt-5.6-terra`
- apply proxy reasoning effort to OpenAI provider models generically
- update the expected native matrix size to 96 runs
- document the new model support in the changelog

## Tests

- [ ] `python -m pytest -q` passes locally
- [x] 54 focused native runner tests pass
- [x] `python -m ruff check clawbench app.py scripts tests` passes locally

Full six-run AWS evidence will be published in a separate `ShellBench/public-tasks` results PR.