### PR TITLE
fix(native-eval): reconstruct OpenClaw delegated traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   of applying one fleet-wide boolean.
 - Report scoped Harbor parity independently from native leaderboard eligibility,
   so complete runs remain scoreable without an unsupported parity claim.
+- Keep yielded OpenClaw runs alive, pin delegated models, and audit whole-agent
+  model identity and terminal trajectories across every native harness.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   so complete runs remain scoreable without an unsupported parity claim.
 - Keep yielded OpenClaw runs alive, pin delegated models, and audit whole-agent
   model identity and terminal trajectories across every native harness.
+- Pin native OpenClaw runs to the embedded runtime, preserve deleted delegated
+  transcripts, and merge accepted terminal subagent trees into one trajectory.
 
 ### Added
 

--- a/scripts/native_eval/harness_trajectories.py
+++ b/scripts/native_eval/harness_trajectories.py
@@ -57,13 +57,31 @@ def write_openclaw_trajectory(
     }
     session_models = _openclaw_session_models(session_path)
     log_models = _openclaw_log_models(log_path)
-    observed_models = session_models or envelope_models
-    if not observed_models and run.model_id in log_models:
-        observed_models = {run.model_id}
+    child_models = _openclaw_spawn_models(session_path)
+    parent_models = {
+        _normalize_observed_model(value, run)
+        for value in session_models | envelope_models
+    }
+    normalized_log_models = {
+        _normalize_observed_model(value, run) for value in log_models
+    }
+    normalized_child_models = {
+        _normalize_observed_model(value, run) for value in child_models
+    }
+    observed_models = parent_models | normalized_log_models | normalized_child_models
     runtime_model_name = (
-        next(iter(observed_models)) if len(observed_models) == 1 else None
+        next(iter(parent_models))
+        if len(parent_models) == 1
+        else run.model_id
+        if run.model_id in parent_models
+        else None
     )
-    canonical_model_identity = observed_models == {run.model_id}
+    canonical_model_identity = bool(observed_models) and observed_models == {
+        run.model_id
+    }
+    terminal_event_seen = _openclaw_session_terminal(session_path)
+    if not terminal_event_seen and envelope is not None:
+        terminal_event_seen = _openclaw_envelope_terminal(envelope)
 
     steps = _openclaw_session_steps(
         session_path,
@@ -87,12 +105,18 @@ def write_openclaw_trajectory(
         )
         trace_fidelity = "envelope"
         source_path = log_path
-    if len(steps) < 2:
+    if len(steps) < 2 or not terminal_event_seen:
         return _unavailable(
             source_path,
             runtime_model_name=runtime_model_name,
             canonical_model_identity=canonical_model_identity,
             observed_models=observed_models,
+            extra_validation={
+                "terminal_event_seen": terminal_event_seen,
+                "parent_models": sorted(parent_models),
+                "child_models": sorted(normalized_child_models),
+                "log_models": sorted(normalized_log_models),
+            },
         )
 
     usage = agent_meta.get("usage")
@@ -128,9 +152,12 @@ def write_openclaw_trajectory(
             "native_raw_trace_file": source_path.name,
             "trace_fidelity": trace_fidelity,
             "observed_models": sorted(observed_models),
-            "log_models": sorted(log_models),
+            "parent_models": sorted(parent_models),
+            "child_models": sorted(normalized_child_models),
+            "log_models": sorted(normalized_log_models),
             "stop_reason": _nested_string(meta, "completion", "stopReason"),
             "aborted": meta.get("aborted"),
+            "terminal_event_seen": terminal_event_seen,
         },
     }
     _atomic_write_json(agent_dir / "trajectory.json", trajectory)
@@ -143,8 +170,11 @@ def write_openclaw_trajectory(
         "trajectory_validation": {
             "trace_fidelity": trace_fidelity,
             "observed_models": sorted(observed_models),
-            "log_models": sorted(log_models),
+            "parent_models": sorted(parent_models),
+            "child_models": sorted(normalized_child_models),
+            "log_models": sorted(normalized_log_models),
             "session_id": session_id,
+            "terminal_event_seen": terminal_event_seen,
         },
     }
 
@@ -166,27 +196,36 @@ def write_hermes_trajectory(
         ),
         sessions[-1],
     )
-    observed_models = {
-        value
+    parent_models = {
+        _normalize_observed_model(value, run)
         for value in [session.get("model"), *_hermes_message_models(session)]
         if isinstance(value, str) and value
     }
+    observed_models = {
+        _normalize_observed_model(value, run)
+        for item in sessions
+        for value in [item.get("model"), *_hermes_message_models(item)]
+        if isinstance(value, str) and value
+    }
     runtime_model_name = (
-        next(iter(observed_models)) if len(observed_models) == 1 else None
+        next(iter(parent_models)) if len(parent_models) == 1 else None
     )
-    canonical_model_identity = observed_models == {run.model_id}
+    canonical_model_identity = bool(observed_models) and observed_models == {
+        run.model_id
+    }
     validation = _validate_hermes_session(session, instruction)
     steps = _hermes_steps(
         session,
         instruction,
         model_name=f"{run.provider}/{run.model_id}",
     )
-    if len(steps) < 2:
+    if len(steps) < 2 or validation["terminal_event_seen"] is not True:
         return _unavailable(
             source_path,
             runtime_model_name=runtime_model_name,
             canonical_model_identity=canonical_model_identity,
             observed_models=observed_models,
+            extra_validation=validation,
         )
 
     session_id = str(session.get("id") or session.get("session_id") or uuid.uuid4())
@@ -233,6 +272,174 @@ def write_hermes_trajectory(
             "session_id": session_id,
             **validation,
         },
+    }
+
+
+def write_claude_code_trajectory(
+    instruction: str,
+    run: RunSpec,
+    agent_dir: Path,
+) -> dict[str, Any]:
+    source_path = agent_dir / "claude-code.txt"
+    events = _load_json_lines(source_path)
+    observed_models: set[str] = set()
+    assistant_models: set[str] = set()
+    terminal_event_seen = False
+    session_id = str(uuid.uuid4())
+    steps: list[dict[str, Any]] = [
+        {"step_id": 1, "source": "user", "message": instruction}
+    ]
+    pending_calls: dict[str, dict[str, Any]] = {}
+    result_event: dict[str, Any] | None = None
+
+    for event in events:
+        event_type = str(event.get("type") or "")
+        if event_type == "system":
+            if event.get("session_id"):
+                session_id = str(event["session_id"])
+            _add_model(observed_models, event.get("model"), run)
+            continue
+        if event_type == "assistant":
+            message = event.get("message")
+            if not isinstance(message, dict):
+                continue
+            _add_model(observed_models, message.get("model"), run)
+            _add_model(assistant_models, message.get("model"), run)
+            text, reasoning, calls = _claude_content(message.get("content"))
+            if not (text or reasoning or calls):
+                continue
+            step = _without_none(
+                {
+                    "step_id": len(steps) + 1,
+                    "source": "agent",
+                    "message": text or "[tool call]",
+                    "model_name": f"{run.provider}/{run.model_id}",
+                    "reasoning_content": reasoning or None,
+                    "tool_calls": calls or None,
+                    "llm_call_count": 1,
+                }
+            )
+            steps.append(step)
+            for call in calls:
+                pending_calls[call["tool_call_id"]] = step
+            continue
+        if event_type == "user":
+            message = event.get("message")
+            if not isinstance(message, dict):
+                continue
+            for result in _claude_tool_results(message.get("content")):
+                step = pending_calls.get(str(result.get("source_call_id") or ""))
+                if step is None:
+                    continue
+                observation = step.setdefault("observation", {"results": []})
+                observation["results"].append(result)
+            continue
+        if event_type == "result":
+            result_event = event
+            if event.get("session_id"):
+                session_id = str(event["session_id"])
+            model_usage = event.get("modelUsage")
+            if isinstance(model_usage, dict):
+                for model_name, details in model_usage.items():
+                    _add_model(observed_models, model_name, run)
+                    if isinstance(details, dict):
+                        _add_model(
+                            observed_models,
+                            details.get("canonicalModel"),
+                            run,
+                        )
+            terminal_event_seen = (
+                event.get("is_error") is not True
+                and str(event.get("subtype") or "").lower() == "success"
+                and str(event.get("terminal_reason") or "completed").lower()
+                == "completed"
+            )
+            result_text = event.get("result")
+            if (
+                isinstance(result_text, str)
+                and result_text.strip()
+                and not any(
+                    step.get("source") == "agent"
+                    and step.get("message") == result_text.strip()
+                    for step in steps
+                )
+            ):
+                steps.append(
+                    {
+                        "step_id": len(steps) + 1,
+                        "source": "agent",
+                        "message": result_text.strip(),
+                        "model_name": f"{run.provider}/{run.model_id}",
+                        "llm_call_count": 1,
+                    }
+                )
+
+    runtime_model_name = (
+        next(iter(assistant_models))
+        if len(assistant_models) == 1
+        else run.model_id
+        if run.model_id in assistant_models
+        else None
+    )
+    canonical_model_identity = bool(observed_models) and observed_models == {
+        run.model_id
+    }
+    validation = {
+        "terminal_event_seen": terminal_event_seen,
+        "observed_models": sorted(observed_models),
+        "assistant_models": sorted(assistant_models),
+    }
+    if len(steps) < 2 or not terminal_event_seen or runtime_model_name is None:
+        return _unavailable(
+            source_path,
+            runtime_model_name=runtime_model_name,
+            canonical_model_identity=canonical_model_identity,
+            observed_models=observed_models,
+            extra_validation=validation,
+        )
+
+    usage = result_event.get("usage") if isinstance(result_event, dict) else {}
+    if not isinstance(usage, dict):
+        usage = {}
+    final_metrics = _without_none(
+        {
+            "total_prompt_tokens": _int(usage.get("input_tokens")) or None,
+            "total_completion_tokens": _int(usage.get("output_tokens")) or None,
+            "total_cached_tokens": _int(usage.get("cache_read_input_tokens"))
+            or None,
+            "total_cost_usd": (
+                result_event.get("total_cost_usd")
+                if isinstance(result_event, dict)
+                and isinstance(result_event.get("total_cost_usd"), (int, float))
+                else None
+            ),
+            "total_steps": len(steps),
+        }
+    )
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "session_id": session_id,
+        "agent": {
+            "name": run.harness,
+            "version": run.harness_version,
+            "model_name": f"{run.provider}/{runtime_model_name}",
+        },
+        "steps": steps,
+        "final_metrics": final_metrics,
+        "extra": {
+            "native_raw_trace_file": source_path.name,
+            "native_raw_event_count": len(events),
+            **validation,
+        },
+    }
+    _atomic_write_json(agent_dir / "trajectory.json", trajectory)
+    return {
+        "trajectory_status": "real",
+        "trajectory_source": str(source_path),
+        "trajectory_event_count": len(events),
+        "runtime_model_name": runtime_model_name,
+        "canonical_model_identity": canonical_model_identity,
+        "trajectory_validation": validation,
     }
 
 
@@ -440,6 +647,15 @@ def _openclaw_session_models(path: Path) -> set[str]:
     return models
 
 
+def _openclaw_spawn_models(path: Path) -> set[str]:
+    models: set[str] = set()
+    for record in _openclaw_session_records(path):
+        for value in _nested_strings(record):
+            for match in re.finditer(r'"resolvedModel"\s*:\s*"([^"]+)"', value):
+                models.add(match.group(1))
+    return models
+
+
 def _openclaw_log_models(path: Path) -> set[str]:
     if not path.is_file():
         return set()
@@ -449,6 +665,47 @@ def _openclaw_log_models(path: Path) -> set[str]:
             path.read_text(encoding="utf-8", errors="replace"),
         )
     )
+
+
+def _openclaw_session_terminal(path: Path) -> bool:
+    for record in reversed(_openclaw_session_records(path)):
+        message = record.get("message")
+        if (
+            record.get("type") != "message"
+            or not isinstance(message, dict)
+            or message.get("role") != "assistant"
+        ):
+            continue
+        text, tools = _openclaw_assistant_content(message.get("content"))
+        stop_reason = str(message.get("stopReason") or "").lower()
+        return bool(text.strip()) and not tools and stop_reason in {
+            "end_turn",
+            "stop",
+        }
+    return False
+
+
+def _openclaw_envelope_terminal(envelope: dict[str, Any]) -> bool:
+    meta = envelope.get("meta")
+    if not isinstance(meta, dict):
+        return False
+    liveness = str(meta.get("livenessState") or "").lower()
+    if meta.get("yielded") is True or liveness in {
+        "active",
+        "paused",
+        "running",
+        "waiting",
+    }:
+        return False
+    payloads = envelope.get("payloads")
+    visible = any(
+        isinstance(item, dict)
+        and isinstance(item.get("text"), str)
+        and item["text"].strip()
+        and item.get("isReasoning") is not True
+        for item in payloads
+    ) if isinstance(payloads, list) else False
+    return visible or meta.get("aborted") is True
 
 
 def _openclaw_session_id(path: Path) -> str | None:
@@ -703,6 +960,98 @@ def _content_text(content: Any) -> str:
     )
 
 
+def _load_json_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            events.append(value)
+    return events
+
+
+def _claude_content(
+    content: Any,
+) -> tuple[str, str, list[dict[str, Any]]]:
+    if not isinstance(content, list):
+        return "", "", []
+    text: list[str] = []
+    reasoning: list[str] = []
+    calls: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        part_type = str(part.get("type") or "")
+        if part_type == "text" and isinstance(part.get("text"), str):
+            text.append(part["text"])
+        elif part_type == "thinking" and isinstance(part.get("thinking"), str):
+            reasoning.append(part["thinking"])
+        elif part_type == "tool_use" and isinstance(part.get("name"), str):
+            calls.append(
+                {
+                    "tool_call_id": str(part.get("id") or uuid.uuid4().hex[:8]),
+                    "function_name": part["name"],
+                    "arguments": _arguments(part.get("input")),
+                }
+            )
+    return "\n".join(text), "\n".join(reasoning), calls
+
+
+def _claude_tool_results(content: Any) -> list[dict[str, Any]]:
+    if not isinstance(content, list):
+        return []
+    results: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict) or part.get("type") != "tool_result":
+            continue
+        results.append(
+            _without_none(
+                {
+                    "source_call_id": str(part.get("tool_use_id") or ""),
+                    "content": _content_text(part.get("content")) or None,
+                    "is_error": part.get("is_error"),
+                }
+            )
+        )
+    return results
+
+
+def _add_model(models: set[str], value: Any, run: RunSpec) -> None:
+    if isinstance(value, str) and value:
+        models.add(_normalize_observed_model(value, run))
+
+
+def _normalize_observed_model(value: str, run: RunSpec) -> str:
+    if value == run.proxy_model_name:
+        return run.model_id
+    for prefix in ("anthropic/", "openai/"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    return value
+
+
+def _nested_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [
+            item
+            for child in value
+            for item in _nested_strings(child)
+        ]
+    if isinstance(value, dict):
+        return [
+            item
+            for child in value.values()
+            for item in _nested_strings(child)
+        ]
+    return []
+
+
 def _arguments(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
@@ -721,16 +1070,20 @@ def _unavailable(
     runtime_model_name: str | None = None,
     canonical_model_identity: bool = False,
     observed_models: set[str] | None = None,
+    extra_validation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    validation = {
+        "observed_models": sorted(observed_models or set()),
+    }
+    if extra_validation:
+        validation.update(extra_validation)
     return {
         "trajectory_status": "unavailable",
         "trajectory_source": str(source_path),
         "trajectory_event_count": 0,
         "runtime_model_name": runtime_model_name,
         "canonical_model_identity": canonical_model_identity,
-        "trajectory_validation": {
-            "observed_models": sorted(observed_models or set()),
-        },
+        "trajectory_validation": validation,
     }
 
 

--- a/scripts/native_eval/harness_trajectories.py
+++ b/scripts/native_eval/harness_trajectories.py
@@ -4,10 +4,14 @@ import json
 import os
 import re
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from scripts.native_eval.models import RunSpec
+
+
+OpenClawSessionTrace = tuple[str, Path, int, list[dict[str, Any]]]
 
 
 def load_openclaw_envelope(path: Path) -> dict[str, Any] | None:
@@ -55,19 +59,28 @@ def write_openclaw_trajectory(
         )
         if isinstance(value, str) and value
     }
-    session_models = _openclaw_session_models(session_path)
+    session_tree, session_tree_validation = _openclaw_session_tree(
+        agent_dir,
+        session_path,
+    )
+    root_records = session_tree[0][3] if session_tree else None
+    session_models = _openclaw_session_models(session_path, records=root_records)
     log_models = _openclaw_log_models(log_path)
-    child_models = _openclaw_spawn_models(session_path)
+    child_models = {
+        result["resolved_model"]
+        for _, path, _, records in session_tree
+        for result in _openclaw_spawn_results(path, records=records)
+        if result.get("resolved_model")
+    } | {
+        model
+        for _, path, _, records in session_tree[1:]
+        for model in _openclaw_session_models(path, records=records)
+    }
     parent_models = {
-        _normalize_observed_model(value, run)
-        for value in session_models | envelope_models
+        _normalize_observed_model(value, run) for value in session_models | envelope_models
     }
-    normalized_log_models = {
-        _normalize_observed_model(value, run) for value in log_models
-    }
-    normalized_child_models = {
-        _normalize_observed_model(value, run) for value in child_models
-    }
+    normalized_log_models = {_normalize_observed_model(value, run) for value in log_models}
+    normalized_child_models = {_normalize_observed_model(value, run) for value in child_models}
     observed_models = parent_models | normalized_log_models | normalized_child_models
     runtime_model_name = (
         next(iter(parent_models))
@@ -76,19 +89,44 @@ def write_openclaw_trajectory(
         if run.model_id in parent_models
         else None
     )
-    canonical_model_identity = bool(observed_models) and observed_models == {
-        run.model_id
-    }
-    terminal_event_seen = _openclaw_session_terminal(session_path)
+    canonical_model_identity = bool(observed_models) and observed_models == {run.model_id}
+    terminal_event_seen = _openclaw_session_terminal(
+        session_path,
+        records=root_records,
+    )
     if not terminal_event_seen and envelope is not None:
         terminal_event_seen = _openclaw_envelope_terminal(envelope)
+    if session_tree_validation["session_tree_complete"] is not True:
+        return _unavailable(
+            session_path,
+            runtime_model_name=runtime_model_name,
+            canonical_model_identity=canonical_model_identity,
+            observed_models=observed_models,
+            extra_validation={
+                "terminal_event_seen": terminal_event_seen,
+                "parent_models": sorted(parent_models),
+                "child_models": sorted(normalized_child_models),
+                "log_models": sorted(normalized_log_models),
+                **session_tree_validation,
+            },
+        )
 
-    steps = _openclaw_session_steps(
-        session_path,
-        instruction=instruction,
-        model_name=f"{run.provider}/{run.model_id}",
+    steps = (
+        _openclaw_session_tree_steps(
+            session_tree,
+            instruction=instruction,
+            run=run,
+            failed_session_keys=set(session_tree_validation["session_tree_failed_session_keys"]),
+        )
+        if len(session_tree) > 1
+        else _openclaw_session_steps(
+            session_path,
+            instruction=instruction,
+            model_name=f"{run.provider}/{run.model_id}",
+            records=root_records,
+        )
     )
-    trace_fidelity = "session"
+    trace_fidelity = "session_tree" if len(session_tree) > 1 else "session"
     source_path = session_path
     if not steps:
         if envelope is None:
@@ -119,16 +157,20 @@ def write_openclaw_trajectory(
             },
         )
 
-    usage = agent_meta.get("usage")
+    usage = (
+        _openclaw_session_tree_usage(session_tree)
+        if len(session_tree) > 1
+        else agent_meta.get("usage")
+    )
+    if not isinstance(usage, dict) and session_tree:
+        usage = _openclaw_session_tree_usage(session_tree)
     if not isinstance(usage, dict):
-        usage = _openclaw_session_usage(session_path)
+        usage = _openclaw_session_usage(session_path, records=root_records)
     input_tokens = _int(usage.get("input"))
     output_tokens = _int(usage.get("output"))
     cache_read = _int(usage.get("cacheRead"))
     session_id = str(
-        agent_meta.get("sessionId")
-        or _openclaw_session_id(session_path)
-        or uuid.uuid4()
+        agent_meta.get("sessionId") or _openclaw_session_id(session_path) or uuid.uuid4()
     )
     model_name = runtime_model_name or run.model_id
     trajectory = {
@@ -158,6 +200,7 @@ def write_openclaw_trajectory(
             "stop_reason": _nested_string(meta, "completion", "stopReason"),
             "aborted": meta.get("aborted"),
             "terminal_event_seen": terminal_event_seen,
+            **session_tree_validation,
         },
     }
     _atomic_write_json(agent_dir / "trajectory.json", trajectory)
@@ -175,6 +218,7 @@ def write_openclaw_trajectory(
             "log_models": sorted(normalized_log_models),
             "session_id": session_id,
             "terminal_event_seen": terminal_event_seen,
+            **session_tree_validation,
         },
     }
 
@@ -207,12 +251,8 @@ def write_hermes_trajectory(
         for value in [item.get("model"), *_hermes_message_models(item)]
         if isinstance(value, str) and value
     }
-    runtime_model_name = (
-        next(iter(parent_models)) if len(parent_models) == 1 else None
-    )
-    canonical_model_identity = bool(observed_models) and observed_models == {
-        run.model_id
-    }
+    runtime_model_name = next(iter(parent_models)) if len(parent_models) == 1 else None
+    canonical_model_identity = bool(observed_models) and observed_models == {run.model_id}
     validation = _validate_hermes_session(session, instruction)
     steps = _hermes_steps(
         session,
@@ -242,9 +282,7 @@ def write_hermes_trajectory(
             {
                 "total_prompt_tokens": _int(session.get("input_tokens")) or None,
                 "total_completion_tokens": _int(session.get("output_tokens")) or None,
-                "total_cached_tokens": (
-                    _int(session.get("cache_read_tokens")) or None
-                ),
+                "total_cached_tokens": (_int(session.get("cache_read_tokens")) or None),
                 "total_steps": len(steps),
             }
         ),
@@ -286,9 +324,7 @@ def write_claude_code_trajectory(
     assistant_models: set[str] = set()
     terminal_event_seen = False
     session_id = str(uuid.uuid4())
-    steps: list[dict[str, Any]] = [
-        {"step_id": 1, "source": "user", "message": instruction}
-    ]
+    steps: list[dict[str, Any]] = [{"step_id": 1, "source": "user", "message": instruction}]
     pending_calls: dict[str, dict[str, Any]] = {}
     result_event: dict[str, Any] | None = None
 
@@ -351,16 +387,14 @@ def write_claude_code_trajectory(
             terminal_event_seen = (
                 event.get("is_error") is not True
                 and str(event.get("subtype") or "").lower() == "success"
-                and str(event.get("terminal_reason") or "completed").lower()
-                == "completed"
+                and str(event.get("terminal_reason") or "completed").lower() == "completed"
             )
             result_text = event.get("result")
             if (
                 isinstance(result_text, str)
                 and result_text.strip()
                 and not any(
-                    step.get("source") == "agent"
-                    and step.get("message") == result_text.strip()
+                    step.get("source") == "agent" and step.get("message") == result_text.strip()
                     for step in steps
                 )
             ):
@@ -381,9 +415,7 @@ def write_claude_code_trajectory(
         if run.model_id in assistant_models
         else None
     )
-    canonical_model_identity = bool(observed_models) and observed_models == {
-        run.model_id
-    }
+    canonical_model_identity = bool(observed_models) and observed_models == {run.model_id}
     validation = {
         "terminal_event_seen": terminal_event_seen,
         "observed_models": sorted(observed_models),
@@ -405,8 +437,7 @@ def write_claude_code_trajectory(
         {
             "total_prompt_tokens": _int(usage.get("input_tokens")) or None,
             "total_completion_tokens": _int(usage.get("output_tokens")) or None,
-            "total_cached_tokens": _int(usage.get("cache_read_input_tokens"))
-            or None,
+            "total_cached_tokens": _int(usage.get("cache_read_input_tokens")) or None,
             "total_cost_usd": (
                 result_event.get("total_cost_usd")
                 if isinstance(result_event, dict)
@@ -506,16 +537,17 @@ def _openclaw_session_steps(
     *,
     instruction: str,
     model_name: str,
+    session_key: str | None = None,
+    session_depth: int = 0,
+    deduplicated_handoff_sources: set[str] | None = None,
+    records: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     if not path.is_file():
         return []
     rows: list[tuple[dict[str, Any], dict[str, Any]]] = []
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(record, dict) or record.get("type") != "message":
+    session_records = records if records is not None else _openclaw_session_records(path)
+    for record in session_records:
+        if record.get("type") != "message":
             continue
         message = record.get("message")
         if isinstance(message, dict) and message.get("role") in {
@@ -536,17 +568,50 @@ def _openclaw_session_steps(
         timestamp = timestamp if isinstance(timestamp, str) else None
         role = message.get("role")
         if role == "user":
+            handoff_source = _openclaw_subagent_announce_source(message)
+            if (
+                handoff_source
+                and deduplicated_handoff_sources
+                and handoff_source in deduplicated_handoff_sources
+            ):
+                index += 1
+                continue
             body = _content_text(message.get("content"))
+            if handoff_source:
+                steps.append(
+                    _with_openclaw_session_provenance(
+                        _without_none(
+                            {
+                                "step_id": len(steps) + 1,
+                                "source": "agent",
+                                "message": body or "(empty subagent handoff)",
+                                "timestamp": timestamp,
+                                "extra": {
+                                    "openclaw_event": "subagent_announce",
+                                    "openclaw_source_session_key": handoff_source,
+                                },
+                            }
+                        ),
+                        session_key=session_key,
+                        session_depth=session_depth,
+                    )
+                )
+                index += 1
+                continue
             text = instruction.strip() if first_user and instruction.strip() else body
             first_user = False
             steps.append(
-                _without_none(
-                    {
-                        "step_id": len(steps) + 1,
-                        "source": "user",
-                        "message": text or "(empty user message)",
-                        "timestamp": timestamp,
-                    }
+                _with_openclaw_session_provenance(
+                    _without_none(
+                        {
+                            "step_id": len(steps) + 1,
+                            "source": "user",
+                            "message": text or "(empty user message)",
+                            "timestamp": timestamp,
+                        }
+                    ),
+                    session_key=session_key,
+                    session_depth=session_depth,
                 )
             )
             index += 1
@@ -564,9 +629,7 @@ def _openclaw_session_steps(
         else:
             agent_text = "(no assistant text)"
 
-        pending = {
-            call["tool_call_id"] for call in tool_calls if call.get("tool_call_id")
-        }
+        pending = {call["tool_call_id"] for call in tool_calls if call.get("tool_call_id")}
         observations: list[dict[str, Any]] = []
         cursor = index + 1
         while cursor < len(rows) and rows[cursor][1].get("role") == "toolResult":
@@ -594,20 +657,22 @@ def _openclaw_session_steps(
         usage = message.get("usage")
         metrics = _openclaw_usage_metrics(usage)
         steps.append(
-            _without_none(
-                {
-                    "step_id": len(steps) + 1,
-                    "source": "agent",
-                    "message": agent_text,
-                    "timestamp": timestamp,
-                    "model_name": model_name,
-                    "tool_calls": tool_calls or None,
-                    "observation": (
-                        {"results": observations} if observations else None
-                    ),
-                    "metrics": metrics,
-                    "llm_call_count": 1,
-                }
+            _with_openclaw_session_provenance(
+                _without_none(
+                    {
+                        "step_id": len(steps) + 1,
+                        "source": "agent",
+                        "message": agent_text,
+                        "timestamp": timestamp,
+                        "model_name": model_name,
+                        "tool_calls": tool_calls or None,
+                        "observation": ({"results": observations} if observations else None),
+                        "metrics": metrics,
+                        "llm_call_count": 1,
+                    }
+                ),
+                session_key=session_key,
+                session_depth=session_depth,
             )
         )
         index = cursor
@@ -628,9 +693,673 @@ def _openclaw_session_records(path: Path) -> list[dict[str, Any]]:
     return records
 
 
-def _openclaw_session_models(path: Path) -> set[str]:
+_OPENCLAW_CANONICAL_SESSION_ENTRY_TYPES = {
+    "message",
+    "thinking_level_change",
+    "model_change",
+    "compaction",
+    "reset",
+    "branch_summary",
+    "custom",
+    "custom_message",
+    "label",
+    "session_info",
+}
+_OPENCLAW_FAILURE_STATUSES = {
+    "cancelled",
+    "deleted",
+    "error",
+    "failed",
+    "killed",
+    "reset",
+    "timeout",
+}
+
+
+def _openclaw_active_session_records(
+    records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Select OpenClaw's active parent-linked transcript branch."""
+
+    def nonempty(value: Any) -> str | None:
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    def canonical(record: dict[str, Any]) -> bool:
+        return record.get("type") in _OPENCLAW_CANONICAL_SESSION_ENTRY_TYPES
+
+    def parse(
+        record: dict[str, Any],
+        *,
+        fallback_parent: str | None,
+    ) -> dict[str, Any] | None:
+        if record.get("type") == "session":
+            return None
+        explicit = "parentId" in record
+        if not explicit and not canonical(record):
+            return None
+        record_id = nonempty(record.get("id"))
+        if not record_id:
+            return None
+        if explicit:
+            raw_parent = record.get("parentId")
+            parent_id = None if raw_parent is None else nonempty(raw_parent)
+            if raw_parent is not None and parent_id is None:
+                return None
+        else:
+            parent_id = fallback_parent
+        if record.get("type") == "leaf":
+            raw_target = record.get("targetId")
+            target_id = None if raw_target is None else nonempty(raw_target)
+            if raw_target is not None and target_id is None:
+                return None
+            raw_append_parent = record.get("appendParentId", raw_target)
+            append_parent_id = None if raw_append_parent is None else nonempty(raw_append_parent)
+            if raw_append_parent is not None and append_parent_id is None:
+                return None
+            append_mode = record.get("appendMode")
+            if append_mode not in {None, "side"}:
+                return None
+            return {
+                "id": record_id,
+                "parent_id": target_id,
+                "leaf_id": target_id,
+                "append_parent_id": append_parent_id,
+                "is_leaf": True,
+                "explicit": True,
+            }
+        append_mode = record.get("appendMode")
+        return {
+            "id": record_id,
+            "parent_id": parent_id,
+            "leaf_id": (record_id if canonical(record) and append_mode != "side" else ...),
+            "append_parent_id": record_id,
+            "is_leaf": False,
+            "explicit": explicit,
+            "append_mode": append_mode,
+        }
+
+    def resolve_parent(
+        parent_id: str | None,
+        by_id: dict[str, dict[str, Any]],
+    ) -> str | None:
+        seen: set[str] = set()
+        current = parent_id
+        while current is not None:
+            if current in seen:
+                return current
+            seen.add(current)
+            parent = by_id.get(current)
+            if parent is None or not parent["is_leaf"]:
+                return current
+            current = parent["parent_id"]
+        return None
+
+    nodes: list[dict[str, Any]] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    leaf_id: str | None = None
+    append_parent_id: str | None = None
+    has_explicit_leaf_update = False
+    invalid_leaf_ids: set[str] = set()
+    for index, record in enumerate(records):
+        node = parse(record, fallback_parent=leaf_id)
+        if node is None:
+            continue
+        if node["is_leaf"]:
+            references = (node["leaf_id"], node["append_parent_id"])
+            invalid = any(
+                reference is not None and (reference not in by_id or reference in invalid_leaf_ids)
+                for reference in references
+            )
+            if invalid:
+                invalid_leaf_ids.add(node["id"])
+                node["leaf_id"] = ...
+                node["append_parent_id"] = append_parent_id
+                node["parent_id"] = (
+                    record.get("parentId") if isinstance(record.get("parentId"), str) else None
+                )
+        elif canonical(record):
+            parent_id = node["parent_id"]
+            if (
+                node["explicit"]
+                and parent_id is not None
+                and parent_id not in by_id
+                and leaf_id is not None
+            ):
+                parent_id = leaf_id
+            elif (
+                node["explicit"]
+                and node.get("append_mode") != "side"
+                and parent_id == append_parent_id
+                and leaf_id != append_parent_id
+            ):
+                parent_id = leaf_id
+            node["parent_id"] = resolve_parent(parent_id, by_id)
+        node["record"] = record
+        node["index"] = index
+        nodes.append(node)
+        by_id[node["id"]] = node
+        append_parent_id = node["append_parent_id"]
+        if node["leaf_id"] is not ...:
+            leaf_id = node["leaf_id"]
+            if node["explicit"]:
+                has_explicit_leaf_update = True
+
+    # Older synthetic/plain transcripts have no parent links and remain linear.
+    if not has_explicit_leaf_update:
+        return records
+    if leaf_id is None:
+        return []
+
+    active: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    current: str | None = leaf_id
+    while current is not None:
+        if current in seen:
+            return []
+        seen.add(current)
+        node = by_id.get(current)
+        if node is None:
+            break
+        if not node["is_leaf"]:
+            active.append(node["record"])
+        current = node["parent_id"]
+    active.reverse()
+    return active
+
+
+def _openclaw_child_session_records(
+    parent_path: Path,
+    child_path: Path,
+    entry: dict[str, Any],
+) -> list[dict[str, Any]]:
+    child_records = _openclaw_session_records(child_path)
+    header = child_records[0] if child_records else None
+    forked = (
+        entry.get("forkedFromParent") is True
+        or bool(entry.get("forkSource"))
+        or (isinstance(header, dict) and bool(header.get("parentSession")))
+    )
+    if not forked or len(child_records) < 2:
+        return child_records
+
+    parent_identities = {
+        _openclaw_record_identity(record) for record in _openclaw_session_records(parent_path)
+    }
+    first_child_record = 1
+    while (
+        first_child_record < len(child_records)
+        and _openclaw_record_identity(child_records[first_child_record]) in parent_identities
+    ):
+        first_child_record += 1
+    return [child_records[0], *child_records[first_child_record:]]
+
+
+def _openclaw_record_identity(record: dict[str, Any]) -> tuple[str, str]:
+    record_id = record.get("id")
+    if isinstance(record_id, (str, int)) and str(record_id):
+        return "id", str(record_id)
+    return (
+        "json",
+        json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+    )
+
+
+def _openclaw_session_tree(
+    agent_dir: Path,
+    root_path: Path,
+) -> tuple[list[OpenClawSessionTrace], dict[str, Any]]:
+    empty_validation = {
+        "session_tree_session_count": 0,
+        "session_tree_descendant_count": 0,
+        "session_tree_accepted_spawn_count": 0,
+        "session_tree_reused_spawn_count": 0,
+        "session_tree_ignored_entry_count": 0,
+        "session_tree_missing_transcript_count": 0,
+        "session_tree_missing_timestamp_count": 0,
+        "session_tree_ambiguous_timestamp_count": 0,
+        "session_tree_session_keys": [],
+        "session_tree_failed_session_keys": [],
+        "session_tree_nonterminal_session_keys": [],
+        "session_tree_errors": [],
+        "session_tree_complete": True,
+    }
+    if not root_path.is_file():
+        return [], empty_validation
+
+    archive = agent_dir / "openclaw.sessions"
+    entries, ambiguous_keys = _load_openclaw_session_index(archive)
+    audit = _load_openclaw_session_audit(archive)
+    root_session_id = _openclaw_session_id(root_path)
+    root_key = next(
+        (
+            key
+            for key, (entry, _) in entries.items()
+            if root_session_id
+            and isinstance(entry.get("sessionId"), str)
+            and entry["sessionId"] == root_session_id
+        ),
+        None,
+    )
+    if root_key is None and "agent:main:main" in entries:
+        root_key = "agent:main:main"
+    if root_key is None:
+        root_key = "agent:main:main"
+
+    root_records = _openclaw_active_session_records(_openclaw_session_records(root_path))
+    traces: list[OpenClawSessionTrace] = [(root_key, root_path, 0, root_records)]
+    depth_by_key = {root_key: 0}
+    parent_by_key: dict[str, str | None] = {root_key: None}
+    entry_by_key: dict[str, dict[str, Any]] = {}
+    pending = [(root_key, root_path, root_records)]
+    errors: list[str] = []
+    missing_transcripts = 0
+    accepted_spawn_count = 0
+    reused_spawn_count = 0
+    seen_paths = {root_path.resolve()}
+    while pending:
+        parent_key, parent_path, parent_records = pending.pop(0)
+        for spawn in _openclaw_spawn_results(
+            parent_path,
+            records=parent_records,
+        ):
+            child_key = spawn.get("child_session_key")
+            if not child_key:
+                continue
+            accepted_spawn_count += 1
+            ancestor: str | None = parent_key
+            while ancestor is not None and ancestor != child_key:
+                ancestor = parent_by_key.get(ancestor)
+            if ancestor == child_key:
+                errors.append(f"cycle:{parent_key}->{child_key}")
+                continue
+            if child_key in depth_by_key:
+                if parent_by_key.get(child_key) != parent_key:
+                    errors.append(f"duplicate-session-reference:{child_key}")
+                else:
+                    reused_spawn_count += 1
+                continue
+            indexed = entries.get(child_key)
+            if indexed is None:
+                deleted, deleted_error = _resolve_deleted_openclaw_session(
+                    audit=audit,
+                    audit_root=archive / "audit",
+                    child_key=child_key,
+                    parent_key=parent_key,
+                    seen_paths=seen_paths,
+                )
+                if deleted_error:
+                    errors.append(deleted_error)
+                    missing_transcripts += 1
+                    continue
+                if deleted is None:
+                    errors.append(f"missing-session-entry:{child_key}")
+                    missing_transcripts += 1
+                    continue
+                entry, path = deleted
+            else:
+                entry, store_dir = indexed
+                path = _resolve_archived_openclaw_session_path(store_dir, entry)
+                if path is None:
+                    deleted, deleted_error = _resolve_deleted_openclaw_session(
+                        audit=audit,
+                        audit_root=archive / "audit",
+                        child_key=child_key,
+                        parent_key=parent_key,
+                        seen_paths=seen_paths,
+                    )
+                    if deleted_error:
+                        errors.append(deleted_error)
+                        missing_transcripts += 1
+                        continue
+                    if deleted is not None:
+                        entry, path = deleted
+            if child_key in ambiguous_keys:
+                errors.append(f"ambiguous-session-entry:{child_key}")
+                continue
+            spawned_by = entry.get("spawnedBy")
+            if isinstance(spawned_by, str) and spawned_by.strip() and spawned_by != parent_key:
+                errors.append(f"spawn-lineage-mismatch:{child_key}:{spawned_by}!={parent_key}")
+                continue
+            if path is None:
+                errors.append(f"missing-session-transcript:{child_key}")
+                missing_transcripts += 1
+                continue
+            resolved = path.resolve()
+            if resolved in seen_paths:
+                errors.append(f"duplicate-session-transcript:{child_key}")
+                continue
+            seen_paths.add(resolved)
+            depth_by_key[child_key] = depth_by_key[parent_key] + 1
+            parent_by_key[child_key] = parent_key
+            entry_by_key[child_key] = entry
+            child_records = _openclaw_active_session_records(
+                _openclaw_child_session_records(
+                    parent_path,
+                    path,
+                    entry,
+                )
+            )
+            traces.append((child_key, path, depth_by_key[child_key], child_records))
+            pending.append((child_key, path, child_records))
+
+    nonterminal_keys = [
+        key
+        for key, path, _, records in traces[1:]
+        if not _openclaw_indexed_session_terminal(
+            entry_by_key[key],
+            path,
+            records=records,
+        )
+    ]
+    failed_keys = [
+        key
+        for key, entry in entry_by_key.items()
+        if str(entry.get("status") or "").lower() in _OPENCLAW_FAILURE_STATUSES
+    ]
+    errors.extend(f"nonterminal-session:{key}" for key in nonterminal_keys)
+    missing_timestamps = 0
+    ambiguous_timestamps = 0
+    if not errors and len(traces) > 1:
+        order_errors, missing_timestamps, ambiguous_timestamps = (
+            _openclaw_session_tree_order_errors(
+                traces,
+                failed_session_keys=set(failed_keys),
+            )
+        )
+        errors.extend(order_errors)
+
+    return traces, {
+        "session_tree_session_count": len(traces),
+        "session_tree_descendant_count": max(0, len(traces) - 1),
+        "session_tree_accepted_spawn_count": accepted_spawn_count,
+        "session_tree_reused_spawn_count": reused_spawn_count,
+        "session_tree_ignored_entry_count": max(0, len(entries) - len(depth_by_key)),
+        "session_tree_missing_transcript_count": missing_transcripts,
+        "session_tree_missing_timestamp_count": missing_timestamps,
+        "session_tree_ambiguous_timestamp_count": ambiguous_timestamps,
+        "session_tree_session_keys": [key for key, _, _, _ in traces],
+        "session_tree_failed_session_keys": failed_keys,
+        "session_tree_nonterminal_session_keys": nonterminal_keys,
+        "session_tree_errors": errors,
+        "session_tree_complete": not errors,
+    }
+
+
+def _openclaw_session_tree_order_errors(
+    session_tree: list[OpenClawSessionTrace],
+    *,
+    failed_session_keys: set[str] | None = None,
+) -> tuple[list[str], int, int]:
+    missing: list[str] = []
+    timestamp_sessions: dict[float, str] = {}
+    ambiguous: set[tuple[str, str, float]] = set()
+    deduplicated_handoff_sources = _openclaw_terminal_child_session_keys(
+        session_tree,
+        failed_session_keys=failed_session_keys,
+    )
+    for session_key, _, _, records in session_tree:
+        for record_index, record in enumerate(records):
+            message = record.get("message")
+            if (
+                record.get("type") != "message"
+                or not isinstance(message, dict)
+                or message.get("role") not in {"user", "assistant"}
+            ):
+                continue
+            handoff_source = _openclaw_subagent_announce_source(message)
+            if handoff_source in deduplicated_handoff_sources:
+                continue
+            timestamp = _openclaw_timestamp_value(record.get("timestamp"))
+            if timestamp is None:
+                missing.append(f"missing-step-timestamp:{session_key}:{record_index}")
+                continue
+            other_session = timestamp_sessions.setdefault(timestamp, session_key)
+            if other_session != session_key:
+                first, second = sorted((other_session, session_key))
+                ambiguous.add((first, second, timestamp))
+    errors = [
+        *missing,
+        *[
+            f"ambiguous-step-timestamp:{first}:{second}:{timestamp}"
+            for first, second, timestamp in sorted(ambiguous)
+        ],
+    ]
+    return errors, len(missing), len(ambiguous)
+
+
+def _load_openclaw_session_index(
+    archive: Path,
+) -> tuple[dict[str, tuple[dict[str, Any], Path]], set[str]]:
+    entries: dict[str, tuple[dict[str, Any], Path]] = {}
+    ambiguous_keys: set[str] = set()
+    store_paths = sorted(archive.rglob("sessions.json")) if archive.is_dir() else []
+    for store_path in store_paths:
+        store = _load_json_object(store_path)
+        for key, value in store.items():
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            if key in entries:
+                ambiguous_keys.add(key)
+                continue
+            entries[key] = (value, store_path.parent)
+    return entries, ambiguous_keys
+
+
+def _load_openclaw_session_audit(archive: Path) -> dict[str, dict[str, Any]]:
+    audit: dict[str, dict[str, Any]] = {}
+    for event in _openclaw_session_records(archive / "audit" / "sessions.jsonl"):
+        key = event.get("sessionKey")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        audit.setdefault(key.strip(), {}).update(event)
+    return audit
+
+
+def _resolve_deleted_openclaw_session(
+    *,
+    audit: dict[str, dict[str, Any]],
+    audit_root: Path,
+    child_key: str,
+    parent_key: str,
+    seen_paths: set[Path],
+) -> tuple[tuple[dict[str, Any], Path] | None, str | None]:
+    audited = audit.get(child_key)
+    if audited is not None:
+        spawned_by = audited.get("spawnedBy")
+        if isinstance(spawned_by, str) and spawned_by.strip() and spawned_by != parent_key:
+            return None, (f"spawn-lineage-mismatch:{child_key}:{spawned_by}!={parent_key}")
+        transcript = audited.get("auditTranscript")
+        if isinstance(transcript, str) and transcript.strip():
+            resolved_root = audit_root.resolve()
+            path = (audit_root / transcript).resolve()
+            if path.is_relative_to(resolved_root) and path.is_file():
+                if path in seen_paths:
+                    return None, f"duplicate-session-transcript:{child_key}"
+                return (audited, path), None
+            return None, f"missing-session-transcript:{child_key}"
+
+    return None, None
+
+
+def _resolve_archived_openclaw_session_path(
+    store_dir: Path,
+    entry: dict[str, Any],
+) -> Path | None:
+    candidates: list[Path] = []
+    session_file = entry.get("sessionFile")
+    if isinstance(session_file, str) and session_file.strip():
+        source = Path(session_file)
+        if not source.is_absolute():
+            candidates.append(store_dir / source)
+        else:
+            session_parts = [index for index, part in enumerate(source.parts) if part == "sessions"]
+            if session_parts and session_parts[-1] + 1 < len(source.parts):
+                candidates.append(store_dir / Path(*source.parts[session_parts[-1] + 1 :]))
+        candidates.append(store_dir / source.name)
+    session_id = entry.get("sessionId")
+    if isinstance(session_id, str) and session_id.strip():
+        candidates.append(store_dir / f"{session_id}.jsonl")
+    resolved_store = store_dir.resolve()
+    return next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.resolve().is_relative_to(resolved_store) and candidate.is_file()
+        ),
+        None,
+    )
+
+
+def _openclaw_session_tree_steps(
+    session_tree: list[OpenClawSessionTrace],
+    *,
+    instruction: str,
+    run: RunSpec,
+    failed_session_keys: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    ordered: list[tuple[tuple[int, float, str], int, int, int, dict[str, Any]]] = []
+    initial_user: dict[str, Any] | None = None
+    deduplicated_handoff_sources = _openclaw_terminal_child_session_keys(
+        session_tree,
+        failed_session_keys=failed_session_keys,
+    )
+    for session_index, (session_key, path, depth, records) in enumerate(session_tree):
+        models = {
+            _normalize_observed_model(model, run)
+            for model in _openclaw_session_models(path, records=records)
+        }
+        session_model = next(iter(models)) if len(models) == 1 else run.model_id
+        session_steps = _openclaw_session_steps(
+            path,
+            instruction=instruction if session_index == 0 else "",
+            model_name=f"{run.provider}/{session_model}",
+            session_key=session_key,
+            session_depth=depth,
+            deduplicated_handoff_sources=deduplicated_handoff_sources,
+            records=records,
+        )
+        if session_index == 0 and session_steps and session_steps[0].get("source") == "user":
+            initial_user = session_steps.pop(0)
+        for local_index, step in enumerate(session_steps):
+            ordered.append(
+                (
+                    _openclaw_timestamp_order(step.get("timestamp")),
+                    depth,
+                    session_index,
+                    local_index,
+                    step,
+                )
+            )
+
+    merged = ([initial_user] if initial_user is not None else []) + [
+        item[-1] for item in sorted(ordered, key=lambda item: item[:-1])
+    ]
+    for step_id, step in enumerate(merged, start=1):
+        step["step_id"] = step_id
+    return merged
+
+
+def _openclaw_timestamp_order(value: Any) -> tuple[int, float, str]:
+    timestamp = _openclaw_timestamp_value(value)
+    if timestamp is not None:
+        return 0, timestamp, ""
+    if not isinstance(value, str) or not value.strip():
+        return 1, 0.0, ""
+    return 1, 0.0, value
+
+
+def _openclaw_timestamp_value(value: Any) -> float | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
+        return None
+
+
+def _with_openclaw_session_provenance(
+    step: dict[str, Any],
+    *,
+    session_key: str | None,
+    session_depth: int,
+) -> dict[str, Any]:
+    if not session_key:
+        return step
+    extra = step.get("extra")
+    if not isinstance(extra, dict):
+        extra = {}
+    step["extra"] = {
+        **extra,
+        "openclaw_session_key": session_key,
+        "openclaw_session_depth": session_depth,
+    }
+    return step
+
+
+def _openclaw_subagent_announce_source(message: dict[str, Any]) -> str | None:
+    provenance = message.get("provenance")
+    if (
+        not isinstance(provenance, dict)
+        or provenance.get("kind") != "inter_session"
+        or provenance.get("sourceTool") != "subagent_announce"
+    ):
+        return None
+    source = provenance.get("sourceSessionKey")
+    return source if isinstance(source, str) and source.strip() else None
+
+
+def _openclaw_terminal_child_session_keys(
+    session_tree: list[OpenClawSessionTrace],
+    *,
+    failed_session_keys: set[str] | None = None,
+) -> set[str]:
+    # Only a successful child response supersedes its parent announcement.
+    # Failure announcements carry the terminal outcome missing from the child log.
+    return {
+        key
+        for key, path, _, records in session_tree[1:]
+        if key not in (failed_session_keys or set())
+        and _openclaw_session_terminal(path, records=records)
+    }
+
+
+def _openclaw_session_tree_usage(
+    session_tree: list[OpenClawSessionTrace],
+) -> dict[str, int] | None:
+    totals = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
+    observed = False
+    for _, path, _, records in session_tree:
+        observed = observed or any(
+            isinstance(record.get("message"), dict)
+            and record["message"].get("role") == "assistant"
+            and isinstance(record["message"].get("usage"), dict)
+            for record in records
+        )
+        usage = _openclaw_session_usage(path, records=records)
+        for key in totals:
+            totals[key] += usage[key]
+    return totals if observed else None
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _openclaw_session_models(
+    path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+) -> set[str]:
     models: set[str] = set()
-    for record in _openclaw_session_records(path):
+    session_records = records if records is not None else _openclaw_session_records(path)
+    for record in session_records:
         if record.get("type") == "model_change":
             model_id = record.get("modelId")
             if isinstance(model_id, str) and model_id:
@@ -647,13 +1376,84 @@ def _openclaw_session_models(path: Path) -> set[str]:
     return models
 
 
-def _openclaw_spawn_models(path: Path) -> set[str]:
-    models: set[str] = set()
-    for record in _openclaw_session_records(path):
-        for value in _nested_strings(record):
-            for match in re.finditer(r'"resolvedModel"\s*:\s*"([^"]+)"', value):
-                models.add(match.group(1))
-    return models
+def _openclaw_spawn_results(
+    path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    pending: dict[str, str | None] = {}
+    results: list[dict[str, Any]] = []
+    session_records = records if records is not None else _openclaw_session_records(path)
+    for record in session_records:
+        if record.get("type") != "message":
+            continue
+        message = record.get("message")
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            _, calls = _openclaw_assistant_content(message.get("content"))
+            for call in calls:
+                if call.get("function_name") != "sessions_spawn" or not call.get("tool_call_id"):
+                    continue
+                arguments = call.get("arguments")
+                task = (
+                    arguments.get("task")
+                    if isinstance(arguments, dict) and isinstance(arguments.get("task"), str)
+                    else None
+                )
+                pending[call["tool_call_id"]] = task
+            continue
+        if message.get("role") != "toolResult":
+            continue
+        call_id = str(message.get("toolCallId") or "")
+        if call_id not in pending:
+            continue
+        task = pending.pop(call_id)
+        payload = _openclaw_tool_result_object(message)
+        if str(payload.get("status") or "").lower() != "accepted":
+            continue
+        child_key = payload.get("childSessionKey")
+        if not isinstance(child_key, str) or not child_key.strip():
+            continue
+        resolved_model = payload.get("resolvedModel")
+        results.append(
+            _without_none(
+                {
+                    "child_session_key": child_key.strip(),
+                    "task": task,
+                    "resolved_model": (
+                        resolved_model.strip()
+                        if isinstance(resolved_model, str) and resolved_model.strip()
+                        else None
+                    ),
+                }
+            )
+        )
+    return results
+
+
+def _openclaw_tool_result_object(message: dict[str, Any]) -> dict[str, Any]:
+    details = message.get("details")
+    if isinstance(details, dict):
+        return details
+    text = _content_text(message.get("content")).strip()
+    if not text:
+        return {}
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        decoder = json.JSONDecoder()
+        for start, char in enumerate(text):
+            if char != "{":
+                continue
+            try:
+                value, _ = decoder.raw_decode(text[start:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                return value
+        return {}
+    return value if isinstance(value, dict) else {}
 
 
 def _openclaw_log_models(path: Path) -> set[str]:
@@ -667,22 +1467,46 @@ def _openclaw_log_models(path: Path) -> set[str]:
     )
 
 
-def _openclaw_session_terminal(path: Path) -> bool:
-    for record in reversed(_openclaw_session_records(path)):
+def _openclaw_session_terminal(
+    path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+) -> bool:
+    session_records = records if records is not None else _openclaw_session_records(path)
+    active_records = _openclaw_active_session_records(session_records)
+    for record in reversed(active_records):
         message = record.get("message")
-        if (
-            record.get("type") != "message"
-            or not isinstance(message, dict)
-            or message.get("role") != "assistant"
-        ):
+        if record.get("type") != "message" or not isinstance(message, dict):
             continue
+        if message.get("role") != "assistant":
+            return False
         text, tools = _openclaw_assistant_content(message.get("content"))
         stop_reason = str(message.get("stopReason") or "").lower()
-        return bool(text.strip()) and not tools and stop_reason in {
-            "end_turn",
-            "stop",
-        }
+        return (
+            bool(text.strip())
+            and not tools
+            and stop_reason
+            in {
+                "end_turn",
+                "stop",
+            }
+        )
     return False
+
+
+def _openclaw_indexed_session_terminal(
+    entry: dict[str, Any],
+    path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+) -> bool:
+    transcript_terminal = _openclaw_session_terminal(path, records=records)
+    status = str(entry.get("status") or "").lower()
+    if status in _OPENCLAW_FAILURE_STATUSES:
+        return True
+    # Index writes can lag transcript archival. Require a terminal transcript for
+    # normal completion, but keep explicit failure states that may have no final turn.
+    return transcript_terminal
 
 
 def _openclaw_envelope_terminal(envelope: dict[str, Any]) -> bool:
@@ -698,13 +1522,17 @@ def _openclaw_envelope_terminal(envelope: dict[str, Any]) -> bool:
     }:
         return False
     payloads = envelope.get("payloads")
-    visible = any(
-        isinstance(item, dict)
-        and isinstance(item.get("text"), str)
-        and item["text"].strip()
-        and item.get("isReasoning") is not True
-        for item in payloads
-    ) if isinstance(payloads, list) else False
+    visible = (
+        any(
+            isinstance(item, dict)
+            and isinstance(item.get("text"), str)
+            and item["text"].strip()
+            and item.get("isReasoning") is not True
+            for item in payloads
+        )
+        if isinstance(payloads, list)
+        else False
+    )
     return visible or meta.get("aborted") is True
 
 
@@ -715,9 +1543,14 @@ def _openclaw_session_id(path: Path) -> str | None:
     return path.stem if path.is_file() else None
 
 
-def _openclaw_session_usage(path: Path) -> dict[str, int]:
+def _openclaw_session_usage(
+    path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+) -> dict[str, int]:
     totals = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
-    for record in _openclaw_session_records(path):
+    session_records = records if records is not None else _openclaw_session_records(path)
+    for record in session_records:
         message = record.get("message")
         if not isinstance(message, dict) or message.get("role") != "assistant":
             continue
@@ -790,9 +1623,7 @@ def _hermes_steps(
     *,
     model_name: str,
 ) -> list[dict[str, Any]]:
-    messages = [
-        item for item in session.get("messages", []) if isinstance(item, dict)
-    ]
+    messages = [item for item in session.get("messages", []) if isinstance(item, dict)]
     steps: list[dict[str, Any]] = []
     first_user = True
     index = 0
@@ -823,8 +1654,7 @@ def _hermes_steps(
                     _without_none(
                         {
                             "source_call_id": tool_message.get("tool_call_id"),
-                            "content": _content_text(tool_message.get("content"))
-                            or None,
+                            "content": _content_text(tool_message.get("content")) or None,
                         }
                     )
                 )
@@ -839,15 +1669,11 @@ def _hermes_steps(
                             "model_name": model_name,
                             "reasoning_content": (
                                 message.get("reasoning_content")
-                                if isinstance(
-                                    message.get("reasoning_content"), str
-                                )
+                                if isinstance(message.get("reasoning_content"), str)
                                 else None
                             ),
                             "tool_calls": tool_calls or None,
-                            "observation": (
-                                {"results": observations} if observations else None
-                            ),
+                            "observation": ({"results": observations} if observations else None),
                             "llm_call_count": 1,
                         }
                     )
@@ -861,13 +1687,11 @@ def _validate_hermes_session(
     session: dict[str, Any],
     instruction: str,
 ) -> dict[str, Any]:
-    messages = [
-        item for item in session.get("messages", []) if isinstance(item, dict)
-    ]
+    messages = [item for item in session.get("messages", []) if isinstance(item, dict)]
     message_ids = [item.get("id") for item in messages]
-    unique_message_ids = all(
-        value is not None for value in message_ids
-    ) and len(message_ids) == len(set(message_ids))
+    unique_message_ids = all(value is not None for value in message_ids) and len(
+        message_ids
+    ) == len(set(message_ids))
     timestamps = [
         float(item["timestamp"])
         for item in messages
@@ -907,9 +1731,7 @@ def _validate_hermes_session(
     )
     return {
         "message_count_matches": session.get("message_count") == len(messages),
-        "tool_call_count_matches": (
-            session.get("tool_call_count") == flattened_tool_calls
-        ),
+        "tool_call_count_matches": (session.get("tool_call_count") == flattened_tool_calls),
         "message_ids_unique": unique_message_ids,
         "timestamps_ordered": timestamps_ordered,
         "instruction_matches": instruction_matches,
@@ -955,8 +1777,7 @@ def _content_text(content: Any) -> str:
     return " ".join(
         str(part.get("text") or part.get("content") or "")
         for part in content
-        if isinstance(part, dict)
-        and isinstance(part.get("text") or part.get("content"), str)
+        if isinstance(part, dict) and isinstance(part.get("text") or part.get("content"), str)
     )
 
 
@@ -1030,26 +1851,8 @@ def _normalize_observed_model(value: str, run: RunSpec) -> str:
         return run.model_id
     for prefix in ("anthropic/", "openai/"):
         if value.startswith(prefix):
-            return value[len(prefix):]
+            return value[len(prefix) :]
     return value
-
-
-def _nested_strings(value: Any) -> list[str]:
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [
-            item
-            for child in value
-            for item in _nested_strings(child)
-        ]
-    if isinstance(value, dict):
-        return [
-            item
-            for child in value.values()
-            for item in _nested_strings(child)
-        ]
-    return []
 
 
 def _arguments(value: Any) -> dict[str, Any]:

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 import shlex
 from dataclasses import dataclass
 from pathlib import PurePosixPath
@@ -67,6 +68,429 @@ for start in range(len(text) - 1, -1, -1):
 sys.exit(1)
 """
 
+# ShellBench pins OpenClaw 2026.7.1-2, whose runtime session contract is the
+# sessions.json registry plus JSONL transcripts under each agent's sessions dir.
+_OPENCLAW_SESSION_PROBE = """\
+import json
+import pathlib
+import sys
+
+sessions = pathlib.Path(sys.argv[1])
+audit_root = pathlib.Path(sys.argv[2])
+try:
+    store = json.loads((sessions / "sessions.json").read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    sys.exit(1)
+if not isinstance(store, dict):
+    sys.exit(1)
+
+audit = {}
+audit_path = audit_root / "sessions.jsonl"
+if audit_path.is_file():
+    for line in audit_path.read_text(
+        encoding="utf-8",
+        errors="replace",
+    ).splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        key = event.get("sessionKey") if isinstance(event, dict) else None
+        if isinstance(key, str) and key.strip():
+            audit.setdefault(key.strip(), {}).update(event)
+
+def session_path(key, entry):
+    def contained(root, candidate):
+        try:
+            return candidate.resolve().is_relative_to(root.resolve())
+        except (OSError, RuntimeError):
+            return False
+
+    session_file = entry.get("sessionFile")
+    if isinstance(session_file, str) and session_file.strip():
+        path = pathlib.Path(session_file)
+        candidate = path if path.is_absolute() else sessions / path
+        if contained(sessions, candidate) and candidate.is_file():
+            return candidate
+    session_id = entry.get("sessionId")
+    active = sessions / f"{session_id}.jsonl" if session_id else None
+    if active and active.is_file():
+        return active
+    transcript = audit.get(key, {}).get("auditTranscript")
+    if isinstance(transcript, str) and transcript.strip():
+        candidate = audit_root / transcript
+        return candidate if contained(audit_root, candidate) else None
+    return active
+
+def records_for(key, entry):
+    path = session_path(key, entry)
+    if path is None or not path.is_file():
+        return []
+    records = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            records.append(value)
+    return records
+
+def content_text(content):
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(
+        part.get("text", "")
+        for part in content
+        if isinstance(part, dict) and isinstance(part.get("text"), str)
+    )
+
+def active_records(records):
+    canonical_types = {
+        "message",
+        "thinking_level_change",
+        "model_change",
+        "compaction",
+        "reset",
+        "branch_summary",
+        "custom",
+        "custom_message",
+        "label",
+        "session_info",
+    }
+    nodes = {}
+    leaf = None
+    append_parent = None
+    explicit_update = False
+    invalid_leaf_ids = set()
+
+    def text(value):
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    def resolve_parent(parent):
+        seen = set()
+        while parent is not None:
+            if parent in seen:
+                return parent
+            seen.add(parent)
+            node = nodes.get(parent)
+            if node is None or not node["is_leaf"]:
+                return parent
+            parent = node["parent"]
+        return None
+
+    for record in records:
+        record_type = record.get("type")
+        canonical = record_type in canonical_types
+        explicit = "parentId" in record
+        if record_type == "session" or (not explicit and not canonical):
+            continue
+        record_id = text(record.get("id"))
+        if record_id is None:
+            continue
+        raw_parent = record.get("parentId") if explicit else leaf
+        parent = None if raw_parent is None else text(raw_parent)
+        if raw_parent is not None and parent is None:
+            continue
+        is_leaf = record_type == "leaf"
+        if is_leaf:
+            raw_target = record.get("targetId")
+            target = None if raw_target is None else text(raw_target)
+            raw_append = record.get("appendParentId", raw_target)
+            next_append = None if raw_append is None else text(raw_append)
+            if (
+                (raw_target is not None and target is None)
+                or (raw_append is not None and next_append is None)
+                or record.get("appendMode") not in {None, "side"}
+            ):
+                continue
+            invalid = any(
+                ref is not None and (ref not in nodes or ref in invalid_leaf_ids)
+                for ref in (target, next_append)
+            )
+            if invalid:
+                invalid_leaf_ids.add(record_id)
+                next_leaf = ...
+                next_append = append_parent
+            else:
+                parent = target
+                next_leaf = target
+        else:
+            if (
+                explicit
+                and parent is not None
+                and parent not in nodes
+                and leaf is not None
+            ):
+                parent = leaf
+            elif (
+                explicit
+                and record.get("appendMode") != "side"
+                and parent == append_parent
+                and leaf != append_parent
+            ):
+                parent = leaf
+            parent = resolve_parent(parent)
+            next_leaf = record_id if canonical and record.get("appendMode") != "side" else ...
+            next_append = record_id
+        node = {
+            "record": record,
+            "parent": parent,
+            "leaf": next_leaf,
+            "append": next_append,
+            "is_leaf": is_leaf,
+        }
+        nodes[record_id] = node
+        append_parent = next_append
+        if next_leaf is not ...:
+            leaf = next_leaf
+            explicit_update = explicit_update or explicit
+
+    if not explicit_update:
+        return records
+    if leaf is None:
+        return []
+    selected = []
+    seen = set()
+    current = leaf
+    while current is not None:
+        if current in seen:
+            return []
+        seen.add(current)
+        node = nodes.get(current)
+        if node is None:
+            break
+        if not node["is_leaf"]:
+            selected.append(node["record"])
+        current = node["parent"]
+    selected.reverse()
+    return selected
+
+def terminal(entry, records):
+    if str(entry.get("status") or "").lower() in {
+        "cancelled",
+        "deleted",
+        "error",
+        "failed",
+        "killed",
+        "reset",
+        "timeout",
+    }:
+        return bool(records)
+    for record in reversed(active_records(records)):
+        message = record.get("message")
+        if (
+            record.get("type") != "message"
+            or not isinstance(message, dict)
+        ):
+            continue
+        if message.get("role") != "assistant":
+            return False
+        content = message.get("content")
+        parts = content if isinstance(content, list) else []
+        text = content_text(content)
+        tools = [
+            part
+            for part in parts
+            if isinstance(part, dict) and part.get("type") == "toolCall"
+        ]
+        return (
+            bool(text.strip())
+            and not tools
+            and str(message.get("stopReason") or "").lower() in {"end_turn", "stop"}
+        )
+    return False
+
+def result_object(message):
+    details = message.get("details")
+    if isinstance(details, dict):
+        return details
+    text = content_text(message.get("content")).strip()
+    if not text:
+        return {}
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        decoder = json.JSONDecoder()
+        for start, char in enumerate(text):
+            if char != "{":
+                continue
+            try:
+                value, _ = decoder.raw_decode(text[start:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                return value
+        return {}
+    return value if isinstance(value, dict) else {}
+
+def spawned_children(records):
+    pending = set()
+    children = []
+    for record in active_records(records):
+        message = record.get("message")
+        if record.get("type") != "message" or not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            pending.update(
+                str(part.get("id"))
+                for part in content
+                if isinstance(part, dict)
+                and part.get("type") == "toolCall"
+                and part.get("name") == "sessions_spawn"
+                and part.get("id")
+            )
+            continue
+        if message.get("role") != "toolResult":
+            continue
+        call_id = str(message.get("toolCallId") or "")
+        if call_id not in pending:
+            continue
+        pending.discard(call_id)
+        payload = result_object(message)
+        child = payload.get("childSessionKey")
+        if (
+            str(payload.get("status") or "").lower() == "accepted"
+            and isinstance(child, str)
+            and child.strip()
+        ):
+            children.append(child.strip())
+    return children
+
+root_key = "agent:main:main"
+pending = [(root_key, None)]
+seen = set()
+while pending:
+    key, parent = pending.pop(0)
+    if key in seen:
+        continue
+    seen.add(key)
+    entry = store.get(key)
+    if not isinstance(entry, dict):
+        entry = audit.get(key)
+    if not isinstance(entry, dict):
+        sys.exit(1)
+    if parent and entry.get("spawnedBy") not in {None, "", parent}:
+        sys.exit(1)
+    records = records_for(key, entry)
+    if not terminal(entry, records):
+        sys.exit(1)
+    pending.extend((child, key) for child in spawned_children(records))
+sys.exit(0)
+"""
+
+_OPENCLAW_GATEWAY_PROBE = """\
+import json
+import sys
+import urllib.request
+
+request = urllib.request.Request(
+    "http://127.0.0.1:18789/readyz",
+    headers={"Authorization": f"Bearer {sys.argv[1]}"},
+)
+try:
+    with urllib.request.urlopen(request, timeout=1) as response:
+        payload = json.load(response)
+        sys.exit(
+            0
+            if response.status == 200
+            and isinstance(payload, dict)
+            and payload.get("ready") is True
+            else 1
+        )
+except Exception:
+    sys.exit(1)
+"""
+
+_OPENCLAW_AUDIT_PLUGIN = """\
+const fs = require("node:fs");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+const auditRoot = path.join(process.env.HOME, ".openclaw", "shellbench-audit");
+const eventPath = path.join(auditRoot, "sessions.jsonl");
+
+function append(event) {
+  fs.mkdirSync(auditRoot, { recursive: true });
+  fs.appendFileSync(eventPath, `${JSON.stringify(event)}\\n`, { mode: 0o600 });
+}
+
+function materializeTranscript(event) {
+  const source = event.sessionFile;
+  if (typeof source !== "string" || !source || !fs.existsSync(source)) {
+    return undefined;
+  }
+  const transcriptRoot = path.join(auditRoot, "transcripts");
+  fs.mkdirSync(transcriptRoot, { recursive: true });
+  const destination = path.join(transcriptRoot, `${event.sessionId}.jsonl`);
+  try {
+    const content = source.endsWith(".zst")
+      ? zlib.zstdDecompressSync(fs.readFileSync(source))
+      : fs.readFileSync(source);
+    fs.writeFileSync(destination, content, { mode: 0o600 });
+    return path.relative(auditRoot, destination);
+  } catch {
+    return undefined;
+  }
+}
+
+module.exports = {
+  id: "shellbench-audit",
+  register(api) {
+    api.on("subagent_spawned", (event, ctx) => {
+      append({
+        type: "subagent_spawned",
+        sessionKey: event.childSessionKey,
+        spawnedBy: ctx.requesterSessionKey,
+        runId: event.runId,
+      });
+    });
+    api.on("subagent_ended", (event, ctx) => {
+      append({
+        type: "subagent_ended",
+        sessionKey: event.targetSessionKey,
+        spawnedBy: ctx.requesterSessionKey,
+        runId: event.runId,
+        status: event.outcome,
+        reason: event.reason,
+      });
+    });
+    api.on("session_start", (event) => {
+      append({
+        type: "session_start",
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+      });
+    });
+    api.on("session_end", (event) => {
+      const auditTranscript = materializeTranscript(event);
+      append({
+        type: "session_end",
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        reason: event.reason,
+        transcriptArchived: event.transcriptArchived,
+        auditTranscript,
+      });
+    });
+  },
+};
+"""
+
+_OPENCLAW_AUDIT_PLUGIN_MANIFEST = {
+    "id": "shellbench-audit",
+    "configSchema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {},
+    },
+}
+
 
 @dataclass(frozen=True)
 class HarnessCommand:
@@ -108,6 +532,9 @@ def _openclaw(
 ) -> HarnessCommand:
     provider = "openai"
     model = f"{provider}/{run.model_id}"
+    home = "/tmp/shellbench-openclaw"
+    audit_plugin_root = f"{home}/.openclaw/shellbench-audit"
+    gateway_token = secrets.token_urlsafe(32)
     servers: dict[str, dict[str, object]] = {}
     for server in mcp_servers:
         if server.transport == "stdio":
@@ -129,13 +556,17 @@ def _openclaw(
                 "subagents": {"model": model},
             }
         },
-        "gateway": {"mode": "local"},
+        "gateway": {
+            "mode": "local",
+            "auth": {"mode": "token", "token": gateway_token},
+        },
         "models": {
             "providers": {
                 provider: {
                     "baseUrl": f"{proxy_url.rstrip('/')}/v1",
                     "api": "openai-responses",
                     "apiKey": proxy_key,
+                    "agentRuntime": {"id": "openclaw"},
                     "models": [
                         {
                             "id": run.model_id,
@@ -145,50 +576,95 @@ def _openclaw(
                 }
             }
         },
+        "plugins": {
+            "load": {"paths": [audit_plugin_root]},
+            "entries": {"shellbench-audit": {"enabled": True}},
+        },
         "tools": {"deny": ["message"]},
     }
     if servers:
         config["mcp"] = {"servers": servers}
     config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
     completion_probe = shlex.quote(_OPENCLAW_COMPLETION_PROBE)
-    home = "/tmp/shellbench-openclaw"
+    session_probe = shlex.quote(_OPENCLAW_SESSION_PROBE)
+    gateway_probe = shlex.quote(_OPENCLAW_GATEWAY_PROBE)
+    audit_plugin = shlex.quote(_OPENCLAW_AUDIT_PLUGIN)
+    audit_manifest = shlex.quote(json.dumps(_OPENCLAW_AUDIT_PLUGIN_MANIFEST, separators=(",", ":")))
     setup = (
         f"export PATH={_base_path()}; export HOME={home}; "
-        "rm -rf \"$HOME\"; mkdir -p \"$HOME/.openclaw\"; "
-        f"printf %s {config_json} > \"$HOME/.openclaw/openclaw.json\"; "
+        'rm -rf "$HOME"; mkdir -p "$HOME/.openclaw/shellbench-audit"; '
+        f'printf %s {audit_plugin} > "$HOME/.openclaw/shellbench-audit/index.cjs"; '
+        f"printf %s {audit_manifest} "
+        '> "$HOME/.openclaw/shellbench-audit/openclaw.plugin.json"; '
+        f'printf %s {config_json} > "$HOME/.openclaw/openclaw.json"; '
         "openclaw setup --baseline --skip-bootstrap --workspace . "
         ">/logs/agent/setup.log 2>&1; "
         "rm -f AGENTS.md BOOTSTRAP.md HEARTBEAT.md IDENTITY.md "
         "SOUL.md TOOLS.md USER.md; "
-        f"printf %s {config_json} > \"$HOME/.openclaw/openclaw.json\""
+        f'printf %s {config_json} > "$HOME/.openclaw/openclaw.json"'
     )
     run_command = (
         f"export PATH={_base_path()}; export HOME={home}; "
+        f"export OPENCLAW_GATEWAY_TOKEN={shlex.quote(gateway_token)}; "
         "log=/logs/agent/openclaw.txt; "
-        "openclaw agent --local --json --agent main --thinking off "
+        "gateway_log=/logs/agent/openclaw-gateway.txt; "
+        'openclaw gateway --port 18789 >"$gateway_log" 2>&1 & gateway_pid=$!; '
+        "ready=0; for _ in $(seq 1 60); do "
+        f'if python3 -c {gateway_probe} "$OPENCLAW_GATEWAY_TOKEN"; then '
+        "ready=1; break; fi; sleep 1; done; "
+        'if [ "$ready" -ne 1 ]; then '
+        'kill "$gateway_pid" 2>/dev/null || true; '
+        'wait "$gateway_pid" 2>/dev/null || true; '
+        'cat "$gateway_log" >&2; exit 70; fi; '
+        "openclaw agent --json --agent main --thinking off "
         f"--model {shlex.quote(model)} "
-        "--message \"$(cat /tmp/shellbench-instruction.md)\" "
-        ">\"$log\" 2>&1 </dev/null & pid=$!; "
-        "while kill -0 \"$pid\" 2>/dev/null; do "
-        f"if python3 -c {completion_probe} \"$log\"; then "
-        "sleep 1; kill \"$pid\" 2>/dev/null || true; sleep 1; "
-        "kill -KILL \"$pid\" 2>/dev/null || true; "
-        "wait \"$pid\" 2>/dev/null || true; cat \"$log\"; exit 0; "
+        '--message "$(cat /tmp/shellbench-instruction.md)" '
+        '>"$log" 2>&1 </dev/null & pid=$!; '
+        "reaped=0; status=0; "
+        'while kill -0 "$pid" 2>/dev/null; do '
+        f'if python3 -c {completion_probe} "$log"; then '
+        'sleep 1; kill "$pid" 2>/dev/null || true; sleep 1; '
+        'kill -KILL "$pid" 2>/dev/null || true; '
+        'wait "$pid" 2>/dev/null || true; reaped=1; break; '
         "fi; sleep 1; done; "
-        "wait \"$pid\"; status=$?; cat \"$log\"; exit \"$status\""
+        'if [ "$reaped" -ne 1 ]; then wait "$pid"; status=$?; fi; '
+        'session_ready=0; if [ "$status" -eq 0 ]; then '
+        "for _ in $(seq 1 60); do "
+        f"if python3 -c {session_probe} "
+        '"$HOME/.openclaw/agents/main/sessions" '
+        '"$HOME/.openclaw/shellbench-audit"; then '
+        "session_ready=1; break; fi; "
+        'if ! kill -0 "$gateway_pid" 2>/dev/null; then status=70; break; fi; '
+        "sleep 1; done; fi; "
+        'if [ "$status" -eq 0 ] && [ "$session_ready" -ne 1 ]; then '
+        "echo 'OpenClaw terminal session evidence did not stabilize within 60 seconds' "
+        '>>"$log"; status=71; fi; '
+        'kill "$gateway_pid" 2>/dev/null || true; '
+        'wait "$gateway_pid" 2>/dev/null || true; '
+        'cat "$gateway_log" >>"$log"; cat "$log"; exit "$status"'
     )
+    # Keep this archive path aligned with the pinned OpenClaw 2026.7.1-2
+    # sessions.json/JSONL contract used by the completion probe above.
     cleanup = (
         "python3 - <<'PY'\n"
         "import json, pathlib, shutil\n"
         "p=pathlib.Path('/logs/agent/openclaw.txt')\n"
-        "sessions=pathlib.Path("
-        "'/tmp/shellbench-openclaw/.openclaw/agents/main/sessions')\n"
+        "agents=pathlib.Path('/tmp/shellbench-openclaw/.openclaw/agents')\n"
+        "sessions=agents/'main'/'sessions'\n"
         "archive=pathlib.Path('/logs/agent/openclaw.sessions')\n"
-        "if sessions.is_dir():\n"
-        " shutil.copytree(sessions, archive, dirs_exist_ok=True)\n"
+        "audit=pathlib.Path('/tmp/shellbench-openclaw/.openclaw/shellbench-audit')\n"
+        "if agents.is_dir():\n"
+        " for agent in agents.iterdir():\n"
+        "  source=agent/'sessions'\n"
+        "  if not source.is_dir(): continue\n"
+        "  target=archive if agent.name=='main' else archive/'agents'/agent.name\n"
+        "  shutil.copytree(source, target, dirs_exist_ok=True)\n"
+        "if audit.is_dir():\n"
+        " shutil.copytree(audit, archive/'audit', dirs_exist_ok=True)\n"
+        "if archive.is_dir():\n"
         " for item in [archive, *archive.rglob('*')]:\n"
         "  item.chmod(0o755 if item.is_dir() else 0o644)\n"
-        "src=None\n"
+        "sources=[]\n"
         "try:\n"
         " raw=p.read_text(encoding='utf-8', errors='replace').strip()\n"
         " dec=json.JSONDecoder(); d=None\n"
@@ -201,25 +677,28 @@ def _openclaw(
         "   d=candidate; break\n"
         " if d:\n"
         "  src=((d.get('meta') or {}).get('agentMeta') or {}).get('sessionFile')\n"
+        "  if isinstance(src, str) and src: sources.append(src)\n"
         "except Exception:\n"
         " pass\n"
-        "if not src and sessions.is_dir():\n"
+        "if sessions.is_dir():\n"
         " try:\n"
         "  store=json.loads((sessions/'sessions.json').read_text())\n"
         "  entry=store.get('agent:main:main') if isinstance(store, dict) else None\n"
         "  if isinstance(entry, dict):\n"
-        "   src=entry.get('sessionFile')\n"
-        "   if not src and entry.get('sessionId'):\n"
-        "    src=str(sessions/f\"{entry['sessionId']}.jsonl\")\n"
+        "   session_file=entry.get('sessionFile')\n"
+        "   if isinstance(session_file, str) and session_file:\n"
+        "    sources.append(session_file)\n"
+        "   if entry.get('sessionId'):\n"
+        "    sources.append(str(sessions/f\"{entry['sessionId']}.jsonl\"))\n"
         " except Exception:\n"
         "  pass\n"
-        "source=pathlib.Path(src) if src else None\n"
-        "if source and not source.is_absolute(): source=sessions/source\n"
-        "if not source or not source.is_file():\n"
-        " candidates=[f for f in sessions.glob('*.jsonl') "
-        "if '.trajectory.' not in f.name] if sessions.is_dir() else []\n"
-        " source=max(candidates, key=lambda f: f.stat().st_mtime, "
-        "default=None)\n"
+        "source=None\n"
+        "for src in sources:\n"
+        " candidate=pathlib.Path(src)\n"
+        " if not candidate.is_absolute(): candidate=sessions/candidate\n"
+        " if candidate.is_file():\n"
+        "  source=candidate\n"
+        "  break\n"
         "if source and source.is_file():\n"
         " destination=pathlib.Path('/logs/agent/openclaw.session.jsonl')\n"
         " shutil.copy2(source, destination)\n"
@@ -233,6 +712,7 @@ def _openclaw(
         env={
             "OPENAI_API_KEY": proxy_key,
             "OPENAI_BASE_URL": f"{proxy_url.rstrip('/')}/v1",
+            "OPENCLAW_GATEWAY_TOKEN": gateway_token,
         },
     )
 
@@ -284,20 +764,20 @@ def _hermes(
     config_json = shlex.quote(json.dumps(config, separators=(",", ":")))
     setup = (
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
-        "rm -rf \"$HERMES_HOME\"; mkdir -p \"$HERMES_HOME\"; "
-        f"printf %s {config_json} > \"$HERMES_HOME/config.yaml\""
+        'rm -rf "$HERMES_HOME"; mkdir -p "$HERMES_HOME"; '
+        f'printf %s {config_json} > "$HERMES_HOME/config.yaml"'
     )
     run_command = (
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
-        "export TERMINAL_ENV=local; export TERMINAL_CWD=\"$PWD\"; "
-        "hermes --yolo chat -q \"$(cat /tmp/shellbench-instruction.md)\" -Q "
+        'export TERMINAL_ENV=local; export TERMINAL_CWD="$PWD"; '
+        'hermes --yolo chat -q "$(cat /tmp/shellbench-instruction.md)" -Q '
         f"--model {shlex.quote(run.model_id)} "
         f"--provider {shlex.quote(provider_name)} "
         ">/logs/agent/hermes.txt 2>&1; status=$?; "
         "cat /logs/agent/hermes.txt; "
-        "if grep -Eq \"Unknown provider|No LLM provider configured\" "
+        'if grep -Eq "Unknown provider|No LLM provider configured" '
         "/logs/agent/hermes.txt; then exit 64; fi; "
-        "exit \"$status\""
+        'exit "$status"'
     )
     cleanup = (
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
@@ -325,9 +805,7 @@ def _codex(
     for server in mcp_servers:
         config_lines.append(f"[mcp_servers.{server.name}]")
         if server.transport == "stdio":
-            command = shlex.join(
-                [server.command or "", *server.args]
-            )
+            command = shlex.join([server.command or "", *server.args])
             config_lines.append(f"command = {json.dumps(command)}")
         else:
             config_lines.append(f"url = {json.dumps(server.url)}")
@@ -335,9 +813,9 @@ def _codex(
     auth_json = shlex.quote(json.dumps({"OPENAI_API_KEY": proxy_key}))
     setup = (
         f"export PATH={_base_path()}; export CODEX_HOME={home}; "
-        "rm -rf \"$CODEX_HOME\"; mkdir -p \"$CODEX_HOME\"; "
-        f"printf %s {auth_json} > \"$CODEX_HOME/auth.json\"; "
-        f"printf %s {config_text} > \"$CODEX_HOME/config.toml\""
+        'rm -rf "$CODEX_HOME"; mkdir -p "$CODEX_HOME"; '
+        f'printf %s {auth_json} > "$CODEX_HOME/auth.json"; '
+        f'printf %s {config_text} > "$CODEX_HOME/config.toml"'
     )
     run_command = (
         f"export PATH={_base_path()}; export CODEX_HOME={home}; "
@@ -345,11 +823,11 @@ def _codex(
         "--skip-git-repo-check "
         f"--model {shlex.quote(run.model_id)} "
         "--json --enable unified_exec -- "
-        "\"$(cat /tmp/shellbench-instruction.md)\" "
+        '"$(cat /tmp/shellbench-instruction.md)" '
         ">/logs/agent/codex.txt 2>/logs/agent/codex-stderr.txt "
         "</dev/null; status=$?; "
         "cat /logs/agent/codex.txt; "
-        "cat /logs/agent/codex-stderr.txt >&2; exit \"$status\""
+        'cat /logs/agent/codex-stderr.txt >&2; exit "$status"'
     )
     cleanup = (
         "rm -rf /logs/agent/sessions; "
@@ -389,18 +867,18 @@ def _claude_code(
     mcp_json = shlex.quote(json.dumps({"mcpServers": servers}, separators=(",", ":")))
     setup = (
         f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
-        "rm -rf \"$CLAUDE_CONFIG_DIR\"; "
-        "mkdir -p \"$CLAUDE_CONFIG_DIR/debug\" \"$CLAUDE_CONFIG_DIR/projects/-app\"; "
-        f"printf %s {mcp_json} > \"$CLAUDE_CONFIG_DIR/.claude.json\""
+        'rm -rf "$CLAUDE_CONFIG_DIR"; '
+        'mkdir -p "$CLAUDE_CONFIG_DIR/debug" "$CLAUDE_CONFIG_DIR/projects/-app"; '
+        f'printf %s {mcp_json} > "$CLAUDE_CONFIG_DIR/.claude.json"'
     )
     run_command = (
         f"export PATH={_base_path()}; export CLAUDE_CONFIG_DIR={home}; "
         "claude --verbose --output-format=stream-json "
         "--permission-mode=bypassPermissions --print "
         f"--model {shlex.quote(run.model_id)} "
-        "\"$(cat /tmp/shellbench-instruction.md)\" "
+        '"$(cat /tmp/shellbench-instruction.md)" '
         ">/logs/agent/claude-code.txt 2>&1 </dev/null; status=$?; "
-        "cat /logs/agent/claude-code.txt; exit \"$status\""
+        'cat /logs/agent/claude-code.txt; exit "$status"'
     )
     return HarnessCommand(
         setup_command=setup,

--- a/scripts/native_eval/harnesses.py
+++ b/scripts/native_eval/harnesses.py
@@ -40,7 +40,30 @@ for start in range(len(text) - 1, -1, -1):
         and isinstance(value.get("payloads"), list)
         and isinstance(value.get("meta"), dict)
     ):
-        sys.exit(0)
+        meta = value["meta"]
+        liveness = str(meta.get("livenessState") or "").lower()
+        if meta.get("yielded") is True or liveness in {
+            "active",
+            "paused",
+            "running",
+            "waiting",
+        }:
+            continue
+        completion = meta.get("completion")
+        stop_reason = (
+            completion.get("stopReason")
+            if isinstance(completion, dict)
+            else meta.get("stopReason")
+        )
+        visible_payload = any(
+            isinstance(item, dict)
+            and isinstance(item.get("text"), str)
+            and item["text"].strip()
+            and item.get("isReasoning") is not True
+            for item in value["payloads"]
+        )
+        if visible_payload or stop_reason or meta.get("aborted") is True:
+            sys.exit(0)
 sys.exit(1)
 """
 
@@ -102,6 +125,8 @@ def _openclaw(
             "defaults": {
                 "workspace": ".",
                 "skipBootstrap": True,
+                "model": {"primary": model},
+                "subagents": {"model": model},
             }
         },
         "gateway": {"mode": "local"},
@@ -130,9 +155,11 @@ def _openclaw(
     setup = (
         f"export PATH={_base_path()}; export HOME={home}; "
         "rm -rf \"$HOME\"; mkdir -p \"$HOME/.openclaw\"; "
+        f"printf %s {config_json} > \"$HOME/.openclaw/openclaw.json\"; "
         "openclaw setup --baseline --skip-bootstrap --workspace . "
         ">/logs/agent/setup.log 2>&1; "
-        "rm -f BOOTSTRAP.md; "
+        "rm -f AGENTS.md BOOTSTRAP.md HEARTBEAT.md IDENTITY.md "
+        "SOUL.md TOOLS.md USER.md; "
         f"printf %s {config_json} > \"$HOME/.openclaw/openclaw.json\""
     )
     run_command = (
@@ -143,16 +170,9 @@ def _openclaw(
         "--message \"$(cat /tmp/shellbench-instruction.md)\" "
         ">\"$log\" 2>&1 </dev/null & pid=$!; "
         "while kill -0 \"$pid\" 2>/dev/null; do "
-        "if grep -Eq \"\\[agents/agent-command\\] \\[agent\\] run .* "
-        f"ended with stopReason=\" \"$log\" || python3 -c {completion_probe} "
-        "\"$log\"; then "
-        "sleep 2; kill \"$pid\" 2>/dev/null || true; sleep 1; "
+        f"if python3 -c {completion_probe} \"$log\"; then "
+        "sleep 1; kill \"$pid\" 2>/dev/null || true; sleep 1; "
         "kill -KILL \"$pid\" 2>/dev/null || true; "
-        "for f in /proc/[0-9]*/comm; do "
-        "name=$(cat \"$f\" 2>/dev/null || true); "
-        "case \"$name\" in openclaw-agent|\"npm exec chrome\"|chrome-devtools) "
-        "child=${f#/proc/}; child=${child%/comm}; "
-        "kill -KILL \"$child\" 2>/dev/null || true;; esac; done; "
         "wait \"$pid\" 2>/dev/null || true; cat \"$log\"; exit 0; "
         "fi; sleep 1; done; "
         "wait \"$pid\"; status=$?; cat \"$log\"; exit \"$status\""
@@ -245,7 +265,11 @@ def _hermes(
         "memory": {"memory_enabled": False, "user_profile_enabled": False},
         "compression": {"enabled": True, "threshold": 0.85},
         "terminal": {"backend": "local", "timeout": 180},
-        "delegation": {"max_iterations": 50},
+        "delegation": {
+            "max_iterations": 50,
+            "provider": provider_name,
+            "model": run.model_id,
+        },
         "checkpoints": {"enabled": False},
     }
     if mcp_servers:
@@ -277,15 +301,8 @@ def _hermes(
     )
     cleanup = (
         f"export PATH={_base_path()}; export HERMES_HOME={home}; "
-        "session_id=$(sed -n 's/^session_id: //p' "
-        "/logs/agent/hermes.txt | tail -1); "
-        "if [ -n \"$session_id\" ]; then "
         "hermes sessions export /logs/agent/hermes-session.jsonl "
-        "--session-id \"$session_id\" --yes --redact; "
-        "else "
-        "hermes sessions export /logs/agent/hermes-session.jsonl "
-        "--yes --redact; "
-        "fi"
+        "--yes --redact"
     )
     return HarnessCommand(
         setup_command=setup,

--- a/scripts/native_eval/run_job.py
+++ b/scripts/native_eval/run_job.py
@@ -140,9 +140,19 @@ async def run_job(
     )
     manifest["observed_model_ids"] = sorted(
         {
-            str(result.get("runtime_model_name"))
+            str(model_id)
             for result in agent_results
-            if result.get("runtime_model_name")
+            for model_id in (
+                (
+                    result.get("trajectory_validation", {}).get(
+                        "observed_models",
+                        [],
+                    )
+                )
+                if isinstance(result.get("trajectory_validation"), dict)
+                else []
+            )
+            if model_id
         }
     )
     manifest["trajectory_complete"] = bool(agent_results) and all(

--- a/scripts/native_eval/runtime.py
+++ b/scripts/native_eval/runtime.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from scripts.native_eval.harness_trajectories import (
     load_openclaw_envelope,
+    write_claude_code_trajectory,
     write_hermes_trajectory,
     write_openclaw_trajectory,
 )
@@ -1040,6 +1041,8 @@ def write_agent_trajectory(
         return write_openclaw_trajectory(task.instruction, run, agent_dir)
     if run.harness == "hermes":
         return write_hermes_trajectory(task.instruction, run, agent_dir)
+    if run.harness == "claude-code":
+        return write_claude_code_trajectory(task.instruction, run, agent_dir)
     if run.harness != "codex":
         return {
             "trajectory_status": "unsupported",

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -15,7 +15,14 @@ from scripts.native_eval.checkpoint_loop import (
 )
 from scripts.native_eval.harnesses import (
     _OPENCLAW_COMPLETION_PROBE,
+    _OPENCLAW_SESSION_PROBE,
     build_harness_command,
+)
+from scripts.native_eval.harness_trajectories import (
+    _openclaw_session_terminal,
+    _openclaw_session_tree,
+    _openclaw_session_tree_steps,
+    _resolve_archived_openclaw_session_path,
 )
 from scripts.native_eval.models import (
     HARNESSES,
@@ -165,9 +172,7 @@ def test_judge_env_uses_dedicated_proxy_alias() -> None:
 
     assert judge_env["AGENT_JUDGE_MODEL"] == JUDGE_PROXY_MODEL_NAME
     assert judge_env["LLM_JUDGE_MODEL"] == JUDGE_PROXY_MODEL_NAME
-    assert judge_env["AGENT_JUDGE_API_URL"] == (
-        "http://proxy:4000/v1/chat/completions"
-    )
+    assert judge_env["AGENT_JUDGE_API_URL"] == ("http://proxy:4000/v1/chat/completions")
 
 
 def test_run_manifest_records_native_audit_metadata(
@@ -349,9 +354,7 @@ def test_run_manifest_records_targeted_repair_lineage(tmp_path: Path) -> None:
     )
 
     assert manifest["repair_mode"] is True
-    assert manifest["rerun_of_canonical_run"] == (
-        "openclaw-gpt55-low-full-116-r1-parent"
-    )
+    assert manifest["rerun_of_canonical_run"] == ("openclaw-gpt55-low-full-116-r1-parent")
     assert manifest["repair_task_names"] == ["task-a", "task-b"]
 
 
@@ -399,8 +402,7 @@ def test_harness_commands_preserve_canonical_model_identity() -> None:
         )
 
         assert "claude-opus-5" in command.run_command or (
-            harness.name == "claude-code"
-            and command.env["ANTHROPIC_MODEL"] == "claude-opus-5"
+            harness.name == "claude-code" and command.env["ANTHROPIC_MODEL"] == "claude-opus-5"
         )
         assert "sb-opus5" not in command.run_command
         assert "OPENROUTER_API_KEY" not in command.env
@@ -409,18 +411,32 @@ def test_harness_commands_preserve_canonical_model_identity() -> None:
             assert "ended with stopReason=" not in command.run_command
             assert "python3 -c" in command.run_command
             assert "--thinking off" in command.run_command
+            assert "openclaw gateway --port 18789" in command.run_command
+            assert "127.0.0.1:18789/readyz" in command.run_command
+            assert "openclaw agent --local" not in command.run_command
+            assert "OPENCLAW_GATEWAY_TOKEN" in command.env
+            assert len(command.env["OPENCLAW_GATEWAY_TOKEN"]) >= 32
+            assert "seq 1 60" in command.run_command
+            assert "status=71" in command.run_command
             assert "setup --baseline --skip-bootstrap" in command.setup_command
-            assert "rm -f AGENTS.md BOOTSTRAP.md HEARTBEAT.md" in (
-                command.setup_command
-            )
+            assert "rm -f AGENTS.md BOOTSTRAP.md HEARTBEAT.md" in (command.setup_command)
             assert '"skipBootstrap":true' in command.setup_command
             assert '"primary":"openai/claude-opus-5"' in command.setup_command
-            assert '"subagents":{"model":"openai/claude-opus-5"}' in (
-                command.setup_command
-            )
-            assert "item.chmod(0o755 if item.is_dir() else 0o644)" in (
-                command.cleanup_command
-            )
+            assert '"subagents":{"model":"openai/claude-opus-5"}' in (command.setup_command)
+            assert '"agentRuntime":{"id":"openclaw"}' in command.setup_command
+            assert '"shellbench-audit":{"enabled":true}' in command.setup_command
+            assert "openclaw.plugin.json" in command.setup_command
+            assert '"configSchema":{"type":"object"' in command.setup_command
+            assert 'api.on("subagent_spawned"' in command.setup_command
+            assert 'api.on("subagent_ended"' in command.setup_command
+            assert 'api.on("session_end"' in command.setup_command
+            assert "zstdDecompressSync" in command.setup_command
+            assert "catch {" in command.setup_command
+            assert "item.chmod(0o755 if item.is_dir() else 0o644)" in (command.cleanup_command)
+            assert "for agent in agents.iterdir()" in command.cleanup_command
+            assert "archive/'audit'" in command.cleanup_command
+            assert "sources.append(str(sessions" in command.cleanup_command
+            assert "max(candidates" not in command.cleanup_command
             assert "destination.chmod(0o644)" in command.cleanup_command
         if harness.name == "hermes":
             assert '"delegation":{"max_iterations":50' in command.setup_command
@@ -494,6 +510,460 @@ def test_openclaw_completion_probe_rejects_paused_yielded_envelope(
     )
 
     assert completed.returncode == 1
+
+
+def test_openclaw_session_probe_requires_terminal_accepted_tree(
+    tmp_path: Path,
+) -> None:
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    child_key = "agent:main:subagent:child"
+    root_records = [
+        {"type": "session", "id": "root"},
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "delegate"},
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "inspect"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-1",
+                "content": json.dumps(
+                    {
+                        "status": "accepted",
+                        "childSessionKey": child_key,
+                    }
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    child_records = [
+        {"type": "session", "id": "child"},
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "inspect"},
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "inspected"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    (sessions / "root.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in root_records) + "\n",
+        encoding="utf-8",
+    )
+    (sessions / "child.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    store = {
+        "agent:main:main": {
+            "sessionId": "root",
+            "sessionFile": "root.jsonl",
+        },
+        child_key: {
+            "sessionId": "child",
+            "sessionFile": "child.jsonl",
+            "spawnedBy": "agent:main:main",
+            "status": "done",
+        },
+    }
+    (sessions / "sessions.json").write_text(json.dumps(store), encoding="utf-8")
+
+    complete = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert complete.returncode == 0
+
+    root_records[3]["message"]["content"] = "spawn accepted: " + json.dumps(
+        {
+            "status": "accepted",
+            "childSessionKey": child_key,
+        }
+    )
+    (sessions / "root.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in root_records) + "\n",
+        encoding="utf-8",
+    )
+    embedded_result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert embedded_result.returncode == 0
+
+    store.pop(child_key)
+    (sessions / "sessions.json").write_text(json.dumps(store), encoding="utf-8")
+    missing_child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert missing_child.returncode == 1
+
+    (audit / "sessions.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "subagent_ended",
+                "sessionKey": child_key,
+                "spawnedBy": "agent:main:main",
+                "status": "failed",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    failed_without_transcript = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert failed_without_transcript.returncode == 1
+
+    (audit / "transcripts").mkdir()
+    (audit / "transcripts" / "child.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    (audit / "sessions.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "subagent_spawned",
+                        "sessionKey": child_key,
+                        "spawnedBy": "agent:main:main",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "session_end",
+                        "sessionKey": child_key,
+                        "sessionId": "child",
+                        "status": "done",
+                        "auditTranscript": "transcripts/child.jsonl",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    audited_child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert audited_child.returncode == 0
+
+    store[child_key] = {
+        "sessionId": "child",
+        "sessionFile": "missing-child.jsonl",
+        "spawnedBy": "agent:main:main",
+        "status": "done",
+    }
+    (sessions / "sessions.json").write_text(json.dumps(store), encoding="utf-8")
+    stale_index_with_audit = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert stale_index_with_audit.returncode == 0
+
+    (audit / "transcripts" / "child.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records[:2]) + "\n",
+        encoding="utf-8",
+    )
+    for terminal_status in ("deleted", "error", "reset"):
+        with (audit / "sessions.jsonl").open("a", encoding="utf-8") as audit_file:
+            audit_file.write(
+                json.dumps(
+                    {
+                        "type": "subagent_ended",
+                        "sessionKey": child_key,
+                        "status": terminal_status,
+                    }
+                )
+                + "\n"
+            )
+        failed_child = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _OPENCLAW_SESSION_PROBE,
+                str(sessions),
+                str(audit),
+            ],
+            check=False,
+        )
+
+        assert failed_child.returncode == 0
+
+
+def test_openclaw_terminal_rejects_an_unanswered_latest_user_turn(
+    tmp_path: Path,
+) -> None:
+    records = [
+        {"type": "session", "id": "root"},
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "first"},
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "first answer"}],
+                "stopReason": "stop",
+            },
+        },
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "second"},
+        },
+    ]
+    session = tmp_path / "session.jsonl"
+    session.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    assert _openclaw_session_terminal(session) is False
+
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "root.jsonl").write_text(session.read_text(encoding="utf-8"))
+    (sessions / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {
+                    "sessionId": "root",
+                    "sessionFile": "root.jsonl",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    audit = tmp_path / "audit"
+    audit.mkdir()
+
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert probe.returncode == 1
+
+
+def test_openclaw_session_probe_rejects_audit_paths_outside_its_root(
+    tmp_path: Path,
+) -> None:
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    outside = tmp_path / "outside.jsonl"
+    child_key = "agent:main:subagent:child"
+    root_records = [
+        {"type": "session", "id": "root"},
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "delegate"},
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "inspect"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-1",
+                "content": json.dumps({"status": "accepted", "childSessionKey": child_key}),
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    terminal_records = [
+        {"type": "session", "id": "outside"},
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "forged"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    (sessions / "root.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in root_records) + "\n",
+        encoding="utf-8",
+    )
+    outside.write_text(
+        "\n".join(json.dumps(record) for record in terminal_records) + "\n",
+        encoding="utf-8",
+    )
+    (sessions / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {
+                    "sessionId": "root",
+                    "sessionFile": "root.jsonl",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (audit / "sessions.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "session_end",
+                "sessionKey": child_key,
+                "sessionId": "child",
+                "spawnedBy": "agent:main:main",
+                "status": "done",
+                "auditTranscript": "../outside.jsonl",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _OPENCLAW_SESSION_PROBE,
+            str(sessions),
+            str(audit),
+        ],
+        check=False,
+    )
+
+    assert probe.returncode == 1
+
+
+def test_openclaw_archived_session_path_preserves_safe_subdirectories(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "sessions"
+    nested = store / "nested" / "child.jsonl"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}\n", encoding="utf-8")
+
+    assert (
+        _resolve_archived_openclaw_session_path(
+            store,
+            {"sessionFile": "nested/child.jsonl"},
+        )
+        == nested
+    )
+    assert (
+        _resolve_archived_openclaw_session_path(
+            store,
+            {"sessionFile": "/tmp/source/sessions/nested/child.jsonl"},
+        )
+        == nested
+    )
+    assert (
+        _resolve_archived_openclaw_session_path(
+            store,
+            {"sessionFile": "../outside.jsonl"},
+        )
+        is None
+    )
 
 
 def test_hermes_uses_named_local_proxy_provider() -> None:
@@ -797,10 +1267,7 @@ def test_codex_trajectory_rejects_unknown_interleaved_output(tmp_path: Path) -> 
         {"type": "turn.completed", "usage": {"input_tokens": 1}},
     ]
     (agent_dir / "codex.txt").write_text(
-        "\n".join(
-            event if isinstance(event, str) else json.dumps(event)
-            for event in events
-        )
+        "\n".join(event if isinstance(event, str) else json.dumps(event) for event in events)
         + "\n",
         encoding="utf-8",
     )
@@ -1055,9 +1522,7 @@ def test_claude_code_stream_converts_to_real_trajectory(tmp_path: Path) -> None:
             "session_id": "claude-session-123",
             "result": "done",
             "usage": {"input_tokens": 10, "output_tokens": 3},
-            "modelUsage": {
-                "sb-gpt55": {"canonicalModel": "sb-gpt55"}
-            },
+            "modelUsage": {"sb-gpt55": {"canonicalModel": "sb-gpt55"}},
         },
     ]
     (agent_dir / "claude-code.txt").write_text(
@@ -1304,10 +1769,104 @@ def test_openclaw_session_without_envelope_converts_to_atif(
     assert trajectory["final_metrics"]["total_completion_tokens"] == 7
     assert trajectory["final_metrics"]["total_cached_tokens"] == 30
 
+    records[-1]["message"]["usage"] = {"input": 1}
+    (agent_dir / "openclaw.session.jsonl").write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    envelope = {
+        "payloads": [{"text": "done"}],
+        "meta": {
+            "agentMeta": {
+                "sessionId": "session-only-123",
+                "model": "gpt-5.6-terra",
+                "usage": {"input": 80, "output": 9, "cacheRead": 20},
+            },
+            "executionTrace": {
+                "winnerProvider": "openai",
+                "winnerModel": "gpt-5.6-terra",
+            },
+            "completion": {"stopReason": "stop"},
+            "aborted": False,
+        },
+    }
+    (agent_dir / "openclaw.txt").write_text(
+        json.dumps(envelope),
+        encoding="utf-8",
+    )
+
+    write_agent_trajectory(task, run, agent_dir)
+    fallback_trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+
+    assert fallback_trajectory["final_metrics"]["total_prompt_tokens"] == 100
+    assert fallback_trajectory["final_metrics"]["total_completion_tokens"] == 9
+    assert fallback_trajectory["final_metrics"]["total_cached_tokens"] == 20
+
+
+def test_openclaw_transport_model_mismatch_invalidates_identity(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    records = [
+        {"type": "session", "id": "session-123"},
+        {"type": "model_change", "modelId": "gpt-5.6-sol"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00Z",
+            "message": {"role": "user", "content": "do the task"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:01Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    (agent_dir / "openclaw.session.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (agent_dir / "openclaw.txt").write_text(
+        "[provider-transport-fetch] [model-fetch] response "
+        "provider=openai api=openai-responses model=gpt-5.5 status=200\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="openclaw-gpt56-sol",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "do the task"),
+        run,
+        agent_dir,
+    )
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["canonical_model_identity"] is False
+    assert metadata["trajectory_validation"]["observed_models"] == [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+    ]
+    assert metadata["trajectory_validation"]["log_models"] == ["gpt-5.5"]
+
 
 def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> None:
     agent_dir = tmp_path / "agent"
-    agent_dir.mkdir()
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    child_key = "agent:main:subagent:model-mismatch"
     records = [
         {
             "type": "session",
@@ -1319,10 +1878,12 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
         },
         {
             "type": "message",
+            "timestamp": "2026-07-29T08:00:00Z",
             "message": {"role": "user", "content": "do the task"},
         },
         {
             "type": "message",
+            "timestamp": "2026-07-29T08:00:01Z",
             "message": {
                 "role": "assistant",
                 "model": "gpt-5.6-sol",
@@ -1339,14 +1900,17 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
         },
         {
             "type": "message",
+            "timestamp": "2026-07-29T08:00:02Z",
             "message": {
                 "role": "toolResult",
+                "toolCallId": "spawn-1",
                 "content": [
                     {
                         "type": "text",
                         "text": json.dumps(
                             {
                                 "status": "accepted",
+                                "childSessionKey": child_key,
                                 "resolvedModel": "openai/gpt-5.5",
                             }
                         ),
@@ -1356,6 +1920,7 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
         },
         {
             "type": "message",
+            "timestamp": "2026-07-29T08:00:05Z",
             "message": {
                 "role": "assistant",
                 "model": "gpt-5.6-sol",
@@ -1364,8 +1929,49 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
             },
         },
     ]
+    child_records = [
+        {
+            "type": "session",
+            "id": "child-session-123",
+        },
+        {
+            "type": "model_change",
+            "modelId": "gpt-5.5",
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:03Z",
+            "message": {"role": "user", "content": "[Subagent Task] inspect"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.5",
+                "content": [{"type": "text", "text": "child done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
     (agent_dir / "openclaw.session.jsonl").write_text(
         "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (archive / "child-session-123.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {"sessionId": "session-123"},
+                child_key: {
+                    "sessionId": "child-session-123",
+                    "spawnedBy": "agent:main:main",
+                },
+            }
+        ),
         encoding="utf-8",
     )
     (agent_dir / "openclaw.txt").write_text(
@@ -1395,6 +2001,7 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
     )
 
     assert metadata["trajectory_status"] == "real"
+    assert metadata["trajectory_validation"]["trace_fidelity"] == "session_tree"
     assert metadata["runtime_model_name"] == "gpt-5.6-sol"
     assert metadata["canonical_model_identity"] is False
     assert metadata["trajectory_validation"]["observed_models"] == [
@@ -1402,6 +2009,1184 @@ def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> N
         "gpt-5.6-sol",
     ]
     assert metadata["trajectory_validation"]["child_models"] == ["gpt-5.5"]
+
+
+def test_openclaw_session_tree_includes_descendant_tools_and_ignores_stale_sessions(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    root_key = "agent:main:main"
+    child_key = "agent:main:subagent:worker"
+    stale_key = "agent:main:subagent:stale"
+    root_records = [
+        {
+            "type": "session",
+            "id": "root-session",
+            "timestamp": "2026-07-29T08:00:00Z",
+        },
+        {
+            "type": "model_change",
+            "modelId": "gpt-5.6-sol",
+            "timestamp": "2026-07-29T08:00:00.100Z",
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:01Z",
+            "message": {"role": "user", "content": "fix both files"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:02Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "fix notifications.py"},
+                    }
+                ],
+                "usage": {
+                    "input": 10,
+                    "output": 2,
+                    "cacheRead": 3,
+                },
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:02.100Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-1",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "status": "accepted",
+                                "childSessionKey": child_key,
+                                "resolvedModel": "openai/gpt-5.6-sol",
+                            }
+                        ),
+                    }
+                ],
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:06Z",
+            "message": {
+                "role": "user",
+                "content": "A completed subagent task is ready: child fixed notifications.py",
+                "provenance": {
+                    "kind": "inter_session",
+                    "sourceSessionKey": child_key,
+                    "sourceTool": "subagent_announce",
+                },
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:07Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "integrated and verified"}],
+                "usage": {"input": 4, "output": 2},
+                "stopReason": "stop",
+            },
+        },
+    ]
+    child_records = [
+        {
+            "type": "session",
+            "id": "child-session",
+            "timestamp": "2026-07-29T08:00:02.200Z",
+            "parentSession": "/tmp/openclaw/root-session.jsonl",
+        },
+        root_records[2],
+        root_records[3],
+        {
+            "type": "model_change",
+            "modelId": "gpt-5.6-sol",
+            "timestamp": "2026-07-29T08:00:02.300Z",
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:03Z",
+            "message": {
+                "role": "user",
+                "content": (
+                    "[Subagent Context] You are running as a subagent (depth 2/2)."
+                    "\n\n[Subagent Task]\nfix notifications.py"
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "read-1",
+                        "name": "read",
+                        "arguments": {"path": "notifications.py"},
+                    }
+                ],
+                "usage": {
+                    "input": 5,
+                    "output": 1,
+                    "cacheRead": 2,
+                },
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04.100Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "read-1",
+                "content": [{"type": "text", "text": "broken code"}],
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:05Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "edit-1",
+                        "name": "edit",
+                        "arguments": {"path": "notifications.py"},
+                    }
+                ],
+                "usage": {"input": 6, "output": 1},
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:05.100Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "edit-1",
+                "content": [{"type": "text", "text": "updated"}],
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:05.500Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "child fixed notifications.py"}],
+                "usage": {"input": 2, "output": 2},
+                "stopReason": "stop",
+            },
+        },
+    ]
+    stale_records = [
+        {
+            "type": "session",
+            "id": "stale-session",
+            "timestamp": "2026-07-29T07:00:00Z",
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T07:00:01Z",
+            "message": {"role": "user", "content": "old task"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T07:00:02Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "stale-1",
+                        "name": "exec",
+                        "arguments": {"command": "old-command"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+    ]
+    for path, records in (
+        (agent_dir / "openclaw.session.jsonl", root_records),
+        (archive / "root-session.jsonl", root_records),
+        (archive / "child-session.jsonl", child_records),
+        (archive / "stale-session.jsonl", stale_records),
+    ):
+        path.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n",
+            encoding="utf-8",
+        )
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                root_key: {
+                    "sessionId": "root-session",
+                    "sessionFile": "/tmp/openclaw/root-session.jsonl",
+                },
+                child_key: {
+                    "sessionId": "child-session",
+                    "sessionFile": "/tmp/openclaw/child-session.jsonl",
+                    "spawnedBy": root_key,
+                    "forkedFromParent": True,
+                },
+                stale_key: {
+                    "sessionId": "stale-session",
+                    "sessionFile": "/tmp/openclaw/stale-session.jsonl",
+                    "spawnedBy": root_key,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (agent_dir / "openclaw.txt").write_text(
+        "[provider-transport-fetch] [model-fetch] response "
+        "provider=openai api=openai-responses model=gpt-5.6-sol status=200\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="openclaw-gpt56-sol-tree",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "fix both files"),
+        run,
+        agent_dir,
+    )
+    trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+    function_names = [
+        call["function_name"] for step in trajectory["steps"] for call in step.get("tool_calls", [])
+    ]
+    messages = [step["message"] for step in trajectory["steps"]]
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["canonical_model_identity"] is True
+    assert metadata["trajectory_validation"]["trace_fidelity"] == "session_tree"
+    assert metadata["trajectory_validation"]["session_tree_session_count"] == 2
+    assert metadata["trajectory_validation"]["session_tree_descendant_count"] == 1
+    assert metadata["trajectory_validation"]["session_tree_accepted_spawn_count"] == 1
+    assert metadata["trajectory_validation"]["session_tree_reused_spawn_count"] == 0
+    assert metadata["trajectory_validation"]["session_tree_ignored_entry_count"] == 1
+    assert metadata["trajectory_validation"]["session_tree_session_keys"] == [
+        root_key,
+        child_key,
+    ]
+    assert function_names == ["sessions_spawn", "read", "edit"]
+    assert messages.count("child fixed notifications.py") == 1
+    assert messages.count("fix both files") == 1
+    assert "old task" not in messages
+    assert trajectory["final_metrics"]["total_prompt_tokens"] == 32
+    assert trajectory["final_metrics"]["total_completion_tokens"] == 8
+    assert trajectory["final_metrics"]["total_cached_tokens"] == 5
+    assert trajectory["steps"][2]["extra"]["openclaw_session_key"] == child_key
+
+
+def test_openclaw_session_tree_preserves_reused_child_tasks_once(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    root_key = "agent:main:main"
+    child_key = "agent:main:subagent:worker"
+    root_records = [
+        {"type": "session", "id": "root-session"},
+        {"type": "model_change", "modelId": "gpt-5.6-sol"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.000Z",
+            "message": {"role": "user", "content": "delegate twice"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.100Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "first task"},
+                    },
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-2",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "second task"},
+                    },
+                ],
+                "usage": {"input": 10, "output": 2, "cacheRead": 2},
+                "stopReason": "toolUse",
+            },
+        },
+        *[
+            {
+                "type": "message",
+                "timestamp": f"2026-07-29T08:00:00.{index}00Z",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": call_id,
+                    "content": json.dumps(
+                        {
+                            "status": "accepted",
+                            "childSessionKey": child_key,
+                            "resolvedModel": "openai/gpt-5.6-sol",
+                        }
+                    ),
+                },
+            }
+            for index, call_id in enumerate(("spawn-1", "spawn-2"), start=2)
+        ],
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.900Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "both tasks complete"}],
+                "usage": {"input": 4, "output": 1},
+                "stopReason": "stop",
+            },
+        },
+    ]
+    child_records = [
+        {"type": "session", "id": "child-session"},
+        {"type": "model_change", "modelId": "gpt-5.6-sol"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.400Z",
+            "message": {"role": "user", "content": "first task"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.500Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "exec-1",
+                        "name": "exec",
+                        "arguments": {"command": "inspect"},
+                    }
+                ],
+                "usage": {"input": 5, "output": 1, "cacheRead": 1},
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.550Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "exec-1",
+                "content": "inspected",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.600Z",
+            "message": {"role": "user", "content": "second task"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.700Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "edit-1",
+                        "name": "edit",
+                        "arguments": {"path": "target.py"},
+                    }
+                ],
+                "usage": {"input": 7, "output": 2},
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.750Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "edit-1",
+                "content": "edited",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00.800Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "child finished both"}],
+                "usage": {"input": 3, "output": 1},
+                "stopReason": "stop",
+            },
+        },
+    ]
+    for path, records in (
+        (agent_dir / "openclaw.session.jsonl", root_records),
+        (archive / "child-session.jsonl", child_records),
+    ):
+        path.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n",
+            encoding="utf-8",
+        )
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                root_key: {"sessionId": "root-session"},
+                child_key: {
+                    "sessionId": "child-session",
+                    "spawnedBy": root_key,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="openclaw-gpt56-sol-reuse",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "delegate twice"),
+        run,
+        agent_dir,
+    )
+    trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+    function_names = [
+        call["function_name"] for step in trajectory["steps"] for call in step.get("tool_calls", [])
+    ]
+    messages = [step["message"] for step in trajectory["steps"]]
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["trajectory_validation"]["session_tree_accepted_spawn_count"] == 2
+    assert metadata["trajectory_validation"]["session_tree_reused_spawn_count"] == 1
+    assert metadata["trajectory_validation"]["session_tree_session_count"] == 2
+    assert function_names == ["sessions_spawn", "sessions_spawn", "exec", "edit"]
+    assert messages.count("first task") == 1
+    assert messages.count("second task") == 1
+    assert trajectory["final_metrics"]["total_prompt_tokens"] == 32
+    assert trajectory["final_metrics"]["total_completion_tokens"] == 7
+    assert trajectory["final_metrics"]["total_cached_tokens"] == 3
+
+    child_records[2].pop("timestamp")
+    (archive / "child-session.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    _, missing_timestamp_validation = _openclaw_session_tree(
+        agent_dir,
+        agent_dir / "openclaw.session.jsonl",
+    )
+
+    assert missing_timestamp_validation["session_tree_complete"] is False
+    assert missing_timestamp_validation["session_tree_missing_timestamp_count"] == 1
+
+    child_records[2]["timestamp"] = "2026-07-29T08:00:00.900Z"
+    (archive / "child-session.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    _, ambiguous_timestamp_validation = _openclaw_session_tree(
+        agent_dir,
+        agent_dir / "openclaw.session.jsonl",
+    )
+
+    assert ambiguous_timestamp_validation["session_tree_complete"] is False
+    assert ambiguous_timestamp_validation["session_tree_ambiguous_timestamp_count"] == 1
+
+
+def test_openclaw_session_tree_rejects_missing_accepted_child(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    child_key = "agent:main:subagent:missing"
+    records = [
+        {"type": "session", "id": "root-session"},
+        {"type": "model_change", "modelId": "gpt-5.6-sol"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00Z",
+            "message": {"role": "user", "content": "delegate the task"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:01Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "do work"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:02Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-1",
+                "content": json.dumps(
+                    {
+                        "status": "accepted",
+                        "childSessionKey": child_key,
+                        "resolvedModel": "openai/gpt-5.6-sol",
+                    }
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:05Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    (agent_dir / "openclaw.session.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {
+                    "sessionId": "root-session",
+                    "sessionFile": "/tmp/openclaw/root-session.jsonl",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="openclaw-gpt56-sol-missing-child",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "delegate the task"),
+        run,
+        agent_dir,
+    )
+
+    assert metadata["trajectory_status"] == "unavailable"
+    assert metadata["trajectory_validation"]["session_tree_complete"] is False
+    assert metadata["trajectory_validation"]["session_tree_missing_transcript_count"] == 1
+    assert metadata["trajectory_validation"]["session_tree_errors"] == [
+        f"missing-session-entry:{child_key}"
+    ]
+
+    child_records = [
+        {"type": "session", "id": "deleted-child-session"},
+        {"type": "model_change", "modelId": "gpt-5.6-sol"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:02.500Z",
+            "message": {"role": "user", "content": "inherited parent prompt"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:03Z",
+            "message": {
+                "role": "user",
+                "content": (
+                    "[Subagent Context] You are running as a subagent "
+                    "(depth 1/2).\n\n[Subagent Task]\n\ndo work\n\n"
+                    "Begin. Execute the assigned task to completion."
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04Z",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "child done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    audit_dir = archive / "audit"
+    audit_transcripts = audit_dir / "transcripts"
+    audit_transcripts.mkdir(parents=True)
+    audited_child = audit_transcripts / "deleted-child-session.jsonl"
+    audited_child.write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    (audit_dir / "sessions.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "session_end",
+                "sessionKey": child_key,
+                "sessionId": "deleted-child-session",
+                "spawnedBy": "agent:main:main",
+                "status": "done",
+                "auditTranscript": "transcripts/deleted-child-session.jsonl",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                "agent:main:main": {"sessionId": "root-session"},
+                child_key: {
+                    "sessionId": "deleted-child-session",
+                    "sessionFile": "missing-child.jsonl",
+                    "spawnedBy": "agent:main:main",
+                    "status": "done",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    audited_tree, audited_validation = _openclaw_session_tree(
+        agent_dir,
+        agent_dir / "openclaw.session.jsonl",
+    )
+
+    assert [key for key, _, _, _ in audited_tree] == [
+        "agent:main:main",
+        child_key,
+    ]
+    assert audited_validation["session_tree_complete"] is True
+
+    (audit_dir / "sessions.jsonl").unlink()
+    audited_child.unlink()
+    (archive / "sessions.json").write_text(
+        json.dumps({"agent:main:main": {"sessionId": "root-session"}}),
+        encoding="utf-8",
+    )
+    deleted_path = archive / "deleted-child-session.jsonl.deleted.2026-07-29T08-00-04.000Z"
+    deleted_path.write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+
+    unaudited_tree, unaudited_validation = _openclaw_session_tree(
+        agent_dir,
+        agent_dir / "openclaw.session.jsonl",
+    )
+
+    assert [key for key, _, _, _ in unaudited_tree] == ["agent:main:main"]
+    assert unaudited_validation["session_tree_complete"] is False
+    assert unaudited_validation["session_tree_errors"] == [f"missing-session-entry:{child_key}"]
+
+
+def test_openclaw_session_tree_uses_only_the_active_transcript_branch(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    root_path = agent_dir / "openclaw.session.jsonl"
+    stale_child_key = "agent:main:subagent:stale"
+    records = [
+        {"type": "session", "id": "root-session"},
+        {
+            "type": "message",
+            "id": "user-root",
+            "parentId": None,
+            "message": {"role": "user", "content": "delegate"},
+        },
+        {
+            "type": "message",
+            "id": "assistant-stale",
+            "parentId": "user-root",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-stale",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "stale branch"},
+                    }
+                ],
+                "stopReason": "toolUse",
+                "usage": {"input": 1000, "output": 100},
+            },
+        },
+        {
+            "type": "message",
+            "id": "result-stale",
+            "parentId": "assistant-stale",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-stale",
+                "content": json.dumps(
+                    {
+                        "status": "accepted",
+                        "childSessionKey": stale_child_key,
+                    }
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "id": "user-active",
+            "parentId": "user-root",
+            "message": {"role": "user", "content": "do it locally instead"},
+        },
+        {
+            "type": "message",
+            "id": "assistant-active",
+            "parentId": "user-active",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+                "usage": {"input": 10, "output": 2},
+            },
+        },
+    ]
+    root_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (archive / "sessions.json").write_text(
+        json.dumps({"agent:main:main": {"sessionId": "root-session"}}),
+        encoding="utf-8",
+    )
+
+    tree, validation = _openclaw_session_tree(agent_dir, root_path)
+
+    assert validation["session_tree_complete"] is True
+    assert validation["session_tree_accepted_spawn_count"] == 0
+    assert validation["session_tree_session_count"] == 1
+    assert [record.get("id") for record in tree[0][3]] == [
+        "user-root",
+        "user-active",
+        "assistant-active",
+    ]
+
+    run = RunSpec(
+        run_label="openclaw-gpt55-active-branch",
+        harness="openclaw",
+        harness_version="2026.7.1-2",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="gpt-5.5",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "delegate"),
+        run,
+        agent_dir,
+    )
+    trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+
+    assert metadata["trajectory_status"] == "real"
+    assert [
+        call["function_name"] for step in trajectory["steps"] for call in step.get("tool_calls", [])
+    ] == []
+    assert trajectory["final_metrics"]["total_prompt_tokens"] == 10
+    assert trajectory["final_metrics"]["total_completion_tokens"] == 2
+
+
+def test_openclaw_session_tree_recurses_through_grandchildren(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    root_key = "agent:main:main"
+    child_key = "agent:main:subagent:child"
+    grandchild_key = "agent:main:subagent:grandchild"
+
+    def write_session(
+        path: Path,
+        session_id: str,
+        child_session_key: str | None = None,
+    ) -> None:
+        timeline = {
+            "root-session": ("00", "01", "02", "09"),
+            "child-session": ("03", "04", "05", "08"),
+            "grandchild-session": ("06", "07"),
+        }[session_id]
+        records: list[dict[str, object]] = [
+            {"type": "session", "id": session_id},
+            {"type": "model_change", "modelId": "gpt-5.6-sol"},
+            {
+                "type": "message",
+                "timestamp": f"2026-07-29T08:00:{timeline[0]}Z",
+                "message": {"role": "user", "content": f"task for {session_id}"},
+            },
+        ]
+        if child_session_key:
+            records.extend(
+                [
+                    {
+                        "type": "message",
+                        "timestamp": f"2026-07-29T08:00:{timeline[1]}Z",
+                        "message": {
+                            "role": "assistant",
+                            "model": "gpt-5.6-sol",
+                            "content": [
+                                {
+                                    "type": "toolCall",
+                                    "id": f"spawn-{session_id}",
+                                    "name": "sessions_spawn",
+                                    "arguments": {"task": "delegate"},
+                                }
+                            ],
+                            "stopReason": "toolUse",
+                        },
+                    },
+                    {
+                        "type": "message",
+                        "timestamp": f"2026-07-29T08:00:{timeline[2]}Z",
+                        "message": {
+                            "role": "toolResult",
+                            "toolCallId": f"spawn-{session_id}",
+                            "content": json.dumps(
+                                {
+                                    "status": "accepted",
+                                    "childSessionKey": child_session_key,
+                                    "resolvedModel": "openai/gpt-5.6-sol",
+                                }
+                            ),
+                        },
+                    },
+                ]
+            )
+        records.append(
+            {
+                "type": "message",
+                "timestamp": f"2026-07-29T08:00:{timeline[-1]}Z",
+                "message": {
+                    "role": "assistant",
+                    "model": "gpt-5.6-sol",
+                    "content": [{"type": "text", "text": f"done {session_id}"}],
+                    "stopReason": "stop",
+                },
+            }
+        )
+        path.write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n",
+            encoding="utf-8",
+        )
+
+    root_path = agent_dir / "openclaw.session.jsonl"
+    write_session(root_path, "root-session", child_key)
+    write_session(archive / "child-session.jsonl", "child-session", grandchild_key)
+    write_session(archive / "grandchild-session.jsonl", "grandchild-session")
+    (archive / "sessions.json").write_text(
+        json.dumps(
+            {
+                root_key: {"sessionId": "root-session"},
+                child_key: {
+                    "sessionId": "child-session",
+                    "spawnedBy": root_key,
+                },
+                grandchild_key: {
+                    "sessionId": "grandchild-session",
+                    "spawnedBy": child_key,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tree, validation = _openclaw_session_tree(agent_dir, root_path)
+
+    assert [(key, depth) for key, _, depth, _ in tree] == [
+        (root_key, 0),
+        (child_key, 1),
+        (grandchild_key, 2),
+    ]
+    assert validation["session_tree_accepted_spawn_count"] == 2
+    assert validation["session_tree_complete"] is True
+
+
+def test_openclaw_session_tree_reconciles_persisted_child_status(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    archive = agent_dir / "openclaw.sessions"
+    archive.mkdir(parents=True)
+    root_key = "agent:main:main"
+    child_key = "agent:main:subagent:child"
+    root_path = agent_dir / "openclaw.session.jsonl"
+    child_path = archive / "child-session.jsonl"
+    root_records = [
+        {"type": "session", "id": "root-session"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:00Z",
+            "message": {"role": "user", "content": "delegate"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:01Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "inspect"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:02Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "spawn-1",
+                "content": json.dumps(
+                    {
+                        "status": "accepted",
+                        "childSessionKey": child_key,
+                    }
+                ),
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04.500Z",
+            "message": {
+                "role": "user",
+                "content": "The child failed while running false.",
+                "provenance": {
+                    "kind": "inter_session",
+                    "sourceSessionKey": child_key,
+                    "sourceTool": "subagent_announce",
+                },
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:05Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    child_records = [
+        {"type": "session", "id": "child-session"},
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:03Z",
+            "message": {"role": "user", "content": "inspect"},
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "exec-1",
+                        "name": "exec",
+                        "arguments": {"command": "false"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+    ]
+    root_path.write_text(
+        "\n".join(json.dumps(record) for record in root_records) + "\n",
+        encoding="utf-8",
+    )
+    child_path.write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+
+    def write_index(status: str) -> None:
+        (archive / "sessions.json").write_text(
+            json.dumps(
+                {
+                    root_key: {"sessionId": "root-session"},
+                    child_key: {
+                        "sessionId": "child-session",
+                        "spawnedBy": root_key,
+                        "status": status,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    run = RunSpec(
+        run_label="openclaw-gpt55-status",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="gpt-5.5",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260729",
+    )
+
+    for terminal_status in (
+        "cancelled",
+        "deleted",
+        "error",
+        "failed",
+        "killed",
+        "reset",
+        "timeout",
+    ):
+        write_index(terminal_status)
+        _, terminal_validation = _openclaw_session_tree(agent_dir, root_path)
+        assert terminal_validation["session_tree_complete"] is True
+        assert terminal_validation["session_tree_nonterminal_session_keys"] == []
+
+    write_index("failed")
+    failed_tree, failed_validation = _openclaw_session_tree(agent_dir, root_path)
+    failed_steps = _openclaw_session_tree_steps(
+        failed_tree,
+        instruction="delegate",
+        run=run,
+    )
+
+    assert failed_validation["session_tree_complete"] is True
+    assert failed_validation["session_tree_nonterminal_session_keys"] == []
+    assert [
+        step["message"]
+        for step in failed_steps
+        if step.get("extra", {}).get("openclaw_event") == "subagent_announce"
+    ] == ["The child failed while running false."]
+
+    child_records.append(
+        {
+            "type": "message",
+            "timestamp": "2026-07-29T08:00:04.250Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "late final text"}],
+                "stopReason": "stop",
+            },
+        }
+    )
+    child_path.write_text(
+        "\n".join(json.dumps(record) for record in child_records) + "\n",
+        encoding="utf-8",
+    )
+    write_index("running")
+    running_tree, running_validation = _openclaw_session_tree(agent_dir, root_path)
+    running_steps = _openclaw_session_tree_steps(
+        running_tree,
+        instruction="delegate",
+        run=run,
+    )
+
+    assert running_validation["session_tree_complete"] is True
+    assert running_validation["session_tree_nonterminal_session_keys"] == []
+    assert not any(
+        step.get("extra", {}).get("openclaw_event") == "subagent_announce" for step in running_steps
+    )
+
+    write_index("failed")
+    failed_final_tree, failed_final_validation = _openclaw_session_tree(
+        agent_dir,
+        root_path,
+    )
+    failed_final_steps = _openclaw_session_tree_steps(
+        failed_final_tree,
+        instruction="delegate",
+        run=run,
+        failed_session_keys=set(failed_final_validation["session_tree_failed_session_keys"]),
+    )
+
+    assert [
+        step["message"]
+        for step in failed_final_steps
+        if step.get("extra", {}).get("openclaw_event") == "subagent_announce"
+    ] == ["The child failed while running false."]
+
+    child_path.write_text(
+        "\n".join(json.dumps(record) for record in child_records[:-1]) + "\n",
+        encoding="utf-8",
+    )
+    write_index("done")
+    _, stale_done_validation = _openclaw_session_tree(agent_dir, root_path)
+
+    assert stale_done_validation["session_tree_complete"] is False
+    assert stale_done_validation["session_tree_nonterminal_session_keys"] == [child_key]
 
 
 def test_hermes_session_converts_parallel_tools_to_atif(tmp_path: Path) -> None:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -406,16 +406,26 @@ def test_harness_commands_preserve_canonical_model_identity() -> None:
         assert "OPENROUTER_API_KEY" not in command.env
         assert 'exit "$status"' in command.run_command
         if harness.name == "openclaw":
-            assert "ended with stopReason=" in command.run_command
+            assert "ended with stopReason=" not in command.run_command
             assert "python3 -c" in command.run_command
             assert "--thinking off" in command.run_command
             assert "setup --baseline --skip-bootstrap" in command.setup_command
-            assert "rm -f BOOTSTRAP.md" in command.setup_command
+            assert "rm -f AGENTS.md BOOTSTRAP.md HEARTBEAT.md" in (
+                command.setup_command
+            )
             assert '"skipBootstrap":true' in command.setup_command
+            assert '"primary":"openai/claude-opus-5"' in command.setup_command
+            assert '"subagents":{"model":"openai/claude-opus-5"}' in (
+                command.setup_command
+            )
             assert "item.chmod(0o755 if item.is_dir() else 0o644)" in (
                 command.cleanup_command
             )
             assert "destination.chmod(0o644)" in command.cleanup_command
+        if harness.name == "hermes":
+            assert '"delegation":{"max_iterations":50' in command.setup_command
+            assert '"provider":"custom:shellbench"' in command.setup_command
+            assert '"model":"claude-opus-5"' in command.setup_command
         if harness.name == "codex":
             assert "2>/logs/agent/codex-stderr.txt" in command.run_command
             assert "cat /logs/agent/codex-stderr.txt >&2" in command.run_command
@@ -459,6 +469,33 @@ def test_openclaw_completion_probe_rejects_partial_log(tmp_path: Path) -> None:
     assert completed.returncode == 1
 
 
+def test_openclaw_completion_probe_rejects_paused_yielded_envelope(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "openclaw.txt"
+    log_path.write_text(
+        json.dumps(
+            {
+                "payloads": [{"text": "waiting for child"}],
+                "meta": {
+                    "aborted": False,
+                    "livenessState": "paused",
+                    "yielded": True,
+                    "stopReason": "end_turn",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _OPENCLAW_COMPLETION_PROBE, str(log_path)],
+        check=False,
+    )
+
+    assert completed.returncode == 1
+
+
 def test_hermes_uses_named_local_proxy_provider() -> None:
     run = RunSpec(
         run_label="hermes-test",
@@ -486,8 +523,10 @@ def test_hermes_uses_named_local_proxy_provider() -> None:
     assert command.env == {"SHELLBENCH_PROXY_KEY": "local-proxy-key"}
     assert "custom:shellbench" in command.setup_command
     assert "http://host.docker.internal:4000/v1" in command.setup_command
-    assert '--session-id "$session_id" --yes --redact' in command.cleanup_command
-    assert "else hermes sessions export" in command.cleanup_command
+    assert "--session-id" not in command.cleanup_command
+    assert command.cleanup_command.endswith(
+        "hermes sessions export /logs/agent/hermes-session.jsonl --yes --redact"
+    )
 
 
 def test_workdir_falls_back_to_existing_container_directory(
@@ -964,7 +1003,67 @@ def test_codex_trajectory_falls_back_to_complete_session_stream(
     assert trajectory["steps"][3]["message"] == "done"
 
 
-def test_unsupported_trajectory_is_explicitly_unranked(tmp_path: Path) -> None:
+def test_claude_code_stream_converts_to_real_trajectory(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "claude-session-123",
+            "model": "sb-gpt55",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "gpt-5.5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call-1",
+                        "name": "Bash",
+                        "input": {"command": "pwd"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call-1",
+                        "content": "/app",
+                        "is_error": False,
+                    }
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "gpt-5.5",
+                "content": [{"type": "text", "text": "done"}],
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "terminal_reason": "completed",
+            "is_error": False,
+            "session_id": "claude-session-123",
+            "result": "done",
+            "usage": {"input_tokens": 10, "output_tokens": 3},
+            "modelUsage": {
+                "sb-gpt55": {"canonicalModel": "sb-gpt55"}
+            },
+        },
+    ]
+    (agent_dir / "claude-code.txt").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
     run = RunSpec(
         run_label="claude-code-gpt55",
         harness="claude-code",
@@ -972,37 +1071,90 @@ def test_unsupported_trajectory_is_explicitly_unranked(tmp_path: Path) -> None:
         model_slug="gpt55",
         model_id="gpt-5.5",
         provider="openai",
-        proxy_model_name="gpt-5.5",
+        proxy_model_name="sb-gpt55",
         repetition=1,
         expected_task_count=1,
         run_date="20260727",
     )
-    task_dir = tmp_path / "task"
-    task_dir.mkdir()
-    task = TaskSpec(
-        name="task",
-        title="task",
-        path=task_dir,
-        instruction="do the task",
-        raw_config={},
-        checksum="abc",
-        dockerfile=task_dir / "Dockerfile",
-        build_context=task_dir,
-        compose_file=None,
-        verifier_command="bash /tests/test.sh",
-        agent_timeout_sec=900,
-        verifier_timeout_sec=300,
-        build_timeout_sec=1800,
-        mcp_servers=(),
-        environment_env={},
-        verifier_env={},
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "do the task"),
+        run,
+        agent_dir,
+    )
+    trajectory = json.loads((agent_dir / "trajectory.json").read_text())
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["runtime_model_name"] == "gpt-5.5"
+    assert metadata["canonical_model_identity"] is True
+    assert metadata["trajectory_validation"]["terminal_event_seen"] is True
+    assert trajectory["session_id"] == "claude-session-123"
+    assert trajectory["steps"][1]["tool_calls"][0]["function_name"] == "Bash"
+    assert trajectory["steps"][1]["observation"]["results"][0]["content"] == "/app"
+    assert trajectory["steps"][-1]["message"] == "done"
+
+
+def test_claude_code_child_model_mismatch_invalidates_identity(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "claude-session-123",
+            "model": "sb-gpt55",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "gpt-5.5",
+                "content": [{"type": "text", "text": "done"}],
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "terminal_reason": "completed",
+            "is_error": False,
+            "session_id": "claude-session-123",
+            "result": "done",
+            "modelUsage": {
+                "sb-gpt55": {"canonicalModel": "sb-gpt55"},
+                "gpt-5.6-sol": {"canonicalModel": "gpt-5.6-sol"},
+            },
+        },
+    ]
+    (agent_dir / "claude-code.txt").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="claude-code-gpt55",
+        harness="claude-code",
+        harness_version="test",
+        model_slug="gpt55",
+        model_id="gpt-5.5",
+        provider="openai",
+        proxy_model_name="sb-gpt55",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260727",
     )
 
-    metadata = write_agent_trajectory(task, run, tmp_path / "agent")
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "do the task"),
+        run,
+        agent_dir,
+    )
 
-    assert metadata["trajectory_status"] == "unsupported"
-    assert metadata["runtime_model_name"] is None
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["runtime_model_name"] == "gpt-5.5"
     assert metadata["canonical_model_identity"] is False
+    assert metadata["trajectory_validation"]["observed_models"] == [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+    ]
 
 
 def test_openclaw_mixed_log_converts_harbor_envelope_to_atif(
@@ -1153,6 +1305,105 @@ def test_openclaw_session_without_envelope_converts_to_atif(
     assert trajectory["final_metrics"]["total_cached_tokens"] == 30
 
 
+def test_openclaw_child_model_mismatch_invalidates_identity(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    records = [
+        {
+            "type": "session",
+            "id": "session-123",
+        },
+        {
+            "type": "model_change",
+            "modelId": "gpt-5.6-sol",
+        },
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "do the task"},
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": "spawn-1",
+                        "name": "sessions_spawn",
+                        "arguments": {"task": "inspect"},
+                    }
+                ],
+                "stopReason": "toolUse",
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "toolResult",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "status": "accepted",
+                                "resolvedModel": "openai/gpt-5.5",
+                            }
+                        ),
+                    }
+                ],
+            },
+        },
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5.6-sol",
+                "content": [{"type": "text", "text": "done"}],
+                "stopReason": "stop",
+            },
+        },
+    ]
+    (agent_dir / "openclaw.session.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (agent_dir / "openclaw.txt").write_text(
+        "[provider-transport-fetch] [model-fetch] response "
+        "provider=openai api=openai-responses model=gpt-5.6-sol status=200\n"
+        "[provider-transport-fetch] [model-fetch] response "
+        "provider=openai api=openai-responses model=gpt-5.5 status=200\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="openclaw-gpt56-sol",
+        harness="openclaw",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260728",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "do the task"),
+        run,
+        agent_dir,
+    )
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["runtime_model_name"] == "gpt-5.6-sol"
+    assert metadata["canonical_model_identity"] is False
+    assert metadata["trajectory_validation"]["observed_models"] == [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+    ]
+    assert metadata["trajectory_validation"]["child_models"] == ["gpt-5.5"]
+
+
 def test_hermes_session_converts_parallel_tools_to_atif(tmp_path: Path) -> None:
     agent_dir = tmp_path / "agent"
     agent_dir.mkdir()
@@ -1287,6 +1538,77 @@ def test_hermes_session_preserves_unicode_line_separator(tmp_path: Path) -> None
     assert metadata["trajectory_status"] == "real"
     assert metadata["canonical_model_identity"] is True
     assert trajectory["steps"][-1]["message"] == "line one\u2028line two"
+
+
+def test_hermes_child_session_model_mismatch_invalidates_identity(
+    tmp_path: Path,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    parent = {
+        "id": "parent",
+        "model": "gpt-5.6-sol",
+        "message_count": 2,
+        "tool_call_count": 0,
+        "messages": [
+            {"id": 1, "role": "user", "content": "do the task", "timestamp": 1.0},
+            {
+                "id": 2,
+                "role": "assistant",
+                "content": "done",
+                "model": "gpt-5.6-sol",
+                "finish_reason": "stop",
+                "timestamp": 2.0,
+            },
+        ],
+    }
+    child = {
+        "id": "child",
+        "model": "gpt-5.5",
+        "message_count": 2,
+        "tool_call_count": 0,
+        "messages": [
+            {"id": 3, "role": "user", "content": "inspect", "timestamp": 1.0},
+            {
+                "id": 4,
+                "role": "assistant",
+                "content": "child done",
+                "model": "gpt-5.5",
+                "finish_reason": "stop",
+                "timestamp": 2.0,
+            },
+        ],
+    }
+    (agent_dir / "hermes-session.jsonl").write_text(
+        json.dumps(child) + "\n" + json.dumps(parent) + "\n",
+        encoding="utf-8",
+    )
+    run = RunSpec(
+        run_label="hermes-gpt56-sol",
+        harness="hermes",
+        harness_version="test",
+        model_slug="gpt56-sol",
+        model_id="gpt-5.6-sol",
+        provider="openai",
+        proxy_model_name="gpt-5.6-sol",
+        repetition=1,
+        expected_task_count=1,
+        run_date="20260728",
+    )
+
+    metadata = write_agent_trajectory(
+        _trajectory_task(tmp_path, "do the task"),
+        run,
+        agent_dir,
+    )
+
+    assert metadata["trajectory_status"] == "real"
+    assert metadata["runtime_model_name"] == "gpt-5.6-sol"
+    assert metadata["canonical_model_identity"] is False
+    assert metadata["trajectory_validation"]["observed_models"] == [
+        "gpt-5.5",
+        "gpt-5.6-sol",
+    ]
 
 
 def _trajectory_task(tmp_path: Path, instruction: str) -> TaskSpec:


### PR DESCRIPTION
## What does this PR do?

Makes native harness results leaderboard-safe by preserving OpenClaw
continuation states, reconstructing accepted delegated session trees, and
auditing terminal/model identity across the complete agent tree.

Fixes #49.

## Why?

Historical native traces exposed score-invalidating gaps:

- OpenClaw `paused` / `yielded` envelopes were treated as terminal.
- Parent-only identity checks could report a run canonical when a child or
  provider request used another model.
- Accepted child sessions, including deleted children, were omitted from the
  emitted trajectory.
- Root-only trajectories could replay abandoned transcript branches.

Those gaps inflated completion and trajectory scores while losing the evidence
needed to validate delegation.

## Changes

- keep OpenClaw active, paused, waiting, and yielded states nonterminal;
- run through the real Gateway with a per-run token and bounded readiness;
- pin OpenClaw parent/subagent defaults and Hermes delegation to the planned
  model;
- archive the pinned OpenClaw `2026.7.1-2` session registry and JSONL
  transcripts, including deleted child transcripts captured by an audit
  plugin;
- reconstruct accepted child and grandchild sessions recursively, preserving
  provenance, status, timestamps, tool calls, usage, and model evidence;
- follow OpenClaw's active parent-linked transcript branch and reject stale,
  ambiguous, cyclic, nonterminal, or uncorrelated child evidence;
- fail closed when deleted transcripts lack session-index or audit identity;
- preserve explicit failed-child announcements while deduplicating successful
  child handoffs;
- retain all observed model IDs in final run manifests;
- add deliberate mismatch and trace-integrity regressions across native
  harnesses.

## Verification

- [x] `.venv/bin/python -m pytest -q`
  - `433 passed, 5 skipped`
- [x] `.venv/bin/ruff check scripts/native_eval/harness_trajectories.py scripts/native_eval/harnesses.py tests/test_native_eval_runner.py`
- [x] `git diff --check`
- [x] autoreview
  - no accepted/actionable findings
- [x] pinned live OpenClaw `2026.7.1-2` trace
  - GPT-5.5 parent spawned a `cleanup:"delete"` child and yielded
  - child completed, parent resumed, and the child transcript was archived
  - reconstructed 2-session tree with zero missing, ordering, terminal, or
    identity errors
  - emitted `trace_fidelity=session_tree` with canonical GPT-5.5 identity

The ShellBench/OpenClaw public organization surfaces currently expose no
reusable historical native trace dataset or Actions artifact for replay, so the
pinned live trace is the end-to-end evidence for the shipped harness version.

## Tool-search mini-eval

Two tasks, one run per arm, GPT-5.5:

| Mode | Score | Delta vs disabled | Trajectory | Reliability | Mean tokens |
|---|---:|---:|---:|---:|---:|
| disabled | 0.893170 | - | 0.643950 | 1.000 | 664,223 |
| code | 0.725865 | -0.167305 | 0.330750 | 0.600 | 457,635 |
| directory | 0.688245 | -0.204925 | 0.205250 | 0.600 | 502,358 |

The bridge reduces tokens, but currently hides canonical read/edit/exec and
`sessions_spawn` events behind wrappers. That damages trajectory and reliability
scoring and also exposed API errors. Keep tool search disabled for scored runs.
Next step: normalize bridge events back into canonical tool events, fix the
bridge API ergonomics, then rerun at least five repetitions per arm.
