### PR TITLE
fix: accept Claude native trajectories

### DIFF
--- a/scripts/native_eval/models.py
+++ b/scripts/native_eval/models.py
@@ -99,7 +99,7 @@ HARNESSES: tuple[HarnessSpec, ...] = (
 
 NODE_VERSION = "22.23.1"
 LITELLM_VERSION = "1.93.0"
-REAL_TRAJECTORY_HARNESSES = frozenset({"openclaw", "hermes", "codex"})
+REAL_TRAJECTORY_HARNESSES = frozenset({"openclaw", "hermes", "codex", "claude-code"})
 
 
 def model_by_slug(slug: str) -> ModelSpec:

--- a/tests/test_native_eval_runner.py
+++ b/tests/test_native_eval_runner.py
@@ -29,6 +29,7 @@ from scripts.native_eval.models import (
     MODELS,
     RunSpec,
     build_matrix_plan,
+    trajectory_mode_for_harness,
 )
 from scripts.native_eval import plan as native_plan
 from scripts.native_eval.proxy import JUDGE_PROXY_MODEL_NAME, write_proxy_config
@@ -57,6 +58,17 @@ def test_matrix_plan_contains_only_requested_models_and_harnesses() -> None:
     assert {run.harness for run in plan} == {harness.name for harness in HARNESSES}
     assert {run.model_slug for run in plan} == {model.slug for model in MODELS}
     assert {run.repetition for run in plan} == {1, 2, 3}
+
+
+def test_all_native_harnesses_emit_real_trajectories() -> None:
+    assert {
+        harness.name: trajectory_mode_for_harness(harness.name) for harness in HARNESSES
+    } == {
+        "openclaw": "real_harness_events",
+        "hermes": "real_harness_events",
+        "codex": "real_harness_events",
+        "claude-code": "real_harness_events",
+    }
 
 
 def test_run_index_records_agent_and_judge_reasoning(


### PR DESCRIPTION
## What does this PR do?

Marks Claude Code native trajectories as real harness events so completed Claude runs remain eligible for native aggregation.

## Why?

The native runner already converts Claude Code `stream-json` output into `trajectory.json`, but the harness allowlist omitted `claude-code`. Aggregation therefore classified otherwise valid Claude runs as `trajectory_unavailable`.

## Changes

- add `claude-code` to the real-trajectory harness allowlist
- assert every pinned native harness reports `real_harness_events`

## Live proof

A native Claude Code control run completed four tasks with four result files, four valid completed results, and no infrastructure failures. Aggregation classified every trajectory as `real`; the run remained ineligible only because it was intentionally marked as an exploratory four-task subset.

- coverage: `4/4`
- score: `0.75`
- exact passes: `3`
- trajectory complete: `true`
- trajectory status: `real` for all four tasks
- infrastructure failures: `0`
- exclusion reason: `exploratory_subset`

## Tests

- [x] `python -m pytest -q` passes locally (`444 passed, 5 skipped`)
- [x] `python -m ruff check clawbench app.py scripts tests` passes locally
- [x] live Claude Code native run aggregates as real harness events
