### PR TITLE
fix(native-eval): rebootstrap replacement leases

### DIFF
--- a/scripts/native_eval/fleet.py
+++ b/scripts/native_eval/fleet.py
@@ -563,7 +563,8 @@ class FleetController:
             if remote_state == "missing":
                 if self._local_artifacts(run.run_label):
                     raise FleetError("local artifacts exist but the remote run state is missing")
-                if not entry.get("bootstrapped_at_utc"):
+                current = self._store.get(run.run_label)
+                if current.get("bootstrapped_lease_id") != lease.lease_id:
                     self._hydrate_lease(lease)
                 self._dispatch(lease, run)
             elif remote_state == "stale":
@@ -894,6 +895,7 @@ bash "$root/runner/scripts/native_eval/bootstrap_beast.sh"
             self._run_label_for_lease(lease.lease_id),
             status="ready",
             bootstrapped_at_utc=utc_now(),
+            bootstrapped_lease_id=lease.lease_id,
         )
 
     def _probe_remote(self, lease: Lease, run_label: str) -> str:

--- a/tests/test_native_eval_fleet.py
+++ b/tests/test_native_eval_fleet.py
@@ -1273,6 +1273,35 @@ def test_recovery_required_resumes_existing_remote_run(tmp_path: Path) -> None:
     assert final["status"] == "completed"
 
 
+def test_recovery_rehydrates_replacement_lease_despite_old_bootstrap_timestamp(
+    tmp_path: Path,
+) -> None:
+    label = "openclaw-gpt55-full-2-r1-20260727"
+    run = _planned(_run_spec(label))
+    run.update(
+        {
+            "status": "recovery_required",
+            "requested_lease_slug": "replacement",
+            "bootstrapped_at_utc": "2026-07-27T00:00:00Z",
+        }
+    )
+    run_index = tmp_path / "manifests" / "run_index.json"
+    _write_index(run_index, [run])
+    config = _config(tmp_path, run_index)
+    executor = FakeExecutor(config.local_root, expected_counts={label: 2})
+
+    assert FleetController(config, executor=executor).run() == 0
+
+    final = json.loads(run_index.read_text(encoding="utf-8"))["runs"][0]
+    assert final["status"] == "completed"
+    assert final["bootstrapped_lease_id"] == "cbx_1"
+    assert any(
+        command and command[0] == "ssh" and "fleet-hydrate" in " ".join(command)
+        for command in executor.commands
+    )
+    assert executor.dispatches == [label]
+
+
 def test_recovery_infers_success_from_verified_full_archive_and_done_log(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

Rehydrates replacement native-eval leases before dispatch.

## Why?

The controller previously treated an old bootstrap timestamp as proof that a
new lease contained the runner. Recovery could then fail before the harness
started, producing a false benchmark failure.

Fixes #55

## Changes

- record the exact `bootstrapped_lease_id`
- reuse bootstrap state only when it matches the active lease
- add a regression test for recovery with an old timestamp and replacement lease

## Live proof

Recovered a legacy OpenClaw run whose manifest had an old bootstrap timestamp
but no `bootstrapped_lease_id`.

- rebound the run to its active replacement lease
- performed the full native-runner bootstrap on that lease
- persisted the exact active lease as `bootstrapped_lease_id`
- dispatched the OpenClaw harness successfully
- exported a verified final artifact with `4/4` completed results
- run exit code: `0`

This is the exact recovery state the regression test covers; the controller no
longer trusts timestamp-only bootstrap state.

## Tests

- [x] 40 focused fleet tests pass
- [x] Python 3.11 and Python 3.12 CI pass
- [x] Ruff passes on the touched files
- [x] fresh Codex autoreview reports no actionable findings
- [x] live replacement-lease recovery completes a four-task OpenClaw run
