### PR TITLE
chore(deps): refresh Python dependencies and validate websockets 17

### DIFF
--- a/.github/workflows/sync-to-hf-space.yml
+++ b/.github/workflows/sync-to-hf-space.yml
@@ -58,7 +58,7 @@ jobs:
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID || 'openclaw/clawbench' }}
         run: |
           set -euo pipefail
-          python -m pip install --quiet 'huggingface_hub>=1.24.0,<2'
+          python -m pip install --quiet 'huggingface_hub>=1.29.0,<2'
           python - <<'PY'
           import os
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.5
     hooks:
       - id: ruff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Refresh Python runtime, MLflow, lint, and HF mirror dependencies, including websockets 17 with a real gateway socket regression test, while preserving Python 3.11 NumPy support.
 - Record and enforce GPT reasoning effort in native runs, preserve it across
   reruns, and stabilize OpenClaw and Hermes trace completion.
 - Export OpenClaw and Hermes sessions reliably and convert their native traces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,17 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "websockets>=16.1.1,<17",
+    "websockets>=17.1,<18",
     "pydantic>=2.13.4,<3",
     "pyyaml>=6.0.3,<7",
-    "datasets>=5.0.0,<6",
-    "gradio>=6.20.0,<7",
+    "datasets>=5.0.1,<6",
+    "gradio>=6.26.0,<7",
     "pillow>=12.3.0,<13",
     "httpx>=0.28.1,<1",
     "numpy>=2.4.6,<2.5; python_version < '3.12'",
-    "numpy>=2.5.1,<3; python_version >= '3.12'",
+    "numpy>=2.5.2,<3; python_version >= '3.12'",
     "rich>=15.0.0,<16",
-    "click>=8.4.2,<9",
+    "click>=8.5.0,<9",
     # Runtime deps for the task completion verifier. The harness shells out
     # to `pytest -q` / `pytest-asyncio` inside per-task workspaces as the
     # execution check; the container must have them in PATH.
@@ -31,11 +31,11 @@ dev = [
     # benchmark itself runs pytest in task workspaces.
     "pytest>=9.1.1,<10",
     "pytest-asyncio>=1.4.0,<2",
-    "pre-commit>=4.6.1,<5",
-    "ruff>=0.16.0,<1",
+    "pre-commit>=4.6.2,<5",
+    "ruff>=0.16.5,<1",
 ]
 mlflow = [
-    "mlflow>=3.14.0,<4",
+    "mlflow>=3.15.2,<4",
 ]
 hermes = [
     "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@main",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 import pytest
+from websockets.asyncio.server import serve
 from websockets.datastructures import Headers
 from websockets.exceptions import InvalidMessage, InvalidStatus
 from websockets.http11 import Response
@@ -20,6 +21,48 @@ def test_gateway_config_defaults():
     # spurious empty_response failures.
     assert cfg.connect_timeout == 30.0
     assert cfg.request_timeout == 60.0
+
+
+@pytest.mark.asyncio
+async def test_gateway_client_connects_and_creates_session_over_websocket(monkeypatch):
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+    requests = []
+    origins = []
+
+    async def gateway(websocket):
+        origins.append(websocket.request.headers["Origin"])
+        await websocket.send(
+            json.dumps({"type": "event", "event": "connect.challenge", "payload": {"nonce": ""}})
+        )
+        async for raw in websocket:
+            request = json.loads(raw)
+            requests.append(request)
+            payload = (
+                {"type": "hello-ok", "protocol": 3}
+                if request["method"] == "connect"
+                else {"sessionKey": "loopback-session"}
+            )
+            await websocket.send(
+                json.dumps({"type": "res", "id": request["id"], "ok": True, "payload": payload})
+            )
+
+    async with asyncio.timeout(10):
+        async with serve(gateway, "127.0.0.1", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            config = GatewayConfig(
+                url=f"ws://127.0.0.1:{port}", connect_timeout=2, request_timeout=2
+            )
+            async with GatewayClient(config) as client:
+                session = await client.create_session(model="test/model", label="dependency-smoke")
+            assert client._ws is None
+
+    assert session == "loopback-session"
+    assert origins == [f"http://127.0.0.1:{port}"]
+    assert [request["method"] for request in requests] == ["connect", "sessions.create"]
+    assert requests[0]["params"]["minProtocol"] == 3
+    assert requests[0]["params"]["maxProtocol"] == 4
+    assert requests[1]["params"] == {"model": "test/model", "label": "dependency-smoke"}
 
 
 def test_set_session_auth_profile_override_patches_local_store(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Refresh the declared Python dependency minimums to current compatible releases and enable websockets 17.1. Preserve the Python 3.11 NumPy constraint, and add a real loopback gateway test covering handshake, session creation, response handling, and shutdown.

Updated dependencies:

| Group | Updates |
| --- | --- |
| Runtime | websockets 16.1.1 → 17.1; datasets 5.0.0 → 5.0.1; Gradio 6.20.0 → 6.26.0; Click 8.4.2 → 8.5.0; NumPy 2.5.1 → 2.5.2 on Python 3.12+ |
| Optional tracking | MLflow 3.14.0 → 3.15.2 |
| Development | pre-commit 4.6.1 → 4.6.2; Ruff 0.16.0 → 0.16.5, including its hook revision |
| HF mirror | huggingface_hub 1.24.0 → 1.29.0 |

These are minimum-version updates, not a new lockfile. Existing GitHub Action references and the other declared Python dependencies are already current. The Unreleased changelog is updated.

Held upgrades:

- NumPy 2.5.x on Python 3.11: requires Python 3.12; retain the latest compatible 2.4.6 release.
- Node 22.23.1 → 26.8.1 in the native bootstrap: requires qualification of the native benchmark toolchain, beyond the local Python gates.
- Codex CLI 0.145.0 → 0.150.1 in the native bootstrap: requires live native trace and scoring qualification.
- Claude Code 2.1.220 → 2.1.250 in the native bootstrap: requires live native trace and scoring qualification.
- LiteLLM 1.93.0 → 1.98.0 in the native bootstrap: requires qualification of live provider routing and accounting.
- The pinned Hermes benchmark commit: retain its reproducible identity pending a separately qualified native harness update; the optional Python extra already tracks upstream main.
- Playwright 1.59.1 → 1.62.1 in Docker images: requires container/browser integration proof, which the available public test suite does not provide.
- The Kubernetes MLflow server image at 3.14.0: server deployment and persistent-store upgrade are not exercised by the local exporter check, so its image remains unchanged.

Validation on macOS:

- Python 3.12.14 and Python 3.11.16: install with dev and MLflow extras, `pip check`, and full Ruff lint pass.
- Each interpreter: focused client/runtime checks **26 passed**; full suite **444 passed, 5 skipped**. The skips require the absent private `tasks/` directory; the existing Gradio theme/CSS warning remains.
- The same suite, including the new socket test, also passed with websockets 16.1.1 before upgrading.
- Both wheels build and contain all four CI-required runtime files (209 entries each). Installed wheel CLIs pass `clawbench --help` outside the source checkout.
- The repository MLflow exporter passes against a temporary local SQLite database on both interpreters: one finished run, 19 metrics, six parameters, and one JSON artifact verified.
- All eight pre-commit hooks and Actionlint pass.

Baseline default-branch CI is green: [CI](https://github.com/openclaw/shellbench/actions/runs/30447144164) and [HF mirror](https://github.com/openclaw/shellbench/actions/runs/30447143223). No open Dependabot or Renovate PRs are superseded. No release or merge is included.
