### PR TITLE
chore(deps): refresh validation and container dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Refresh bundled Chromium through Playwright 1.62.1, align the Kubernetes MLflow server with client 3.15.2, and require Pydantic 2.13.5 bug fixes.
 - Apply planned native reasoning effort to all four harnesses and resolve proxy, runner, and manifest precedence before proxy startup (#53, thanks @vincentkoc).
 - Rehydrate replacement native fleet leases instead of trusting stale bootstrap timestamps (#58, thanks @vincentkoc).
 - Separate native execution validity from diagnostic rewards, reject wholly invalid runs, and preserve terminal exit status in recovery archives (#63, thanks @vincentkoc).

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 RUN ln -s /app /openclaw
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN cd /tmp && npx -y playwright@1.59.1 install --with-deps chromium && \
+RUN cd /tmp && npx -y playwright@1.62.1 install --with-deps chromium && \
     CHROME_PATH="$(find /ms-playwright -path '*/chrome' -type f | sort | head -n 1)" && \
     test -x "$CHROME_PATH" && \
     ln -sf "$CHROME_PATH" /usr/bin/chromium

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -17,7 +17,7 @@ RUN apt-get update && \
 RUN ln -s /app /openclaw
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN npx -y playwright@1.59.1 install --with-deps chromium && \
+RUN npx -y playwright@1.62.1 install --with-deps chromium && \
     CHROME_PATH="$(find /ms-playwright -path '*/chrome' -type f | sort | head -n 1)" && \
     test -x "$CHROME_PATH" && \
     ln -sf "$CHROME_PATH" /usr/bin/chromium

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -62,7 +62,7 @@ Set these **before** running `deploy.sh`.
 | `MLFLOW_TRACKING_URI` | *(deployed by script)* | External MLflow URI — skips MLflow deploy if set |
 | `MLFLOW_EXPERIMENT_ID` | | MLflow experiment ID |
 | `MLFLOW_EXPERIMENT_NAME` | `clawbench` | MLflow experiment name |
-| `MLFLOW_IMAGE` | `ghcr.io/mlflow/mlflow:v3.14.0` | MLflow server image |
+| `MLFLOW_IMAGE` | `ghcr.io/mlflow/mlflow:v3.15.2` | MLflow server image |
 | `ANTHROPIC_API_KEY` | | Added to K8s secret if set |
 | `OPENROUTER_API_KEY` | | Added to K8s secret if set |
 | `GEMINI_API_KEY` | | Added to K8s secret if set |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "websockets>=17.1,<18",
-    "pydantic>=2.13.4,<3",
+    "pydantic>=2.13.5,<3",
     "pyyaml>=6.0.3,<7",
     "datasets>=5.0.1,<6",
     "gradio>=6.26.0,<7",

--- a/scripts/k8s/deploy.sh
+++ b/scripts/k8s/deploy.sh
@@ -29,7 +29,7 @@
 #   MLFLOW_TRACKING_URI            External MLflow URI (skips MLflow deploy if set)
 #   MLFLOW_EXPERIMENT_ID           MLflow experiment ID
 #   MLFLOW_EXPERIMENT_NAME         MLflow experiment name
-#   MLFLOW_IMAGE                   MLflow image (default: ghcr.io/mlflow/mlflow:v3.14.0)
+#   MLFLOW_IMAGE                   MLflow image (default: ghcr.io/mlflow/mlflow:v3.15.2)
 #   ANTHROPIC_API_KEY              Anthropic key (added to secret if set)
 #   OPENROUTER_API_KEY             OpenRouter key (added to secret if set)
 #   GEMINI_API_KEY                 Gemini key (added to secret if set)
@@ -40,7 +40,7 @@ NS="${CLAWBENCH_NAMESPACE:-}"
 MLFLOW_NS="${MLFLOW_NAMESPACE:-mlflow}"
 CLAWBENCH_IMG="${CLAWBENCH_IMAGE:-quay.io/sallyom/clawbench:latest}"
 OPENCLAW_IMG="${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}"
-MLFLOW_IMG="${MLFLOW_IMAGE:-ghcr.io/mlflow/mlflow:v3.14.0}"
+MLFLOW_IMG="${MLFLOW_IMAGE:-ghcr.io/mlflow/mlflow:v3.15.2}"
 
 # ---------------------------------------------------------------------------
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
@@ -80,7 +80,7 @@ Optional environment:
   MLFLOW_TRACKING_URI          External MLflow URI (skips MLflow deploy)
   MLFLOW_EXPERIMENT_ID         MLflow experiment ID
   MLFLOW_EXPERIMENT_NAME       MLflow experiment name
-  MLFLOW_IMAGE                 MLflow image (default: ghcr.io/mlflow/mlflow:v3.14.0)
+  MLFLOW_IMAGE                 MLflow image (default: ghcr.io/mlflow/mlflow:v3.15.2)
   ANTHROPIC_API_KEY            Anthropic key (added to secret if set)
   OPENROUTER_API_KEY           OpenRouter key (added to secret if set)
   GEMINI_API_KEY               Gemini key (added to secret if set)
@@ -254,7 +254,7 @@ deploy_mlflow() {
   kubectl apply -f "$SCRIPT_DIR/mlflow/pvc.yaml" -n "$MLFLOW_NS"
   kubectl apply -f "$SCRIPT_DIR/mlflow/service.yaml" -n "$MLFLOW_NS"
 
-  if [[ "$MLFLOW_IMG" != "ghcr.io/mlflow/mlflow:v3.14.0" ]]; then
+  if [[ "$MLFLOW_IMG" != "ghcr.io/mlflow/mlflow:v3.15.2" ]]; then
     kubectl apply -f "$SCRIPT_DIR/mlflow/deployment.yaml" -n "$MLFLOW_NS"
     kubectl set image "deploy/mlflow" "mlflow=$MLFLOW_IMG" -n "$MLFLOW_NS"
   else

--- a/scripts/k8s/mlflow/deployment.yaml
+++ b/scripts/k8s/mlflow/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mlflow
-          image: ghcr.io/mlflow/mlflow:v3.14.0
+          image: ghcr.io/mlflow/mlflow:v3.15.2
           command:
             - mlflow
             - server


### PR DESCRIPTION
## What does this PR do?

Refresh the remaining application/container dependency pins after the recent Python update: Pydantic 2.13.4 → 2.13.5, Playwright 1.59.1 → 1.62.1 in both Dockerfiles, and the Kubernetes MLflow server 3.14.0 → 3.15.2. Keep the MLflow manifest, deploy-script defaults, help, and documentation aligned.

## Why?

Pydantic has a new patch release, the bundled Chromium was behind, and the Kubernetes MLflow server lagged the already-current Python extra. No new dependencies or lockfiles were introduced. This repository uses pip and has no dependency lockfile.

## Changes

All changes are patch/minor upgrades. Other direct Python requirements, GitHub Actions, pre-commit hooks, and the HF mirror client already resolve to current stable releases. Python 3.11 keeps its compatible NumPy 2.4.6 range; Python 3.12+ uses 2.5.2.

The fixed OpenClaw image digest and native campaign harness/Node/LiteLLM versions remain reproducibility inputs. Upgrade those in a separately qualified campaign. The optional Hermes source requirement already tracks main.

Upstream notes reviewed: [Pydantic 2.13.5](https://github.com/pydantic/pydantic/releases/tag/v2.13.5), [Playwright release notes](https://playwright.dev/docs/release-notes), and [MLflow 3.15.2](https://github.com/mlflow/mlflow/releases/tag/v3.15.2). Playwright is used here to install Chromium; removed application APIs in its release notes are not used by these Docker commands.

## Tests

Local validation uses Python 3.12.14 with the dev and MLflow extras installed. `python -m pip check` reports `No broken requirements found.` Full Ruff lint reports `All checks passed!`. The full local suite passed: **515 passed, 5 skipped, 1 warning in 268.13s**. The existing five skips require the private `tasks/` holdout, which is absent in this public checkout. The warning is the existing Gradio 6 theme/CSS argument deprecation.

The package wheel built successfully and contains all four runtime-data entries checked by CI. After replacing the editable install with that wheel, the actual `clawbench list-tasks` entry point ran from a scratch working directory. Its exact task IDs matched the packaged YAML definitions: 19 Core v1 tasks plus eight perturbed variants.

```text
Installed wheel: clawbench 0.4.0.dev1; Pydantic 2.13.5; loaded 27 public tasks
```

A full HF image build was attempted but canceled during slow local build-context processing; no full image rebuild is claimed.

The updated Chromium was launched through Playwright against a local HTTP server serving the real public newsletter-form fixture. The smoke check loaded the form and filled its email input:

```text
Playwright 1.62.1; Chromium 151.0.7922.34; HTTP 200; public form loaded
```

The MLflow 3.15.2 container ran locally with an ephemeral SQLite database on tmpfs. The repository's `scripts/log_to_mlflow.py` logged an explicitly synthetic result to an experiment configured with a proxied artifact URI. Client readback verified the metric, model parameter, and JSON artifact:

```text
MLflow 3.15.2: GET /health -> 200 OK
Logged to MLflow: experiment=deps-refresh-smoke run=synthetic/dependency-smoke-deps-smo
MLflow readback: 1 run, overall_score=0.8, model and JSON artifact verified
```

These checks validate dependency/runtime behavior. The synthetic score is a test fixture.


### Exact local commands

```bash
python3.12 -m venv .tmp/deps-refresh-20260830/venv
source .tmp/deps-refresh-20260830/venv/bin/activate
python -m pip install --no-compile -e '.[dev,mlflow]'
python -m pip check
python -m ruff check clawbench app.py scripts tests
PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -o cache_dir=.tmp/deps-refresh-20260830/pytest-cache
python -m pip wheel --no-deps . -w .tmp/deps-refresh-20260830/wheel
python -m pip install --no-compile --force-reinstall --no-deps .tmp/deps-refresh-20260830/wheel/clawbench-0.4.0.dev1-py3-none-any.whl
env -u PYTHONPATH -u CLAWBENCH_TASKS_DIR PYTHONDONTWRITEBYTECODE=1 .tmp/deps-refresh-20260830/venv/bin/python .tmp/deps-refresh-20260830/cli-proof.py
```

```text
No broken requirements found.
All checks passed!
515 passed, 5 skipped, 1 warning in 268.13s (0:04:28)
Successfully built clawbench
```

```bash
npm install --prefix .tmp/deps-refresh-20260830/browser --no-audit --no-fund --package-lock=false playwright@1.62.1
PLAYWRIGHT_BROWSERS_PATH="$PWD/.tmp/deps-refresh-20260830/browsers" .tmp/deps-refresh-20260830/browser/node_modules/.bin/playwright install chromium
PLAYWRIGHT_BROWSERS_PATH="$PWD/.tmp/deps-refresh-20260830/browsers" node .tmp/deps-refresh-20260830/browser-proof.cjs
```

```bash
# Server, in a separate foreground terminal:
docker run --rm --name shellbench-deps-refresh-mlflow-20260830 --tmpfs /tmp -p 127.0.0.1::5000 ghcr.io/mlflow/mlflow:v3.15.2 mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri sqlite:////tmp/mlflow.db --default-artifact-root /tmp/artifacts --serve-artifacts
# Client:
MLFLOW_ENABLE_TELEMETRY=false PYTHONDONTWRITEBYTECODE=1 .tmp/deps-refresh-20260830/venv/bin/python .tmp/deps-refresh-20260830/mlflow-roundtrip.py
```

The temporary smoke helpers below make these commands reproducible. They are included here as proof scaffolding.

<details>
<summary>Smoke helper source</summary>

`cli-proof.py`

```python
from importlib.metadata import version
from pathlib import Path
import subprocess
import sys
import clawbench
import yaml

root = Path(__file__).absolute().parent
workdir = root / 'installed-cli'
workdir.mkdir(exist_ok=True)
assert 'site-packages/clawbench' in str(Path(clawbench.__file__))
command = [str(Path(sys.executable).parent / 'clawbench'), 'list-tasks']
result = subprocess.run(command, cwd=workdir, check=True, capture_output=True, text=True)
(root / 'cli-tasks.log').write_text(result.stdout)
print(result.stdout)
tasks = [line for line in result.stdout.splitlines() if line.startswith('  t')]
task_root = Path(clawbench.__file__).parent.parent / 'tasks-public'
expected = {yaml.safe_load(path.read_text())['id'] for path in task_root.glob('tier*/*.yaml')}
actual = {line.split()[0] for line in tasks}
assert actual == expected and len(tasks) == len(expected), (actual, expected)
manifest = yaml.safe_load((task_root / 'MANIFEST.yaml').read_text())
core = {task['id'] for task in manifest['tasks']}
assert len(core) == manifest['task_count'] == 19 and core <= actual
assert all(task.endswith('-perturbed') for task in actual - core)
print(f"Installed wheel: clawbench {version('clawbench')}; Pydantic {version('pydantic')}; loaded {len(tasks)} public tasks")
```

`browser-proof.cjs`

```javascript
const { chromium } = require('./browser/node_modules/playwright');
const { createServer } = require('node:http');
const { readFileSync } = require('node:fs');
const assert = require('node:assert/strict');
(async () => {
  const html = readFileSync('tasks-public/assets/t2_browser_form_fix/index.html');
  const server = createServer((req, res) => {
    res.setHeader('Content-Type', req.url === '/app.js' ? 'text/javascript' : 'text/html');
    res.end(req.url === '/app.js' ? readFileSync('tasks-public/assets/t2_browser_form_fix/app.js') : html);
  });
  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
  let browser;
  try {
    browser = await chromium.launch({headless: true});
    const page = await browser.newPage();
    const response = await page.goto(`http://127.0.0.1:${server.address().port}`);
    assert.equal(response.status(), 200);
    assert.equal(await page.title(), 'Newsletter Signup');
    await page.locator('#email').fill('synthetic@example.com');
    assert.equal(await page.locator('#email').inputValue(), 'synthetic@example.com');
    console.log(`Playwright ${require('./browser/node_modules/playwright/package.json').version}; Chromium ${browser.version()}; HTTP ${response.status()}; public form loaded`);
  } finally {
    if (browser) await browser.close();
    server.close();
  }
})().catch(error => { console.error(error); process.exitCode = 1; });
```

`mlflow-roundtrip.py`

```python
import json
import os
from pathlib import Path
import subprocess
import sys
import urllib.request
from mlflow.tracking import MlflowClient

proof = Path('.tmp/deps-refresh-20260830').absolute()
port = subprocess.check_output(['docker', 'port', 'shellbench-deps-refresh-mlflow-20260830', '5000'], text=True).strip()
uri = 'http://' + port
with urllib.request.urlopen(uri + '/health', timeout=10) as response:
    print(f'MLflow 3.15.2: GET /health -> {response.status} {response.read().decode()}', flush=True)
result = {
    'submission_id': 'deps-smoke', 'model': 'synthetic/dependency-smoke',
    'provider': 'synthetic', 'timestamp': '2026-08-30T00:00:00Z',
    'overall_score': 0.8, 'overall_completion': 1.0,
    'overall_trajectory': 0.75, 'overall_behavior': 0.75,
    'overall_ci_lower': 0.8, 'overall_ci_upper': 0.8, 'overall_pass_hat_k': 1.0,
}
result_file = proof / 'synthetic-result.json'
result_file.write_text(json.dumps(result))
proof_env = dict(os.environ, MLFLOW_TRACKING_URI=uri,
    MLFLOW_EXPERIMENT_NAME='deps-refresh-smoke', MLFLOW_ENABLE_TELEMETRY='false')
proof_env.pop('MLFLOW_EXPERIMENT_ID', None)
client = MlflowClient(tracking_uri=uri)
client.create_experiment('deps-refresh-smoke', artifact_location='mlflow-artifacts:/deps-refresh-smoke')
subprocess.run([sys.executable, 'scripts/log_to_mlflow.py', str(result_file)], env=proof_env, check=True)
client = MlflowClient(tracking_uri=uri)
experiment = client.get_experiment_by_name('deps-refresh-smoke')
runs = client.search_runs([experiment.experiment_id])
assert len(runs) == 1 and runs[0].data.metrics['overall_score'] == 0.8
assert runs[0].data.params['model'] == result['model']
assert any(a.path == result_file.name for a in client.list_artifacts(runs[0].info.run_id))
print('MLflow readback: 1 run, overall_score=0.8, model and JSON artifact verified', flush=True)
```

</details>

## CI reasoning

The orchestrator's NORUNS snapshot was stale. Default-branch build/test CI was already [green at 7e117cb](https://github.com/openclaw/shellbench/actions/runs/33189579876). The updated branch [push run](https://github.com/openclaw/shellbench/actions/runs/33364792708) and [PR run at 42d6294](https://github.com/openclaw/shellbench/actions/runs/33367948909) are green: both Python 3.11 and 3.12 pass full Ruff lint, runtime contract smoke tests, the full test suite, and wheel runtime-data verification. CodeQL analyses for Python, JavaScript/TypeScript, and Actions also passed. No assertions or jobs were weakened.

The HF mirror is a deployment workflow, not test CI; its [latest main run is successful](https://github.com/openclaw/shellbench/actions/runs/33189579873). ClawSweeper dispatch is operations automation; Testbox and Crabbox hydration are manual validation infrastructure. No production deployment or credentials were changed.

Codex autoreview completed scoped-clean at its default P0 threshold, with no accepted/actionable findings. This PR is for orchestrator review and has not been merged.
